### PR TITLE
fix(hanko-js): checkmark icon not shown when logging in with email+we…

### DIFF
--- a/hanko-js/src/ui/pages/LoginEmail.tsx
+++ b/hanko-js/src/ui/pages/LoginEmail.tsx
@@ -36,9 +36,14 @@ const LoginEmail = () => {
   } = useContext(RenderContext);
 
   const [userInfo, setUserInfo] = useState<UserInfo>(null);
-  const [isWebAuthnLoading, setIsWebAuthnLoading] = useState<boolean>(false);
-  const [isWebAuthnSuccess, setIsWebAuthnSuccess] = useState<boolean>(false);
-  const [isEmailLoading, setIsEmailLoading] = useState<boolean>(false);
+  const [isPasskeyLoginLoading, setIsPasskeyLoginLoading] =
+    useState<boolean>(false);
+  const [isPasskeyLoginSuccess, setIsPasskeyLoginSuccess] =
+    useState<boolean>(false);
+  const [isEmailLoginLoading, setIsEmailLoginLoading] =
+    useState<boolean>(false);
+  const [isEmailLoginSuccess, setIsEmailLoginSuccess] =
+    useState<boolean>(false);
   const [error, setError] = useState<HankoError>(null);
   const [isAuthenticatorSupported, setIsAuthenticatorSupported] =
     useState<boolean>(null);
@@ -51,7 +56,7 @@ const LoginEmail = () => {
 
   const onEmailSubmit = (event: Event) => {
     event.preventDefault();
-    setIsEmailLoading(true);
+    setIsEmailLoginLoading(true);
 
     hanko.user
       .getInfo(email)
@@ -66,26 +71,26 @@ const LoginEmail = () => {
         throw e;
       })
       .catch((e) => {
-        setIsEmailLoading(false);
+        setIsEmailLoginLoading(false);
         setError(e);
       });
   };
 
   const onWebAuthnSubmit = (event: Event) => {
     event.preventDefault();
-    setIsWebAuthnLoading(true);
+    setIsPasskeyLoginLoading(true);
 
     hanko.authenticator
       .login()
       .then(() => {
-        setIsWebAuthnLoading(false);
-        setIsWebAuthnSuccess(true);
+        setIsPasskeyLoginLoading(false);
+        setIsPasskeyLoginSuccess(true);
         emitSuccessEvent();
 
         return;
       })
       .catch((e) => {
-        setIsWebAuthnLoading(false);
+        setIsPasskeyLoginLoading(false);
         setError(e instanceof WebAuthnRequestCancelledError ? null : e);
       });
   };
@@ -93,12 +98,12 @@ const LoginEmail = () => {
   const renderAlternateLoginMethod = useCallback(() => {
     if (config.password.enabled) {
       renderPassword(userInfo.id).catch((e) => {
-        setIsEmailLoading(false);
+        setIsEmailLoginLoading(false);
         setError(e);
       });
     } else {
       renderPasscode(userInfo.id, false, false).catch((e) => {
-        setIsEmailLoading(false);
+        setIsEmailLoginLoading(false);
         setError(e);
       });
     }
@@ -125,6 +130,8 @@ const LoginEmail = () => {
       hanko.authenticator
         .login(userInfo.id)
         .then(() => {
+          setIsEmailLoginLoading(false);
+          setIsEmailLoginSuccess(true);
           emitSuccessEvent();
 
           return;
@@ -159,7 +166,9 @@ const LoginEmail = () => {
           pattern={"^.*[^0-9]+$"}
           autofocus
         />
-        <Button isLoading={isEmailLoading}>{t("labels.continue")}</Button>
+        <Button isLoading={isEmailLoginLoading} isSuccess={isEmailLoginSuccess}>
+          {t("labels.continue")}
+        </Button>
       </Form>
       {isAuthenticatorSupported ? (
         <Fragment>
@@ -167,8 +176,8 @@ const LoginEmail = () => {
           <Form onSubmit={onWebAuthnSubmit}>
             <Button
               secondary
-              isLoading={isWebAuthnLoading}
-              isSuccess={isWebAuthnSuccess}
+              isLoading={isPasskeyLoginLoading}
+              isSuccess={isPasskeyLoginSuccess}
             >
               {t("labels.signInPasskey")}
             </Button>


### PR DESCRIPTION
Register a WebAuthN credential, then log in with WebAuthN by entering the email. If the login was successful, the checkmark icon should replace the text of the "Continue" button.