### PR TITLE
fix(backend): re-add json struct tags for public config attributes

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -160,8 +160,8 @@ func (s *Service) Validate() error {
 }
 
 type Password struct {
-	Enabled           bool
-	MinPasswordLength int `koanf:"min_password_length" yaml:"min_password_length"`
+	Enabled           bool `json:"enabled"`
+	MinPasswordLength int  `koanf:"min_password_length" yaml:"min_password_length" json:"min_password_length"`
 }
 
 type Cookie struct {


### PR DESCRIPTION
JSON struct tags for public config attributes were removed in 7d4f120.
The 'Password.Enabled' attribute is now serialized with an uppercase first letter.
Aside from being inconsistent (the parent `Password` attribute in the
`PublicConfig` struct has a proper JSON struct tag with an uncapitalized
first letter) the hanko-js web component can't handle this: it results
in login flows disregarding passwords and falling back to a passwordless
flow even though they might be enabled in the backend config.