### PR TITLE
wait for the promise to be finished before starting a new webauthn re…

### DIFF
--- a/frontend-sdk/tests/lib/client/WebauthnClient.spec.ts
+++ b/frontend-sdk/tests/lib/client/WebauthnClient.spec.ts
@@ -273,4 +273,22 @@ describe("webauthnClient.shouldRegister()", () => {
       expect(shouldRegister).toEqual(expected);
     }
   );
+
+  describe("webauthnClient._abortPendingGetCredentialRequest()", () => {
+    it("should abort the promise", async () => {
+      const controller = new AbortController();
+      webauthnClient._getCredentialController = controller;
+      webauthnClient._getCredentialPromise =
+        new Promise<PublicKeyCredentialWithAssertionJSON>((resolve) => {
+          controller.signal.addEventListener("abort", () => resolve(null));
+        });
+
+      jest.spyOn(controller, "abort");
+
+      expect(await webauthnClient._abortPendingGetCredentialRequest()).toEqual(
+        null
+      );
+      expect(controller.abort).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
# Description

Wait for the "navigator.credential.get" promise to be finished before starting a new WebAuthn request. Should solve the issue on the RegisterAuthenticator page, where you need to press the button twice to register a credential.

# Tests

A test case has been added
