### PR TITLE
fix: example backend also uses hanko to validate jwts. on docker-comp…

### DIFF
--- a/deploy/docker-compose/quickstart.yaml
+++ b/deploy/docker-compose/quickstart.yaml
@@ -58,6 +58,7 @@ services:
       - "8888:8080"
     environment:
       - HANKO_URL=http://localhost:8000
+      - HANKO_URL_INTERNAL=http://hanko:8000
       - HANKO_ELEMENT_URL=http://localhost:9500/element.hanko-auth.js
     networks:
       - intranet

--- a/example/main.go
+++ b/example/main.go
@@ -18,6 +18,10 @@ func main() {
 
 	hankoUrl := getEnv("HANKO_URL")
 	hankoElementUrl := getEnv("HANKO_ELEMENT_URL")
+	hankoUrlInternal := hankoUrl
+	if value, ok := os.LookupEnv("HANKO_URL_INTERNAL"); ok {
+		hankoUrlInternal = value
+	}
 
 	e := echo.New()
 
@@ -38,7 +42,7 @@ func main() {
 		}
 		return c.Render(http.StatusOK, "index.html", &indexData)
 	})
-	e.File("/secured", "public/html/secured.html", middleware.SessionMiddleware())
+	e.File("/secured", "public/html/secured.html", middleware.SessionMiddleware(hankoUrlInternal))
 	e.File("/unauthorized", "public/html/unauthorized.html")
 
 	e.GET("/logout", func(c echo.Context) error {

--- a/example/middleware/session.go
+++ b/example/middleware/session.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"github.com/labstack/echo/v4"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -9,7 +10,7 @@ import (
 	"net/http"
 )
 
-func SessionMiddleware() echo.MiddlewareFunc {
+func SessionMiddleware(hankoUrl string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			cookie, err := c.Cookie("hanko")
@@ -19,7 +20,7 @@ func SessionMiddleware() echo.MiddlewareFunc {
 			if err != nil {
 				return err
 			}
-			set, err := jwk.Fetch(context.Background(), "http://hanko:8000/.well-known/jwks.json")
+			set, err := jwk.Fetch(context.Background(), fmt.Sprintf("%v/.well-known/jwks.json", hankoUrl))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
…ose this url differs from the one inserted into html.