### PR TITLE
docs: add plausible analytics

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -13,6 +13,7 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
+  scripts: [{ src: 'https://plausible.io/js/plausible.js', defer: true, 'data-domain': 'docs.hanko.io' }],
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
# Description

Add plausible analytics to the docs

# Additional context

https://plausible.io/docs/docusaurus-integration

