### PR TITLE
fix: remove webauthn transports when on android

### DIFF
--- a/hanko-js/src/lib/HankoClient.ts
+++ b/hanko-js/src/lib/HankoClient.ts
@@ -330,17 +330,10 @@ class WebauthnClient extends AbstractClient {
           reject(e);
         })
         .then((challenge: CredentialRequestOptionsJSON) => {
-          if (
-            challenge.publicKey.allowCredentials != undefined &&
-            this.isAndroidUserAgent
-          ) {
-            for (
-              let i = 0;
-              i < challenge.publicKey.allowCredentials.length;
-              i++
-            ) {
-              delete challenge.publicKey.allowCredentials[i].transports;
-            }
+          if (this.isAndroidUserAgent) {
+            challenge.publicKey?.allowCredentials?.map((c) => {
+              delete c.transports;
+            });
           }
           return getWebauthnCredential(challenge);
         })

--- a/hanko-js/src/lib/HankoClient.ts
+++ b/hanko-js/src/lib/HankoClient.ts
@@ -330,6 +330,8 @@ class WebauthnClient extends AbstractClient {
           reject(e);
         })
         .then((challenge: CredentialRequestOptionsJSON) => {
+          /* Due to a bug in Android, the internal authenticator gets triggered when transports are set to `internal` although the credential is unknown.
+          As a workaround the transports are removed. In case Google fixes the problem, this can be removed. */
           if (this.isAndroidUserAgent) {
             challenge.publicKey?.allowCredentials?.map((c) => {
               delete c.transports;


### PR DESCRIPTION
This PR removes the transports from the `allowCredentials` when webauthn is request on Android.

When the transports are not removed and only `internal` is set at transports, then Android does not check if it knows one of the credentials in the list and shows the BiometricPrompt and after the biometric were provided, the Web Component switches to Passcode, because after the biometrics are provided, an generic error (`DOMException: The operation either timed out or was not allowed`) is returned. When the transports are not available, then a chooser is shown where the user can select the transport the authenticator will use, but the `internal` authenticator is not offered. 

Prerequisites: The android device has no stored credential for the requested user.

With this change, the UI does not seem buggy after the biometrics were provided. But it is not great, because the user must cancel the transport chooser before passcodes can be used.