### PR TITLE
fix: ignore transport with empty string

### DIFF
--- a/backend/dto/intern/WebauthnCredential.go
+++ b/backend/dto/intern/WebauthnCredential.go
@@ -23,7 +23,6 @@ func WebauthnCredentialToModel(credential *webauthn.Credential, userId uuid.UUID
 		SignCount:       int(credential.Authenticator.SignCount),
 		CreatedAt:       now,
 		UpdatedAt:       now,
-		Transports:      make([]models.WebauthnCredentialTransport, len(credential.Transport)),
 	}
 
 	for _, name := range credential.Transport {

--- a/backend/dto/intern/WebauthnCredential.go
+++ b/backend/dto/intern/WebauthnCredential.go
@@ -26,12 +26,15 @@ func WebauthnCredentialToModel(credential *webauthn.Credential, userId uuid.UUID
 		Transports:      make([]models.WebauthnCredentialTransport, len(credential.Transport)),
 	}
 
-	for i, name := range credential.Transport {
-		id, _ := uuid.NewV4()
-		c.Transports[i] = models.WebauthnCredentialTransport{
-			ID:                   id,
-			Name:                 string(name),
-			WebauthnCredentialID: credentialID,
+	for _, name := range credential.Transport {
+		if string(name) != "" {
+			id, _ := uuid.NewV4()
+			t := models.WebauthnCredentialTransport{
+				ID:                   id,
+				Name:                 string(name),
+				WebauthnCredentialID: credentialID,
+			}
+			c.Transports = append(c.Transports, t)
 		}
 	}
 


### PR DESCRIPTION
Sometimes a client sends a transport list with an empty string:
```
transports: ["internal", ""]
```

The backend should ignore those values.