### PR TITLE
refactor(example): remove redundant template renderer assignment

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -41,7 +41,6 @@ func main() {
 	}))
 
 	e.Use(middleware.CacheControlMiddleware())
-	e.Renderer = t
 
 	e.Static("/static", "public/assets")
 


### PR DESCRIPTION
Renderer is already assigned a few lines earlier