### PR TITLE
feat: add session lifespan config & refatoring

### DIFF
--- a/cmd/jwt/create.go
+++ b/cmd/jwt/create.go
@@ -33,7 +33,7 @@ func NewCreateCommand(cfg *config.Config, persister persistence.Persister) *cobr
 				return
 			}
 
-			sessionManager, err := session.NewManager(jwkManager, cfg.Cookies)
+			sessionManager, err := session.NewManager(jwkManager, cfg.Session)
 			if err != nil {
 				fmt.Printf("failed to create session generator: %s", err)
 				return

--- a/server/public_router.go
+++ b/server/public_router.go
@@ -32,7 +32,7 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister) *echo.
 	if err != nil {
 		panic(fmt.Errorf("failed to create jwk manager: %w", err))
 	}
-	sessionManager, err := session.NewManager(jwkManager, cfg.Cookies)
+	sessionManager, err := session.NewManager(jwkManager, cfg.Session)
 	if err != nil {
 		panic(fmt.Errorf("failed to create session generator: %w", err))
 	}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewGenerator(t *testing.T) {
 	manager := jwkManager{}
-	cfg := config.Cookie{}
+	cfg := config.Session{}
 	sessionGenerator, err := NewManager(&manager, cfg)
 	assert.NoError(t, err)
 	require.NotEmpty(t, sessionGenerator)
@@ -21,7 +21,7 @@ func TestNewGenerator(t *testing.T) {
 
 func TestGenerator_Generate(t *testing.T) {
 	manager := jwkManager{}
-	cfg := config.Cookie{}
+	cfg := config.Session{}
 	sessionGenerator, err := NewManager(&manager, cfg)
 	assert.NoError(t, err)
 	require.NotEmpty(t, sessionGenerator)
@@ -35,8 +35,9 @@ func TestGenerator_Generate(t *testing.T) {
 }
 
 func TestGenerator_Verify(t *testing.T) {
+	sessionLifespan := "5m"
 	manager := jwkManager{}
-	cfg := config.Cookie{}
+	cfg := config.Session{Lifespan: sessionLifespan}
 	sessionGenerator, err := NewManager(&manager, cfg)
 	assert.NoError(t, err)
 	require.NotEmpty(t, sessionGenerator)
@@ -54,11 +55,14 @@ func TestGenerator_Verify(t *testing.T) {
 	assert.Equal(t, token.Subject(), userId.String())
 	assert.False(t, time.Time{}.Equal(token.IssuedAt()))
 	assert.False(t, time.Time{}.Equal(token.Expiration()))
+
+	sessionDuration, _ := time.ParseDuration(sessionLifespan)
+	assert.True(t, token.IssuedAt().Add(sessionDuration).Equal(token.Expiration()))
 }
 
 func TestGenerator_Verify_Error(t *testing.T) {
 	manager := jwkManager{}
-	cfg := config.Cookie{}
+	cfg := config.Session{}
 	sessionGenerator, err := NewManager(&manager, cfg)
 	assert.NoError(t, err)
 	require.NotEmpty(t, sessionGenerator)


### PR DESCRIPTION
This PR adds a session lifespan config. It also uses the sameSite config for the cookie. This PR alters the config structure a little bit, to make it clearer, that the cookie config only applies to the session.