### PR TITLE
feat: handle auth-token header and create cross domain cookies

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -303,8 +303,9 @@ func (s *Secrets) Validate() error {
 }
 
 type Session struct {
-	Lifespan string `yaml:"lifespan" json:"lifespan" koanf:"lifespan"`
-	Cookie   Cookie `yaml:"cookie" json:"cookie" koanf:"cookie"`
+	EnableAuthToken bool   `yaml:"enable_auth_token" json:"enable_auth_token" koanf:"enable_auth_token"`
+	Lifespan        string `yaml:"lifespan" json:"lifespan" koanf:"lifespan"`
+	Cookie          Cookie `yaml:"cookie" json:"cookie" koanf:"cookie"`
 }
 
 func (s *Session) Validate() error {

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -303,9 +303,9 @@ func (s *Secrets) Validate() error {
 }
 
 type Session struct {
-	EnableAuthToken bool   `yaml:"enable_auth_token" json:"enable_auth_token" koanf:"enable_auth_token"`
-	Lifespan        string `yaml:"lifespan" json:"lifespan" koanf:"lifespan"`
-	Cookie          Cookie `yaml:"cookie" json:"cookie" koanf:"cookie"`
+	EnableAuthTokenHeader bool   `yaml:"enable_auth_token_header" json:"enable_auth_token_header" koanf:"enable_auth_token_header"`
+	Lifespan              string `yaml:"lifespan" json:"lifespan" koanf:"lifespan"`
+	Cookie                Cookie `yaml:"cookie" json:"cookie" koanf:"cookie"`
 }
 
 func (s *Session) Validate() error {

--- a/backend/docs/Config.md
+++ b/backend/docs/Config.md
@@ -140,11 +140,11 @@ session:
     # Default value: true
     #
     secure: true
-  ## enable_auth_token ##
+  ## enable_auth_token_header ##
   #
   # The JWT will be transmitted via the X-Auth-Token header. Enable during cross-domain operations.
   #
-  enable_auth_token: false
+  enable_auth_token_header: false
 password:
   ## enabled ##
   #

--- a/backend/docs/Config.md
+++ b/backend/docs/Config.md
@@ -140,11 +140,11 @@ session:
     # Default value: true
     #
     secure: true
-    ## enable_auth_token ##
-    #
-    # The JWT will be transmitted via the X-Auth-Token header. Enable during cross-domain operations.
-    #
-    enable_auth_token: false
+  ## enable_auth_token ##
+  #
+  # The JWT will be transmitted via the X-Auth-Token header. Enable during cross-domain operations.
+  #
+  enable_auth_token: false
 password:
   ## enabled ##
   #

--- a/backend/docs/Config.md
+++ b/backend/docs/Config.md
@@ -140,6 +140,11 @@ session:
     # Default value: true
     #
     secure: true
+    ## enable_auth_token ##
+    #
+    # The JWT will be transmitted via the X-Auth-Token header. Enable during cross-domain operations.
+    #
+    enable_auth_token: false
 password:
   ## enabled ##
   #
@@ -211,13 +216,13 @@ webauthn:
     #
     # Examples:
     # - Example Project
-    # - Hanko GmbH 
+    # - Hanko GmbH
     # - Acme, Inc.
     #
     display_name: ""
     ## origin ##
     #
-    # The origin for which WebAuthn credentials will be accepted by the server. Must include the protocol and can only be the effective domain, 
+    # The origin for which WebAuthn credentials will be accepted by the server. Must include the protocol and can only be the effective domain,
     # or a registrable domain suffix of the effective domain, as specified in the id. Except for localhost, the protocol must always be https for WebAuthn to work.
     #
     # Example:

--- a/backend/handler/passcode.go
+++ b/backend/handler/passcode.go
@@ -223,7 +223,7 @@ func (h *PasscodeHandler) Finish(c echo.Context) error {
 
 		c.SetCookie(cookie)
 
-		if h.cfg.Session.EnableAuthToken {
+		if h.cfg.Session.EnableAuthTokenHeader {
 			c.Response().Header().Set("X-Auth-Token", token)
 		}
 

--- a/backend/handler/passcode_test.go
+++ b/backend/handler/passcode_test.go
@@ -19,13 +19,13 @@ import (
 )
 
 func TestNewPasscodeHandler(t *testing.T) {
-	passcodeHandler, err := NewPasscodeHandler(config.Passcode{}, config.Service{}, test.NewPersister(nil, nil, nil, nil, nil, nil), sessionManager{}, mailer{})
+	passcodeHandler, err := NewPasscodeHandler(&config.Config{}, test.NewPersister(nil, nil, nil, nil, nil, nil), sessionManager{}, mailer{})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, passcodeHandler)
 }
 
 func TestPasscodeHandler_Init(t *testing.T) {
-	passcodeHandler, err := NewPasscodeHandler(config.Passcode{}, config.Service{}, test.NewPersister(users, nil, nil, nil, nil, nil), sessionManager{}, mailer{})
+	passcodeHandler, err := NewPasscodeHandler(&config.Config{}, test.NewPersister(users, nil, nil, nil, nil, nil), sessionManager{}, mailer{})
 	require.NoError(t, err)
 
 	body := dto.PasscodeInitRequest{
@@ -47,7 +47,7 @@ func TestPasscodeHandler_Init(t *testing.T) {
 }
 
 func TestPasscodeHandler_Init_UnknownUserId(t *testing.T) {
-	passcodeHandler, err := NewPasscodeHandler(config.Passcode{}, config.Service{}, test.NewPersister(users, nil, nil, nil, nil, nil), sessionManager{}, mailer{})
+	passcodeHandler, err := NewPasscodeHandler(&config.Config{}, test.NewPersister(users, nil, nil, nil, nil, nil), sessionManager{}, mailer{})
 	require.NoError(t, err)
 
 	body := dto.PasscodeInitRequest{
@@ -71,7 +71,7 @@ func TestPasscodeHandler_Init_UnknownUserId(t *testing.T) {
 }
 
 func TestPasscodeHandler_Finish(t *testing.T) {
-	passcodeHandler, err := NewPasscodeHandler(config.Passcode{}, config.Service{}, test.NewPersister(users, passcodes(), nil, nil, nil, nil), sessionManager{}, mailer{})
+	passcodeHandler, err := NewPasscodeHandler(&config.Config{}, test.NewPersister(users, passcodes(), nil, nil, nil, nil), sessionManager{}, mailer{})
 	require.NoError(t, err)
 
 	body := dto.PasscodeFinishRequest{
@@ -94,7 +94,7 @@ func TestPasscodeHandler_Finish(t *testing.T) {
 }
 
 func TestPasscodeHandler_Finish_WrongCode(t *testing.T) {
-	passcodeHandler, err := NewPasscodeHandler(config.Passcode{}, config.Service{}, test.NewPersister(users, passcodes(), nil, nil, nil, nil), sessionManager{}, mailer{})
+	passcodeHandler, err := NewPasscodeHandler(&config.Config{}, test.NewPersister(users, passcodes(), nil, nil, nil, nil), sessionManager{}, mailer{})
 	require.NoError(t, err)
 
 	body := dto.PasscodeFinishRequest{
@@ -119,7 +119,7 @@ func TestPasscodeHandler_Finish_WrongCode(t *testing.T) {
 }
 
 func TestPasscodeHandler_Finish_WrongCode_3_Times(t *testing.T) {
-	passcodeHandler, err := NewPasscodeHandler(config.Passcode{}, config.Service{}, test.NewPersister(users, passcodes(), nil, nil, nil, nil), sessionManager{}, mailer{})
+	passcodeHandler, err := NewPasscodeHandler(&config.Config{}, test.NewPersister(users, passcodes(), nil, nil, nil, nil), sessionManager{}, mailer{})
 	require.NoError(t, err)
 
 	body := dto.PasscodeFinishRequest{
@@ -153,7 +153,7 @@ func TestPasscodeHandler_Finish_WrongCode_3_Times(t *testing.T) {
 }
 
 func TestPasscodeHandler_Finish_WrongId(t *testing.T) {
-	passcodeHandler, err := NewPasscodeHandler(config.Passcode{}, config.Service{}, test.NewPersister(users, passcodes(), nil, nil, nil, nil), sessionManager{}, mailer{})
+	passcodeHandler, err := NewPasscodeHandler(&config.Config{}, test.NewPersister(users, passcodes(), nil, nil, nil, nil), sessionManager{}, mailer{})
 	require.NoError(t, err)
 
 	body := dto.PasscodeFinishRequest{

--- a/backend/handler/password.go
+++ b/backend/handler/password.go
@@ -158,7 +158,7 @@ func (h *PasswordHandler) Login(c echo.Context) error {
 
 	c.SetCookie(cookie)
 
-	if h.cfg.Session.EnableAuthToken {
+	if h.cfg.Session.EnableAuthTokenHeader {
 		c.Response().Header().Set("X-Auth-Token", token)
 	}
 

--- a/backend/handler/password.go
+++ b/backend/handler/password.go
@@ -20,10 +20,10 @@ import (
 type PasswordHandler struct {
 	persister      persistence.Persister
 	sessionManager session.Manager
-	cfg            config.Password
+	cfg            *config.Config
 }
 
-func NewPasswordHandler(persister persistence.Persister, sessionManager session.Manager, cfg config.Password) *PasswordHandler {
+func NewPasswordHandler(persister persistence.Persister, sessionManager session.Manager, cfg *config.Config) *PasswordHandler {
 	return &PasswordHandler{
 		persister:      persister,
 		sessionManager: sessionManager,
@@ -57,8 +57,8 @@ func (h *PasswordHandler) Set(c echo.Context) error {
 	}
 
 	pwBytes := []byte(body.Password)
-	if utf8.RuneCountInString(body.Password) < h.cfg.MinPasswordLength { // use utf8.RuneCountInString, so utf8 characters would count as 1
-		return dto.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("password must be at least %d characters long", h.cfg.MinPasswordLength))
+	if utf8.RuneCountInString(body.Password) < h.cfg.Password.MinPasswordLength { // use utf8.RuneCountInString, so utf8 characters would count as 1
+		return dto.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("password must be at least %d characters long", h.cfg.Password.MinPasswordLength))
 	}
 	if len(pwBytes) > 72 {
 		return dto.NewHTTPError(http.StatusBadRequest, "password must not be longer than 72 bytes")
@@ -146,10 +146,21 @@ func (h *PasswordHandler) Login(c echo.Context) error {
 		return dto.NewHTTPError(http.StatusUnauthorized).SetInternal(err)
 	}
 
-	cookie, err := h.sessionManager.GenerateCookie(pw.UserId)
+	token, err := h.sessionManager.GenerateJWT(pw.UserId)
+	if err != nil {
+		return fmt.Errorf("failed to generate jwt: %w", err)
+	}
+
+	cookie, err := h.sessionManager.GenerateCookie(token)
 	if err != nil {
 		return fmt.Errorf("failed to create session cookie: %w", err)
 	}
+
 	c.SetCookie(cookie)
+
+	if h.cfg.Session.EnableAuthToken {
+		c.Response().Header().Set("X-Auth-Token", token)
+	}
+
 	return c.String(http.StatusOK, "")
 }

--- a/backend/handler/password_test.go
+++ b/backend/handler/password_test.go
@@ -48,7 +48,7 @@ func TestPasswordHandler_Set_Create(t *testing.T) {
 	c.Set("session", token)
 
 	p := test.NewPersister(users, nil, nil, nil, nil, []models.PasswordCredential{})
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{})
 
 	if assert.NoError(t, handler.Set(c)) {
 		assert.Equal(t, http.StatusCreated, rec.Code)
@@ -83,7 +83,7 @@ func TestPasswordHandler_Set_Create_PasswordTooShort(t *testing.T) {
 	c.Set("session", token)
 
 	p := test.NewPersister(users, nil, nil, nil, nil, []models.PasswordCredential{})
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{MinPasswordLength: 8})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{Password: config.Password{MinPasswordLength: 8}})
 
 	err = handler.Set(c)
 	if assert.Error(t, err) {
@@ -120,7 +120,7 @@ func TestPasswordHandler_Set_Create_PasswordTooLong(t *testing.T) {
 	c.Set("session", token)
 
 	p := test.NewPersister(users, nil, nil, nil, nil, []models.PasswordCredential{})
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{MinPasswordLength: 8})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{Password: config.Password{MinPasswordLength: 8}})
 
 	err = handler.Set(c)
 	if assert.Error(t, err) {
@@ -173,7 +173,7 @@ func TestPasswordHandler_Set_Update(t *testing.T) {
 	c.Set("session", token)
 
 	p := test.NewPersister(users, nil, nil, nil, nil, passwords)
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{})
 
 	if assert.NoError(t, handler.Set(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
@@ -198,7 +198,7 @@ func TestPasswordHandler_Set_UserNotFound(t *testing.T) {
 	c.Set("session", token)
 
 	p := test.NewPersister([]models.User{}, nil, nil, nil, nil, []models.PasswordCredential{})
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{})
 
 	err = handler.Set(c)
 	if assert.Error(t, err) {
@@ -251,7 +251,7 @@ func TestPasswordHandler_Set_TokenHasWrongSubject(t *testing.T) {
 	c.Set("session", token)
 
 	p := test.NewPersister(users, nil, nil, nil, nil, passwords)
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{})
 
 	err = handler.Set(c)
 	if assert.Error(t, err) {
@@ -276,7 +276,7 @@ func TestPasswordHandler_Set_BadRequestBody(t *testing.T) {
 	c.Set("session", token)
 
 	p := test.NewPersister(nil, nil, nil, nil, nil, nil)
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{})
 
 	err = handler.Set(c)
 	if assert.Error(t, err) {
@@ -323,7 +323,7 @@ func TestPasswordHandler_Login(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	p := test.NewPersister(users, nil, nil, nil, nil, passwords)
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{})
 
 	if assert.NoError(t, handler.Login(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
@@ -376,7 +376,7 @@ func TestPasswordHandler_Login_WrongPassword(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	p := test.NewPersister(users, nil, nil, nil, nil, passwords)
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{})
 
 	err = handler.Login(c)
 	if assert.Error(t, err) {
@@ -396,7 +396,7 @@ func TestPasswordHandler_Login_NonExistingUser(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	p := test.NewPersister([]models.User{}, nil, nil, nil, nil, []models.PasswordCredential{})
-	handler := NewPasswordHandler(p, sessionManager{}, config.Password{})
+	handler := NewPasswordHandler(p, sessionManager{}, &config.Config{})
 
 	err := handler.Login(c)
 	if assert.Error(t, err) {

--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -122,5 +122,5 @@ func (h *UserHandler) Me(c echo.Context) error {
 		return errors.New("failed to cast session object")
 	}
 
-	return c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("/users/%s", sessionToken.Subject()))
+	return c.JSON(http.StatusOK, map[string]string{"id": sessionToken.Subject()})
 }

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -441,7 +440,12 @@ func TestUserHandler_Me(t *testing.T) {
 	handler := NewUserHandler(p)
 
 	if assert.NoError(t, handler.Me(c)) {
-		assert.Equal(t, http.StatusTemporaryRedirect, rec.Code)
-		assert.Equal(t, fmt.Sprintf("/users/%s", userId.String()), rec.Header().Get("Location"))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		response := struct {
+			UserId string `json:"id"`
+		}{}
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, userId.String(), response.UserId)
 	}
 }

--- a/backend/handler/webauthn.go
+++ b/backend/handler/webauthn.go
@@ -23,22 +23,23 @@ type WebauthnHandler struct {
 	persister      persistence.Persister
 	webauthn       *webauthn.WebAuthn
 	sessionManager session.Manager
+	cfg            *config.Config
 }
 
 // NewWebauthnHandler creates a new handler which handles all webauthn related routes
-func NewWebauthnHandler(cfg config.WebauthnSettings, persister persistence.Persister, sessionManager session.Manager) (*WebauthnHandler, error) {
+func NewWebauthnHandler(cfg *config.Config, persister persistence.Persister, sessionManager session.Manager) (*WebauthnHandler, error) {
 	f := false
 	wa, err := webauthn.New(&webauthn.Config{
-		RPDisplayName:         cfg.RelyingParty.DisplayName,
-		RPID:                  cfg.RelyingParty.Id,
-		RPOrigin:              cfg.RelyingParty.Origin,
+		RPDisplayName:         cfg.Webauthn.RelyingParty.DisplayName,
+		RPID:                  cfg.Webauthn.RelyingParty.Id,
+		RPOrigin:              cfg.Webauthn.RelyingParty.Origin,
 		AttestationPreference: protocol.PreferNoAttestation,
 		AuthenticatorSelection: protocol.AuthenticatorSelection{
 			RequireResidentKey: &f,
 			ResidentKey:        protocol.ResidentKeyRequirementDiscouraged,
 			UserVerification:   protocol.VerificationRequired,
 		},
-		Timeout: cfg.Timeout,
+		Timeout: cfg.Webauthn.Timeout,
 		Debug:   false,
 	})
 
@@ -50,6 +51,7 @@ func NewWebauthnHandler(cfg config.WebauthnSettings, persister persistence.Persi
 		persister:      persister,
 		webauthn:       wa,
 		sessionManager: sessionManager,
+		cfg:            cfg,
 	}, nil
 }
 
@@ -252,12 +254,22 @@ func (h *WebauthnHandler) FinishAuthentication(c echo.Context) error {
 			return fmt.Errorf("failed to delete assertion session data: %w", err)
 		}
 
-		cookie, err := h.sessionManager.GenerateCookie(webauthnUser.UserId)
+		token, err := h.sessionManager.GenerateJWT(webauthnUser.UserId)
+		if err != nil {
+			return fmt.Errorf("failed to generate jwt: %w", err)
+		}
+
+		cookie, err := h.sessionManager.GenerateCookie(token)
 		if err != nil {
 			return fmt.Errorf("failed to create session cookie: %w", err)
 		}
 
 		c.SetCookie(cookie)
+
+		if h.cfg.Session.EnableAuthToken {
+			c.Response().Header().Set("X-Auth-Token", token)
+		}
+
 		return c.JSON(http.StatusOK, map[string]string{"credential_id": base64.RawURLEncoding.EncodeToString(credential.ID), "user_id": webauthnUser.UserId.String()})
 	})
 }

--- a/backend/handler/webauthn.go
+++ b/backend/handler/webauthn.go
@@ -266,7 +266,7 @@ func (h *WebauthnHandler) FinishAuthentication(c echo.Context) error {
 
 		c.SetCookie(cookie)
 
-		if h.cfg.Session.EnableAuthToken {
+		if h.cfg.Session.EnableAuthTokenHeader {
 			c.Response().Header().Set("X-Auth-Token", token)
 		}
 

--- a/backend/handler/webauthn_test.go
+++ b/backend/handler/webauthn_test.go
@@ -50,7 +50,7 @@ func TestWebauthnHandler_BeginRegistration(t *testing.T) {
 		assert.NotEmpty(t, creationOptions.Response.Challenge)
 		assert.Equal(t, userIdBytes, creationOptions.Response.User.ID)
 		assert.Equal(t, defaultConfig.Webauthn.RelyingParty.Id, creationOptions.Response.RelyingParty.ID)
-		assert.Equal(t, creationOptions.Response.AuthenticatorSelection.ResidentKey, protocol.ResidentKeyRequirementRequired)
+		assert.Equal(t, creationOptions.Response.AuthenticatorSelection.ResidentKey, protocol.ResidentKeyRequirementPreferred)
 		assert.Equal(t, creationOptions.Response.AuthenticatorSelection.UserVerification, protocol.VerificationRequired)
 		assert.True(t, *creationOptions.Response.AuthenticatorSelection.RequireResidentKey)
 	}

--- a/backend/server/public_router.go
+++ b/backend/server/public_router.go
@@ -50,7 +50,7 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister) *echo.
 	}
 
 	if cfg.Password.Enabled {
-		passwordHandler := handler.NewPasswordHandler(persister, sessionManager, cfg.Password)
+		passwordHandler := handler.NewPasswordHandler(persister, sessionManager, cfg)
 
 		password := e.Group("/password")
 		password.PUT("", passwordHandler.Set, hankoMiddleware.Session(sessionManager))
@@ -68,11 +68,11 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister) *echo.
 	e.POST("/user", userHandler.GetUserIdByEmail)
 
 	healthHandler := handler.NewHealthHandler()
-	webauthnHandler, err := handler.NewWebauthnHandler(cfg.Webauthn, persister, sessionManager)
+	webauthnHandler, err := handler.NewWebauthnHandler(cfg, persister, sessionManager)
 	if err != nil {
 		panic(fmt.Errorf("failed to create public webauthn handler: %w", err))
 	}
-	passcodeHandler, err := handler.NewPasscodeHandler(cfg.Passcode, cfg.Service, persister, sessionManager, mailer)
+	passcodeHandler, err := handler.NewPasscodeHandler(cfg, persister, sessionManager, mailer)
 	if err != nil {
 		panic(fmt.Errorf("failed to create public passcode handler: %w", err))
 	}

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -14,7 +14,7 @@ import (
 type Manager interface {
 	GenerateJWT(uuid.UUID) (string, error)
 	Verify(string) (jwt.Token, error)
-	GenerateCookie(userId uuid.UUID) (*http.Cookie, error)
+	GenerateCookie(token string) (*http.Cookie, error)
 }
 
 // Manager is used to create and verify session JWTs
@@ -100,15 +100,10 @@ func (g *manager) Verify(token string) (jwt.Token, error) {
 }
 
 // GenerateCookie creates a new session cookie for the given user
-func (g *manager) GenerateCookie(userId uuid.UUID) (*http.Cookie, error) {
-	jwt, err := g.GenerateJWT(userId)
-	if err != nil {
-		return nil, err
-	}
-
+func (g *manager) GenerateCookie(token string) (*http.Cookie, error) {
 	return &http.Cookie{
 		Name:     "hanko",
-		Value:    jwt,
+		Value:    token,
 		Domain:   g.cookieConfig.Domain,
 		Path:     "/",
 		Secure:   g.cookieConfig.Secure,

--- a/docs/spec/api.yaml
+++ b/docs/spec/api.yaml
@@ -418,7 +418,7 @@ paths:
                 $ref: '#/components/schemas/Error'
   /me:
     get:
-      summary: 'Redirects to user resource if user has valid session'
+      summary: 'Get the current user ID'
       operationId: IsUserAuthorized
       tags:
         - authentication
@@ -426,13 +426,15 @@ paths:
         - CookieAuth: [ ]
         - BearerTokenAuth: [ ]
       responses:
-        '307':
-          description: 'Redirect'
-          headers:
-            Location:
+        '200':
+          description: 'User'
+          content:
+            application/json:
               schema:
-                type: string
-              description: Redirect target
+                type: object
+                properties:
+                  id:
+                    $ref:  '#/components/schemas/UUID4'
         '401':
           description: 'Unauthorized'
           content:

--- a/hanko-js/package-lock.json
+++ b/hanko-js/package-lock.json
@@ -12,7 +12,9 @@
         "@denysvuika/preact-translate": "^0.3.0",
         "@github/webauthn-json": "^2.0.0-alpha4",
         "@teamhanko/hanko-webauthn": "^2.0.0",
+        "@types/js-cookie": "^3.0.2",
         "classnames": "^2.3.1",
+        "js-cookie": "^3.0.1",
         "preact": "^10.6.6",
         "preact-custom-element": "^4.2.1"
       },
@@ -1461,6 +1463,11 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.2.tgz",
+      "integrity": "sha512-6+0ekgfusHftJNYpihfkMu8BWdeHs9EOJuGcSofErjstGPfPGEu9yTu4t460lTzzAMl2cM5zngQJqPMHbbnvYA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -5583,6 +5590,14 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -10209,6 +10224,11 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/js-cookie": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.2.tgz",
+      "integrity": "sha512-6+0ekgfusHftJNYpihfkMu8BWdeHs9EOJuGcSofErjstGPfPGEu9yTu4t460lTzzAMl2cM5zngQJqPMHbbnvYA=="
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -13340,6 +13360,11 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/hanko-js/package.json
+++ b/hanko-js/package.json
@@ -64,7 +64,9 @@
     "@denysvuika/preact-translate": "^0.3.0",
     "@github/webauthn-json": "^2.0.0-alpha4",
     "@teamhanko/hanko-webauthn": "^2.0.0",
+    "@types/js-cookie": "^3.0.2",
     "classnames": "^2.3.1",
+    "js-cookie": "^3.0.1",
     "preact": "^10.6.6",
     "preact-custom-element": "^4.2.1"
   }

--- a/hanko-js/src/lib/HankoClient.ts
+++ b/hanko-js/src/lib/HankoClient.ts
@@ -131,7 +131,7 @@ class HttpClient {
       };
 
       if (token) {
-        headers.Authrization = `Bearer ${token}`;
+        headers.Authorization = `Bearer ${token}`;
       }
 
       fetch(this.api + path, {
@@ -168,6 +168,8 @@ class HttpClient {
   _fetch2(method: string, path: string, body?: string) {
     const url = this.api + path;
     const timeout = this.timeout;
+    const cookieName = "hanko";
+    const token = Cookies.get(cookieName);
 
     return new Promise<Response2>(function (resolve, reject) {
       const xhr = new XMLHttpRequest();
@@ -175,6 +177,11 @@ class HttpClient {
       xhr.open(method, url, true);
       xhr.setRequestHeader("Accept", "application/json");
       xhr.setRequestHeader("Content-Type", "application/json");
+
+      if (token) {
+        xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+      }
+
       xhr.timeout = timeout;
       xhr.withCredentials = true;
       xhr.onload = () => {

--- a/hanko-js/src/lib/HankoClient.ts
+++ b/hanko-js/src/lib/HankoClient.ts
@@ -125,16 +125,20 @@ class HttpClient {
       const timeout = setTimeout(() => controller.abort(), this.timeout);
       const cookieName = "hanko";
       const token = Cookies.get(cookieName);
+      const headers: HeadersInit = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      };
+
+      if (token) {
+        headers.Authrization = `Bearer ${token}`;
+      }
 
       fetch(this.api + path, {
         mode: "cors",
         credentials: "include",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
         signal: controller.signal,
+        headers,
         ...init,
       })
         .then((response) => {


### PR DESCRIPTION
* Added a new config parameter `EnableAuthToken` to the session config. This causes the API to issue a JWT via the `X-Auth-Token` header. 
* The HankoClient (.ts) will notice and create a client-side cookie containing the value of `X-Auth-Token`

Sidenotes:
* In the different handlers, due to the introduction of the new config parameter "EnableAuthToken", I needed to access the session config. Since all configs are passed separately as parameters into the handler constructors, I would have had to pass a third config in some cases. But all configs are members of the `config.Config{}` type. So instead of creating another parameter, I changed the handlers to accept `config.Config{}`. This way there is no need to update the router and the test files again, when a handler needs to access another config.
