### PR TITLE
small changes to input properties and example css

### DIFF
--- a/example/public/assets/css/index.css
+++ b/example/public/assets/css/index.css
@@ -14,11 +14,8 @@
 }
 
 @media screen and (max-width: 470px) {
-    .main {
-        margin-top: 8px;
-    }
     .auth-container {
-        padding: 5px;
+        padding: 10px;
     }
 }
 

--- a/hanko-js/src/ui/components/InputPasscodeDigit.tsx
+++ b/hanko-js/src/ui/components/InputPasscodeDigit.tsx
@@ -43,7 +43,7 @@ const InputPasscodeDigit = ({ index, focus, digit = "", ...props }: Props) => {
         part={"input passcode-input"}
         name={props.name + index.toString(10)}
         type={"text"}
-        inputmode={"numeric"}
+        inputMode={"numeric"}
         maxLength={1}
         ref={ref}
         value={digit.charAt(0)}

--- a/hanko-js/src/ui/pages/LoginEmail.tsx
+++ b/hanko-js/src/ui/pages/LoginEmail.tsx
@@ -182,7 +182,8 @@ const LoginEmail = () => {
         <InputText
           name={"email"}
           type={"email"}
-          autocomplete={"username"}
+          autoComplete={"username"}
+          autoCorrect={"off"}
           required={true}
           onInput={onEmailInput}
           value={email}
@@ -194,7 +195,7 @@ const LoginEmail = () => {
             isPasskeyLoginLoading ||
             isPasskeyLoginSuccess
           }
-          autofocus
+          autoFocus
         />
         <Button
           isLoading={isEmailLoginLoading}


### PR DESCRIPTION
- Minor padding changes for example app
- Comply with preact 10.10.0 property requirements (see failing tests for https://github.com/teamhanko/hanko/pull/132)
- added autocorrect = off to username input to prevent autocorrection in Safari:

https://user-images.githubusercontent.com/20115649/182851687-37b9872a-e84e-41e5-a1cd-e960776be41a.mov


