### PR TITLE
feat: quickstart enable debugging

### DIFF
--- a/backend/Dockerfile.debug
+++ b/backend/Dockerfile.debug
@@ -1,0 +1,38 @@
+# Build the hanko binary
+FROM golang:1.17 as builder
+WORKDIR /workspace
+
+# Get Delve
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install github.com/go-delve/delve/cmd/dlv@latest
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+# Copy the go source
+COPY ../main.go main.go
+COPY cmd cmd/
+COPY config config/
+COPY persistence persistence/
+COPY server server/
+COPY handler handler/
+COPY crypto crypto/
+COPY dto dto/
+COPY session session/
+COPY mail mail/
+COPY audit_log audit_log/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags="all=-N -l" -a -o hanko main.go
+
+# Use distroless as minimal base image to package hanko binary
+# See https://github.com/GoogleContainerTools/distroless for details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /go/bin/dlv .
+COPY --from=builder /workspace/hanko .
+USER 65532:65532
+
+EXPOSE 8000 8001 40000
+
+ENTRYPOINT ["/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/hanko", "--"]

--- a/deploy/docker-compose/base.yaml
+++ b/deploy/docker-compose/base.yaml
@@ -52,7 +52,7 @@ services:
       - "9500:80"
     networks:
       - intranet
-  fontendsdk:
+  frontendsdk:
     build: ../../frontend-sdk
     ports:
       - "9501:80"

--- a/deploy/docker-compose/quickstart.debug.yaml
+++ b/deploy/docker-compose/quickstart.debug.yaml
@@ -61,7 +61,7 @@ services:
       - "9500:80"
     networks:
       - intranet
-  fontendsdk:
+  frontendsdk:
     build: ../../frontend-sdk
     ports:
       - "9501:80"

--- a/deploy/docker-compose/quickstart.debug.yaml
+++ b/deploy/docker-compose/quickstart.debug.yaml
@@ -1,0 +1,89 @@
+services:
+  hanko-migrate:
+    build: ../../backend
+    volumes:
+      - type: bind
+        source: ./config.yaml
+        target: /etc/config/config.yaml
+    command: --config /etc/config/config.yaml migrate up
+    restart: on-failure
+    depends_on:
+      postgresd:
+        condition: service_healthy
+    networks:
+      - intranet
+  hanko:
+    depends_on:
+      hanko-migrate:
+        condition: service_completed_successfully
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile.debug
+    security_opt:
+      - "apparmor=unconfined"
+    cap_add:
+      - SYS_PTRACE
+    ports:
+      - '8000:8000' # public
+      - '8001:8001' # admin
+      - '40000:40000' # debug
+    restart: unless-stopped
+    command: serve --config /etc/config/config.yaml all
+    volumes:
+      - type: bind
+        source: ./config.yaml
+        target: /etc/config/config.yaml
+    networks:
+      - intranet
+    environment:
+      - PASSWORD_ENABLED
+  postgresd:
+    image: postgres:12-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=hanko
+      - POSTGRES_PASSWORD=hanko
+      - POSTGRES_DB=hanko
+    healthcheck:
+      test: pg_isready -U hanko -d hanko
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - intranet
+  elements:
+    build:
+      context: ../../elements
+      dockerfile: Dockerfile.debug
+    ports:
+      - "9500:80"
+    networks:
+      - intranet
+  fontendsdk:
+    build: ../../frontend-sdk
+    ports:
+      - "9501:80"
+    networks:
+      - intranet
+  example:
+    build: ../../example
+    ports:
+      - "8888:8080"
+    environment:
+      - HANKO_URL=http://localhost:8000
+      - HANKO_URL_INTERNAL=http://hanko:8000
+      - HANKO_ELEMENT_URL=http://localhost:9500/element.hanko-auth.js
+      - HANKO_FRONTEND_SDK_URL=http://localhost:9501/sdk.umd.js
+    networks:
+      - intranet
+  mailslurper:
+    image: marcopas/docker-mailslurper:latest
+    ports:
+      - '8080:8080' # web UI
+      - '8085:8085'
+    networks:
+      - intranet
+networks:
+  intranet:

--- a/deploy/docker-compose/quickstart.yaml
+++ b/deploy/docker-compose/quickstart.yaml
@@ -52,7 +52,7 @@ services:
       - "9500:80"
     networks:
       - intranet
-  fontendsdk:
+  frontendsdk:
     build: ../../frontend-sdk
     ports:
       - "9501:80"

--- a/elements/Dockerfile.debug
+++ b/elements/Dockerfile.debug
@@ -1,0 +1,18 @@
+FROM node:16.16-alpine as build
+
+WORKDIR /app
+ENV PATH /app/node_modules/.bin:$PATH
+
+COPY package.json ./
+COPY package-lock.json ./
+
+RUN npm ci --silent
+COPY . ./
+RUN npm run build:dev
+
+FROM nginx:stable-alpine
+COPY --from=build /app/dist/element.hanko-auth.js /usr/share/nginx/html
+
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/elements/package-lock.json
+++ b/elements/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-plugin-promise": "^6.1.0",
         "sass": "^1.53.0",
         "sass-loader": "^13.1.0",
