### PR TITLE
chore: fix docker compose that components start in correct order

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,10 @@ git clone https://github.com/teamhanko/hanko.git
 ## With docker-compose
 Just run:
 ```
-docker-compose -f deploy/docker-compose/quickstart.yaml -p "hanko-quickstart" up --force-recreate
+docker-compose -f deploy/docker-compose/quickstart.yaml -p "hanko-quickstart" up --build
 ```
 
 After the services are up and running, the example login can be opened at `localhost:8888`. To receive emails without your own
 smtp server, we added [mailslurper](https://github.com/mailslurper/mailslurper) which will be available at `localhost:8080`.
 
 > **Note:** Services are not published to a registry yet and will be built locally before the services are started.
-
-> **Note:** Currently the services are not waiting for postgres to be ready. This sometimes results in error outputs by the services, indicating that they
-> cannot connect to the database. As soon as postgres is ready, the services reconnect on their own.

--- a/deploy/docker-compose/quickstart.yaml
+++ b/deploy/docker-compose/quickstart.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   hanko-migrate:
     build: ../../backend
@@ -9,12 +8,14 @@ services:
     command: --config /etc/config/config.yaml migrate up
     restart: on-failure
     depends_on:
-      - postgresd
+      postgresd:
+        condition: service_healthy
     networks:
       - intranet
   hanko:
     depends_on:
-      - hanko-migrate
+      hanko-migrate:
+        condition: service_completed_successfully
     build: ../../backend
     ports:
       - '8000:8000' # public
@@ -35,6 +36,12 @@ services:
       - POSTGRES_USER=hanko
       - POSTGRES_PASSWORD=hanko
       - POSTGRES_DB=hanko
+    healthcheck:
+      test: pg_isready -U hanko -d hanko
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     networks:
       - intranet
   hankojs:


### PR DESCRIPTION
Use a new docker compose spec version, so that the services start in the correct order and wait for specific services they depend on