### PR TITLE
fix: fix webauthn login when userHandle is empty

### DIFF
--- a/backend/handler/webauthn.go
+++ b/backend/handler/webauthn.go
@@ -213,10 +213,6 @@ func (h *WebauthnHandler) FinishAuthentication(c echo.Context) error {
 		return dto.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	//userId, err := uuid.FromBytes(request.Response.UserHandle)
-	//if err != nil {
-	//	return dto.NewHTTPError(http.StatusBadRequest, "failed to parse userHandle as uuid").SetInternal(err)
-	//}
 
 	return h.persister.Transaction(func(tx *pop.Connection) error {
 		sessionDataPersister := h.persister.GetWebauthnSessionDataPersisterWithConnection(tx)


### PR DESCRIPTION
This PR fixes logins on android. Currently android does not support discoverable credentials, so the `userHandle` property in an authenticator assertion is missing. 
Before this PR we relied on the `userHandle` (which basically is the userId) every time, but now we only rely on it, when it is a discoverable login.