### PR TITLE
use always lowercase emails

### DIFF
--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/teamhanko/hanko/backend/persistence"
 	"github.com/teamhanko/hanko/backend/persistence/models"
 	"net/http"
+	"strings"
 )
 
 type UserHandler struct {
@@ -34,6 +35,8 @@ func (h *UserHandler) Create(c echo.Context) error {
 	if err := c.Validate(body); err != nil {
 		return dto.ToHttpError(err)
 	}
+
+	body.Email = strings.ToLower(body.Email)
 
 	return h.persister.Transaction(func(tx *pop.Connection) error {
 		user, err := h.persister.GetUserPersisterWithConnection(tx).GetByEmail(body.Email)
@@ -93,7 +96,7 @@ func (h *UserHandler) GetUserIdByEmail(c echo.Context) error {
 		return dto.ToHttpError(err)
 	}
 
-	user, err := h.persister.GetUserPersister().GetByEmail(request.Email)
+	user, err := h.persister.GetUserPersister().GetByEmail(strings.ToLower(request.Email))
 	if err != nil {
 		return fmt.Errorf("failed to get user: %w", err)
 	}

--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/teamhanko/hanko/backend/dto"
 	"github.com/teamhanko/hanko/backend/persistence"
 	"net/http"
+	"strings"
 )
 
 type UserHandlerAdmin struct {
@@ -56,6 +57,8 @@ func (h *UserHandlerAdmin) Patch(c echo.Context) error {
 	if err := c.Validate(patchRequest); err != nil {
 		return dto.ToHttpError(err)
 	}
+
+	patchRequest.Email = strings.ToLower(patchRequest.Email)
 
 	p := h.persister.GetUserPersister()
 	user, err := p.Get(uuid.FromStringOrNil(patchRequest.UserId))

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -55,6 +55,42 @@ func TestUserHandler_Create(t *testing.T) {
 	}
 }
 
+func TestUserHandler_Create_CaseInsensitive(t *testing.T) {
+	userId, _ := uuid.NewV4()
+	users := []models.User{
+		func() models.User {
+			return models.User{
+				ID:        userId,
+				Email:     "john.doe@example.com",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			}
+		}(),
+	}
+
+	e := echo.New()
+	e.Validator = dto.NewCustomValidator()
+
+	body := UserCreateBody{Email: "JANE.DOE@EXAMPLE.COM"}
+	bodyJson, err := json.Marshal(body)
+	assert.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/users", bytes.NewReader(bodyJson))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	p := test.NewPersister(users, nil, nil, nil, nil, nil)
+	handler := NewUserHandler(p)
+
+	if assert.NoError(t, handler.Create(c)) {
+		user := models.User{}
+		err := json.Unmarshal(rec.Body.Bytes(), &user)
+		assert.NoError(t, err)
+		assert.False(t, user.ID.IsNil())
+		assert.Equal(t, strings.ToLower(body.Email), user.Email)
+	}
+}
+
 func TestUserHandler_Create_UserExists(t *testing.T) {
 	userId, _ := uuid.NewV4()
 	users := []models.User{
@@ -71,6 +107,39 @@ func TestUserHandler_Create_UserExists(t *testing.T) {
 	e := echo.New()
 	e.Validator = dto.NewCustomValidator()
 	body := UserCreateBody{Email: "john.doe@example.com"}
+	bodyJson, err := json.Marshal(body)
+	assert.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/users", bytes.NewReader(bodyJson))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	p := test.NewPersister(users, nil, nil, nil, nil, nil)
+	handler := NewUserHandler(p)
+
+	err = handler.Create(c)
+	if assert.Error(t, err) {
+		httpError := dto.ToHttpError(err)
+		assert.Equal(t, http.StatusConflict, httpError.Code)
+	}
+}
+
+func TestUserHandler_Create_UserExists_CaseInsensitive(t *testing.T) {
+	userId, _ := uuid.NewV4()
+	users := []models.User{
+		func() models.User {
+			return models.User{
+				ID:        userId,
+				Email:     "john.doe@example.com",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			}
+		}(),
+	}
+
+	e := echo.New()
+	e.Validator = dto.NewCustomValidator()
+	body := UserCreateBody{Email: "JOHN.DOE@EXAMPLE.COM"}
 	bodyJson, err := json.Marshal(body)
 	assert.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/users", bytes.NewReader(bodyJson))
@@ -299,6 +368,40 @@ func TestUserHandler_GetUserIdByEmail(t *testing.T) {
 	e := echo.New()
 	e.Validator = dto.NewCustomValidator()
 	req := httptest.NewRequest(http.MethodPost, "/user", strings.NewReader(`{"email": "john.doe@example.com"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	p := test.NewPersister(users, nil, nil, nil, nil, nil)
+	handler := NewUserHandler(p)
+
+	if assert.NoError(t, handler.GetUserIdByEmail(c)) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+		response := struct {
+			UserId   string `json:"id"`
+			Verified bool   `json:"verified"`
+		}{}
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, users[0].ID.String(), response.UserId)
+		assert.Equal(t, users[0].Verified, response.Verified)
+	}
+}
+
+func TestUserHandler_GetUserIdByEmail_CaseInsensitive(t *testing.T) {
+	userId, _ := uuid.NewV4()
+	users := []models.User{
+		{
+			ID:        userId,
+			Email:     "john.doe@example.com",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+			Verified:  true,
+		},
+	}
+	e := echo.New()
+	e.Validator = dto.NewCustomValidator()
+	req := httptest.NewRequest(http.MethodPost, "/user", strings.NewReader(`{"email": "JOHN.DOE@EXAMPLE.COM"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)


### PR DESCRIPTION
This PR always transforms the emails to lowercase, so that `john.doe@example.com` will be the same as `JOHN.DOE@example.com`.