### PR TITLE
83 example not friendly ux when trying to sign in before registering

### DIFF
--- a/backend/handler/webauthn.go
+++ b/backend/handler/webauthn.go
@@ -196,7 +196,7 @@ func (h *WebauthnHandler) FinishAuthentication(c echo.Context) error {
 		}
 
 		if sessionData == nil {
-			return dto.NewHTTPError(http.StatusBadRequest, "Stored challenge and received challenge do not match").SetInternal(errors.New("sessionData not found"))
+			return dto.NewHTTPError(http.StatusUnauthorized, "Stored challenge and received challenge do not match").SetInternal(errors.New("sessionData not found"))
 		}
 
 		webauthnUser, err := h.getWebauthnUser(tx, userId)
@@ -205,7 +205,7 @@ func (h *WebauthnHandler) FinishAuthentication(c echo.Context) error {
 		}
 
 		if webauthnUser == nil {
-			return dto.NewHTTPError(http.StatusBadRequest).SetInternal(errors.New("user not found"))
+			return dto.NewHTTPError(http.StatusUnauthorized).SetInternal(errors.New("user not found"))
 		}
 
 		model := intern.WebauthnSessionDataFromModel(sessionData)

--- a/backend/handler/webauthn_test.go
+++ b/backend/handler/webauthn_test.go
@@ -161,7 +161,7 @@ func TestWebauthnHandler_FinishAuthentication(t *testing.T) {
 	err = handler.FinishAuthentication(c2)
 	if assert.Error(t, err) {
 		httpError := dto.ToHttpError(err)
-		assert.Equal(t, http.StatusBadRequest, httpError.Code)
+		assert.Equal(t, http.StatusUnauthorized, httpError.Code)
 		assert.Equal(t, "Stored challenge and received challenge do not match: sessionData not found", err.Error())
 	}
 }

--- a/hanko-js/src/lib/HankoClient.ts
+++ b/hanko-js/src/lib/HankoClient.ts
@@ -261,7 +261,7 @@ class WebauthnClient extends AbstractClient {
         .then((response) => {
           if (response.ok) {
             return response.json();
-          } else if (response.status === 400) {
+          } else if (response.status === 400 || response.status === 401) {
             throw new InvalidWebauthnCredentialError();
           } else {
             throw new TechnicalError();


### PR DESCRIPTION
* When something client related fails during WebAuthn authentication the UI always shows the "Invalid WebAuthn credentials error" - some cases have resulted in a "Technical error".
* Updates the API status codes for /webauthn/login/finalize. If the request was correct (correct types/syntactically valid values), but for example the user was not found, an unauthorized error is returned.