### PR TITLE
fix: logout does not function if the example app does not explicitly …

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -19,8 +19,12 @@ func main() {
 	hankoUrl := getEnv("HANKO_URL")
 	hankoElementUrl := getEnv("HANKO_ELEMENT_URL")
 	hankoUrlInternal := hankoUrl
+	domain := ""
 	if value, ok := os.LookupEnv("HANKO_URL_INTERNAL"); ok {
 		hankoUrlInternal = value
+	}
+	if value, ok := os.LookupEnv("DOMAIN"); ok {
+		domain = value
 	}
 
 	e := echo.New()
@@ -51,6 +55,7 @@ func main() {
 			Value:    "",
 			MaxAge:   -1,
 			HttpOnly: true,
+			Domain:   domain,
 		}
 		c.SetCookie(cookie)
 		return c.Redirect(http.StatusTemporaryRedirect, "/")


### PR DESCRIPTION
…sets the domain. The cookie will not get deleted.If the domain is set, set it in the cookie settings


According to:  https://en.wikipedia.org/wiki/HTTP_cookie#Domain_and_Path

```
If a cookie's Domain and Path attributes are not specified by the server, they default to the domain and path of the resource that was requested. However, in most browsers there is a difference between a cookie set from foo.com without a domain, and a cookie set with the foo.com domain. In the former case, the cookie will only be sent for requests to foo.com, also known as a host-only cookie. In the latter case, all subdomains are also included....
```