### PR TITLE
feat: add endpoint which redirects to current user resource

### DIFF
--- a/docs/spec/api.yaml
+++ b/docs/spec/api.yaml
@@ -394,6 +394,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /me:
+    get:
+      summary: 'Redirects to user resource if user has valid session'
+      operationId: IsUSerAuthorized
+      tags:
+        - authentication
+      security:
+        - CookieAuth: [ ]
+        - BearerTokenAuth: [ ]
+      responses:
+        '307':
+          description: 'Redirect'
+          headers:
+            Location:
+              schema:
+                type: string
+              description: Redirect target
+        '401':
+          description: 'Unauthorized'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 'Internal server error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /users:
     post:
       summary: 'Create a user'

--- a/docs/spec/api.yaml
+++ b/docs/spec/api.yaml
@@ -397,7 +397,7 @@ paths:
   /me:
     get:
       summary: 'Redirects to user resource if user has valid session'
-      operationId: IsUSerAuthorized
+      operationId: IsUserAuthorized
       tags:
         - authentication
       security:

--- a/handler/user.go
+++ b/handler/user.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/teamhanko/hanko/dto"
 	"github.com/teamhanko/hanko/persistence"
 	"github.com/teamhanko/hanko/persistence/models"
@@ -96,4 +98,13 @@ func (h *UserHandler) GetUserIdByEmail(c echo.Context) error {
 	}{
 		UserId: user.ID.String(),
 	})
+}
+
+func (h *UserHandler) Me(c echo.Context) error {
+	sessionToken, ok := c.Get("session").(jwt.Token)
+	if !ok {
+		return errors.New("failed to cast session object")
+	}
+
+	return c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("/users/%s", sessionToken.Subject()))
 }

--- a/handler/user_test.go
+++ b/handler/user_test.go
@@ -3,8 +3,10 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/teamhanko/hanko/dto"
@@ -276,5 +278,28 @@ func TestUserHandler_GetUserIdByEmail(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
 		assert.NoError(t, err)
 		assert.Equal(t, userId.String(), response.UserId)
+	}
+}
+
+func TestUserHandler_Me(t *testing.T) {
+	userId, _ := uuid.NewV4()
+
+	e := echo.New()
+	e.Validator = dto.NewCustomValidator()
+	req := httptest.NewRequest(http.MethodGet, "/me", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	token := jwt.New()
+	err := token.Set(jwt.SubjectKey, userId.String())
+	require.NoError(t, err)
+	c.Set("session", token)
+
+	p := test.NewPersister(users, nil, nil, nil, nil, nil)
+	handler := NewUserHandler(p)
+
+	if assert.NoError(t, handler.Me(c)) {
+		assert.Equal(t, http.StatusTemporaryRedirect, rec.Code)
+		assert.Equal(t, fmt.Sprintf("/users/%s", userId.String()), rec.Header().Get("Location"))
 	}
 }

--- a/server/public_router.go
+++ b/server/public_router.go
@@ -52,6 +52,8 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister) *echo.
 
 	userHandler := handler.NewUserHandler(persister)
 
+	e.GET("/me", userHandler.Me, hankoMiddleware.Session(sessionManager))
+
 	user := e.Group("/users")
 	user.POST("", userHandler.Create)
 	user.GET("/:id", userHandler.Get, hankoMiddleware.Session(sessionManager))


### PR DESCRIPTION
adds the endpoint `/me` which redirects to `users/:id` when the session is valid.