### PR TITLE
chore: add License note for frontend-sdk

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,6 +4,10 @@
 (https://github.com/teamhanko/hanko/tree/main/elements) of this repository is
 licensed under the license defined in "elements/LICENSE".
 
+  All content that resides under the "frontend-sdk" directory
+(https://github.com/teamhanko/hanko/tree/main/frontend-sdk) of this repository is
+licensed under the license defined in "frontend-sdk/LICENSE".
+
   All third party components incorporated into Hanko software are licensed
 under the original license provided by the owner of the applicable component.
 

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ The Hanko project consists of
 Join our [Slack community](https://www.hanko.io/community) if you have any questions about Hanko or just want to chat about passkeys, authentication, identity, or life in general. You can also [follow us on Twitter](https://twitter.com/hanko_io) or just [reach out via email](https://www.hanko.io/contact).
 
 # Licenses
-[hanko-elements](elements) is licensed under the [MIT License](elements/LICENSE). Everything else in this repository, including [hanko backend](backend), is licensed under the [AGPL-3.0](/LICENSE).
+[hanko-elements](elements) and [hanko-frontend-sdk](frontend-sdk) are licensed under the [MIT License](elements/LICENSE). Everything else in this repository, including [hanko backend](backend), is licensed under the [AGPL-3.0](/LICENSE).


### PR DESCRIPTION
closes #216 