### PR TITLE
don't cache pages for the example in the browser

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -18,6 +18,8 @@ func main() {
 			`,"bytes_in":${bytes_in},"bytes_out":${bytes_out}},"referer":"${referer}"` + "\n",
 	}))
 
+	e.Use(middleware.CacheControlMiddleware())
+
 	e.File("/", "public/html/index.html")
 	e.File("/secured", "public/html/secured.html", middleware.SessionMiddleware())
 	e.File("/unauthorized", "public/html/unauthorized.html")

--- a/example/middleware/cache_control.go
+++ b/example/middleware/cache_control.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+func CacheControlMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+
+			c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
+
+			return next(c)
+		}
+	}
+}


### PR DESCRIPTION
The browser should not cache the responses from the example, because if you go to `/secured` directly, then the browser might show the cached version of it, although the session cookie was removed or the session was expired.