### PR TITLE
feat(jwk): make explicit public jwks are used for verifying signatures

### DIFF
--- a/backend/crypto/jwk/generator_rsa.go
+++ b/backend/crypto/jwk/generator_rsa.go
@@ -34,5 +34,10 @@ func (g *RSAKeyGenerator) Generate(id string) (jwk.Key, error) {
 		return nil, err
 	}
 
+	err = key.Set(jwk.KeyUsageKey, jwk.ForSignature)
+	if err != nil {
+		return nil, err
+	}
+
 	return key, nil
 }

--- a/docs/spec/api.yaml
+++ b/docs/spec/api.yaml
@@ -383,7 +383,7 @@ paths:
     get:
       summary: 'Get JSON Web Key Set'
       description: |
-        Retrieve a JSON Web Key Set (JWKS) object containing the public `keys` used to verify
+        Retrieve a [JSON Web Key Set](https://www.rfc-editor.org/rfc/rfc7517#section-5) (JWKS) object containing the public `keys` used to verify
         JSON Web Tokens (JWT) issued by the Hanko API and signed using the RS256 signing algorithm.
       operationId: getJwks
       tags:
@@ -834,64 +834,39 @@ components:
       externalDocs:
         description: RFC7517 - JSON Web Key (JWK)
         url: https://datatracker.ietf.org/doc/html/rfc7517
-      required:
-        - use
-        - kty
-        - kid
-        - alg
       properties:
         alg:
           type: string
           example: RS256
-        crv:
-          type: string
-          example: P-256
-        d:
-          type: string
-          example: T_N8I-6He3M8a7X1vWt6TGIx4xB_GP3Mb4SsZSA4v-orvJzzRiQhLlRR81naWYxfQAYt5isDI6_C2L9bdWo4FFPjGQFvNoRX-_sBJyBI_rl-TBgsZYoUlAj3J92WmY2inbA-PwyJfsaIIDceYBC-eX-xiCu6qMqkZi3MwQAFL6bMdPEM0z4JBcwFT3VdiWAIRUuACWQwrXMq672x7fMuaIaHi7XDGgt1ith23CLfaREmJku9PQcchbt_uEY-hqrFY6ntTtS4paWWQj86xLL94S-Tf6v6xkL918PfLSOTq6XCzxvlFwzBJqApnAhbwqLjpPhgUG04EDRrqrSBc5Y1BLevn6Ip5h1AhessBp3wLkQgz_roeckt-ybvzKTjESMuagnpqLvOT7Y9veIug2MwPJZI2VjczRc1vzMs25XrFQ8DpUy-bNdp89TmvAXwctUMiJdgHloJw23Cv03gIUAkDnsTqZmkpbIf-crpgNKFmQP_EDKoe8p_PXZZgfbRri3NoEVGP7Mk6yEu8LjJhClhZaBNjuWw2-KlBfOA3g79mhfBnkInee5KO9mGR50qPk1V-MorUYNTFMZIm0kFE6eYVWFBwJHLKYhHU34DoiK1VP-svZpC2uAMFNA_UJEwM9CQ2b8qe4-5e9aywMvwcuArRkAB5mBIfOaOJao3mfukKAE
-        dp:
-          type: string
-          example: G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0
-        dq:
-          type: string
-          example: s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk
+          externalDocs:
+            description: RFC7517 - JSON Web Key (JWK) - Section 4.4
+            url: https://www.rfc-editor.org/rfc/rfc7517#section-4.4
         e:
           type: string
+          format: base64url
           example: AQAB
-        k:
-          type: string
-          example: GawgguFyGrWKav7AX4VKUg
+          externalDocs:
+            description: RFC7518 - JSON Web Algorithms (JWA) - Section 6.3.1.2
+            url: https://www.rfc-editor.org/rfc/rfc7518#section-6.3.1.2
         kid:
           type: string
-          example: 1603dfe0af8f4596
+          example: d6ff37d7-e3d1-4432-ab80-b64faf55ae36
+          externalDocs:
+            description: RFC7517 - JSON Web Key (JWK) - Section 4.5
+            url: https://www.rfc-editor.org/rfc/rfc7517#section-4.5
         kty:
           type: string
           example: RSA
+          externalDocs:
+            description: RFC7517 - JSON Web Key (JWK) - Section 4.1
+            url: https://www.rfc-editor.org/rfc/rfc7517#section-4.1
         'n':
           type: string
-          example: vTqrxUyQPl_20aqf5kXHwDZrel-KovIp8s7ewJod2EXHl8tWlRB3_Rem34KwBfqlKQGp1nqah-51H4Jzruqe0cFP58hPEIt6WqrvnmJCXxnNuIB53iX_uUUXXHDHBeaPCSRoNJzNysjoJ30TIUsKBiirhBa7f235PXbKiHducLevV6PcKxJ5cY8zO286qJLBWSPm-OIevwqsIsSIH44Qtm9sioFikhkbLwoqwWORGAY0nl6XvVOlhADdLjBSqSAeT1FPuCDCnXwzCDR8N9IFB_IjdStFkC-rVt2K5BYfPd0c3yFp_vHR15eRd0zJ8XQ7woBC8Vnsac6Et1pKS59pX6256DPWu8UDdEOolKAPgcd_g2NpA76cAaF_jcT80j9KrEzw8Tv0nJBGesuCjPNjGs_KzdkWTUXt23Hn9QJsdc1MZuaW0iqXBepHYfYoqNelzVte117t4BwVp0kUM6we0IqyXClaZgOI8S-WDBw2_Ovdm8e5NmhYAblEVoygcX8Y46oH6bKiaCQfKCFDMcRgChme7AoE1yZZYsPbaG_3IjPrC4LBMHQw8rM9dWjJ8ImjicvZ1pAm0dx-KHCP3y5PVKrxBDf1zSOsBRkOSjB8TPODnJMz6-jd5hTtZxpZPwPoIdCanTZ3ZD6uRBpTmDwtpRGm63UQs1m5FWPwb0T2IF0
-        p:
-          type: string
-          example: 6NbkXwDWUhi-eR55Cgbf27FkQDDWIamOaDr0rj1q0f1fFEz1W5A_09YvG09Fiv1AO2-D8Rl8gS1Vkz2i0zCSqnyy8A025XOcRviOMK7nIxE4OH_PEsko8dtIrb3TmE2hUXvCkmzw9EsTF1LQBOGC6iusLTXepIC1x9ukCKFZQvdgtEObQ5kzd9Nhq-cdqmSeMVLoxPLd1blviVT9Vm8-y12CtYpeJHOaIDtVPLlBhJiBoPKWg3vxSm4XxIliNOefqegIlsmTIa3MpS6WWlCK3yHhat0Q-rRxDxdyiVdG_wzJvp0Iw_2wms7pe-PgNPYvUWH9JphWP5K38YqEBiJFXQ
-        q:
-          type: string
-          example: 0A1FmpOWR91_RAWpqreWSavNaZb9nXeKiBo0DQGBz32DbqKqQ8S4aBJmbRhJcctjCLjain-ivut477tAUMmzJwVJDDq2MZFwC9Q-4VYZmFU4HJityQuSzHYe64RjN-E_NQ02TWhG3QGW6roq6c57c99rrUsETwJJiwS8M5p15Miuz53DaOjv-uqqFAFfywN5WkxHbraBcjHtMiQuyQbQqkCFh-oanHkwYNeytsNhTu2mQmwR5DR2roZ2nPiFjC6nsdk-A7E3S3wMzYYFw7jvbWWoYWo9vB40_MY2Y0FYQSqcDzcBIcq_0tnnasf3VW4Fdx6m80RzOb2Fsnln7vKXAQ
-        qi:
-          type: string
-          example: GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU
-        use:
-          type: string
-          example: sig
-        x:
-          type: string
-          example: f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU
-        x5c:
-          type: array
-          items:
-            type: string
-        'y':
-          type: string
-          example: x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0
+          format: base64url
+          example: vPFRUCRoxN3RygdJHR3S5BV-DDLw6n-7oUXtX0nr7Twl...
+          externalDocs:
+            description: RFC7518 - JSON Web Algorithms (JWA) - Section 6.3.1.1
+            url: https://www.rfc-editor.org/rfc/rfc7518#section-6.3.1.1
     JSONWebKeySet:
       type: object
       properties:
@@ -899,6 +874,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/JSONWebKey'
+          externalDocs:
+            description: RFC7517 - JSON Web Key (JWK) - Section 5.1
+            url: https://www.rfc-editor.org/rfc/rfc7517#section-5.1
+      externalDocs:
+        description: RFC7517 - JSON Web Key (JWK) - Section 5
+        url: https://www.rfc-editor.org/rfc/rfc7517#section-5
     Passcode:
       description: Representation of a passcode
       type: object

--- a/docs/spec/api.yaml
+++ b/docs/spec/api.yaml
@@ -867,6 +867,12 @@ components:
           externalDocs:
             description: RFC7518 - JSON Web Algorithms (JWA) - Section 6.3.1.1
             url: https://www.rfc-editor.org/rfc/rfc7518#section-6.3.1.1
+        use:
+          type: string
+          example: sig
+          externalDocs:
+            description: RFC7517 - JSON Web Key (JWK) - Section 4.2
+            url: https://www.rfc-editor.org/rfc/rfc7517#section-4.2
     JSONWebKeySet:
       type: object
       properties:


### PR DESCRIPTION
also updates jwk related content in the api spec (external doc links to rfcs, removing non-public attributes from jwk schema)