### PR TITLE
get user object only for himself

### DIFF
--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -58,6 +58,15 @@ func (h *UserHandler) Create(c echo.Context) error {
 func (h *UserHandler) Get(c echo.Context) error {
 	userId := c.Param("id")
 
+	sessionToken, ok := c.Get("session").(jwt.Token)
+	if !ok {
+		return errors.New("missing or malformed jwt")
+	}
+
+	if sessionToken.Subject() != userId {
+		return c.JSON(http.StatusForbidden, dto.NewApiError(http.StatusForbidden))
+	}
+
 	user, err := h.persister.GetUserPersister().Get(uuid.FromStringOrNil(userId))
 	if err != nil {
 		return err

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -145,6 +145,11 @@ func TestUserHandler_Get(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(userId.String())
 
+	token := jwt.New()
+	err := token.Set(jwt.SubjectKey, userId.String())
+	require.NoError(t, err)
+	c.Set("session", token)
+
 	p := test.NewPersister(users, nil, nil, nil, nil, nil)
 	handler := NewUserHandler(p)
 
@@ -190,6 +195,11 @@ func TestUserHandler_GetUserWithWebAuthnCredential(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(userId.String())
 
+	token := jwt.New()
+	err := token.Set(jwt.SubjectKey, userId.String())
+	require.NoError(t, err)
+	c.Set("session", token)
+
 	p := test.NewPersister(users, nil, nil, nil, nil, nil)
 	handler := NewUserHandler(p)
 
@@ -210,11 +220,16 @@ func TestUserHandler_Get_InvalidUserId(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
+	token := jwt.New()
+	err := token.Set(jwt.SubjectKey, "completelyDifferentUserId")
+	require.NoError(t, err)
+	c.Set("session", token)
+
 	p := test.NewPersister(nil, nil, nil, nil, nil, nil)
 	handler := NewUserHandler(p)
 
 	if assert.NoError(t, handler.Get(c)) {
-		assert.Equal(t, rec.Code, http.StatusNotFound)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
 	}
 }
 


### PR DESCRIPTION
Currently every logged in user can get user info for every user from the api (`/users/:id`) when he knows the id of a user. So we have broken authorization for this endpoint. This PR fixes this problem.