### PR TITLE
set session cookie to root path

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -108,6 +108,7 @@ func (g *manager) GenerateCookie(userId uuid.UUID) (*http.Cookie, error) {
 		Name:     "hanko",
 		Value:    jwt,
 		Domain:   g.cookieConfig.Domain,
+		Path:     "/",
 		Secure:   true,
 		HttpOnly: g.cookieConfig.HttpOnly,
 		SameSite: g.cookieConfig.SameSite,


### PR DESCRIPTION
Set the session cookie path to root "/" so it can be used on all pages of a website.