+        "source-map-loader": "^4.0.1",
         "style-loader": "^3.3.1",
         "ts-jest": "^29.0.3",
         "ts-loader": "^9.4.1",
@@ -2210,6 +2211,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
+    },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -4726,8 +4733,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -7862,9 +7867,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/sass": {
       "version": "1.55.0",
@@ -8144,6 +8147,27 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.1.tgz",
+      "integrity": "sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.72.1"
       }
     },
     "node_modules/source-map-support": {
@@ -11020,6 +11044,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -12933,8 +12963,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -15296,9 +15324,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "sass": {
       "version": "1.55.0",
@@ -15493,6 +15519,17 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
+    },
+    "source-map-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.1.tgz",
+      "integrity": "sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.6",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      }
     },
     "source-map-support": {
       "version": "0.5.13",

--- a/elements/package.json
+++ b/elements/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint 'src/**/*.ts?(x)'",
     "format": "pretty-quick --staged",
     "build": "npx webpack --mode=production",
-    "build:dev": "npx webpack --mode=development"
+    "build:dev": "npx webpack --mode=development --config ./webpack.config.dev.cjs"
   },
   "description": "The <hanko-auth> element offers a complete user interface that will bring a modern login and registration experience to your users.",
   "repository": "github:teamhanko/hanko",
@@ -59,6 +59,7 @@
     "eslint-plugin-promise": "^6.1.0",
     "sass": "^1.53.0",
     "sass-loader": "^13.1.0",
+    "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.1",
     "ts-jest": "^29.0.3",
     "ts-loader": "^9.4.1",

--- a/elements/webpack.config.dev.cjs
+++ b/elements/webpack.config.dev.cjs
@@ -1,0 +1,77 @@
+const path = require("path");
+
+module.exports = {
+  devtool: 'eval-source-map',
+  entry: {
+    hankoAuth: {
+      filename: 'element.hanko-auth.js',
+      import: './src/index.ts',
+      library: {
+        name: 'HankoAuth',
+        type: 'umd',
+        umdNamedDefine: true,
+      },
+    }
+  },
+  module: {
+    rules: [
+      {
+        test: /\.c?js$/,
+        enforce: "pre",
+        use: ["source-map-loader"],
+      },
+      {
+        test: /\.(tsx?)$/,
+        use: 'ts-loader',
+        exclude: [/node_modules/, /dist/],
+        resolve: {
+          fullySpecified: false
+        },
+      },
+      {
+        test: /\.(sass)$/,
+        use: [
+          {
+            loader: "style-loader",
+            options: {
+              injectType: 'singletonStyleTag',
+              insert: (styleTag) => {
+                // eslint-disable-next-line no-underscore-dangle
+                window._hankoStyle = styleTag;
+              },
+            },
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              modules: {
+                localIdentName: "hanko_[local]",
+                localIdentContext: path.resolve(__dirname, "src"),
+              },
+              importLoaders: 1,
+            }
+          },
+          {
+            loader: "sass-loader",
+            options: {
+              sourceMap: true,
+            }
+          }
+        ]
+      },
+    ]
+  },
+  resolve: {
+    extensions: [
+      '.ts',
+      '.tsx',
+      '.js',
+      '.sass',
+      "declarations.d.ts"
+    ],
+  },
+  output: {
+    clean: true,
+    path: path.resolve(__dirname, 'dist'),
+  },
+};


### PR DESCRIPTION
# Description

When developing I want services in the quickstart cluster to be (remote) debuggable. This primarily concerns: backend and elements/frontend-sdk. 

# Implementation

I added dedicated debug dockerfiles and a debug compose file that provide debugging capabilities in the following way:

## Backend: 

Provide debug dockerfile that uses delve to start the application and listen for a (remote) debugger. 

## Frontend (elements):

1. Add a dedicated development webpack config and build target that adds sourcemaps to the build output
2. Provide debug dockerfile that serves the output from 1. 

# Tests

No written tests necessary, but you can try it out in the following way:

## Backend: 

In a JetBrains product (Goland):

1. Create Run Configuration

In the menu bar select:

Run > Edit Configurations > Add New Configuration (+ icon top left) > Go Remote:

In the shown view add the following:

Name: your choice
Host: localhost
Port: 40000

3. In project root run:

```
docker compose -f deploy/docker-compose/quickstart.debug.yaml -p "hanko-quickstart" up --build
```

4. Run remote config from 1. to attach debugger ("Bug" icon top right next to run config dropdown)
5. Set breakpoints
6. Profit

## Frontend:
After starting the compose cluster (see above), in Chrome (for example):

1. Navigate to example app frontend, 
3. Open Sources > Page tab in DevTools
4. Select "teamhanko"
5. Set breakpoints
6. Profit


