### PR TITLE
fix database column type to store longer webauthn public keys

### DIFF
--- a/backend/persistence/migrations/20220405154240_create_webauthn_credentials.up.fizz
+++ b/backend/persistence/migrations/20220405154240_create_webauthn_credentials.up.fizz
@@ -1,7 +1,7 @@
 create_table("webauthn_credentials") {
     t.Column("id", "string", {primary: true})
     t.Column("user_id", "uuid", {})
-    t.Column("public_key", "string", {})
+    t.Column("public_key", "text", {})
     t.Column("attestation_type", "string", {})
     t.Column("aaguid", "uuid", {})
     t.Column("sign_count", "integer", {})


### PR DESCRIPTION
Change the database column type for the webauthn public keys, because currently the default length which `fizz` assigns is 255, which is too short for some public keys (like Windows Hello ones). This PR changes the column type to `text`, so that which doesn't have a explicit max length.