### PR TITLE
fix: check wrapped error for sql.ErrNoRows

### DIFF
--- a/backend/persistence/audit_log_persister.go
+++ b/backend/persistence/audit_log_persister.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
@@ -39,7 +40,7 @@ func (p *auditLogPersister) Create(auditLog models.AuditLog) error {
 func (p *auditLogPersister) Get(id uuid.UUID) (*models.AuditLog, error) {
 	auditLog := models.AuditLog{}
 	err := p.db.Eager().Find(&auditLog, id)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -61,7 +62,7 @@ func (p *auditLogPersister) List(page int, perPage int, startTime *time.Time, en
 	}
 	err := query.Paginate(page, perPage).Order("created_at desc").All(&auditLogs)
 
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return auditLogs, nil
 	}
 	if err != nil {

--- a/backend/persistence/jwk_persister.go
+++ b/backend/persistence/jwk_persister.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/teamhanko/hanko/backend/persistence/models"
@@ -25,7 +26,7 @@ func NewJwkPersister(db *pop.Connection) JwkPersister {
 func (p *jwkPersister) Get(id int) (*models.Jwk, error) {
 	jwk := models.Jwk{}
 	err := p.db.Find(&jwk, id)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -37,7 +38,7 @@ func (p *jwkPersister) Get(id int) (*models.Jwk, error) {
 func (p *jwkPersister) GetAll() ([]models.Jwk, error) {
 	jwks := []models.Jwk{}
 	err := p.db.All(&jwks)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -49,7 +50,7 @@ func (p *jwkPersister) GetAll() ([]models.Jwk, error) {
 func (p *jwkPersister) GetLast() (*models.Jwk, error) {
 	jwk := models.Jwk{}
 	err := p.db.Last(&jwk)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/backend/persistence/passcode_persister.go
+++ b/backend/persistence/passcode_persister.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
@@ -26,7 +27,7 @@ func NewPasscodePersister(db *pop.Connection) PasscodePersister {
 func (p *passcodePersister) Get(id uuid.UUID) (*models.Passcode, error) {
 	passcode := models.Passcode{}
 	err := p.db.Find(&passcode, id)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/backend/persistence/password_credential_persister.go
+++ b/backend/persistence/password_credential_persister.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
@@ -39,7 +40,7 @@ func (p *passwordCredentialPersister) GetByUserID(userId uuid.UUID) (*models.Pas
 	pw := models.PasswordCredential{}
 	query := p.db.Where("user_id = (?)", userId.String())
 	err := query.First(&pw)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/backend/persistence/webauthn_credential_persister.go
+++ b/backend/persistence/webauthn_credential_persister.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
@@ -27,7 +28,7 @@ func NewWebauthnCredentialPersister(db *pop.Connection) WebauthnCredentialPersis
 func (p *webauthnCredentialPersister) Get(id string) (*models.WebauthnCredential, error) {
 	credential := models.WebauthnCredential{}
 	err := p.db.Find(&credential, id)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -88,7 +89,7 @@ func (p *webauthnCredentialPersister) Delete(credential models.WebauthnCredentia
 func (p *webauthnCredentialPersister) GetFromUser(userId uuid.UUID) ([]models.WebauthnCredential, error) {
 	var credentials []models.WebauthnCredential
 	err := p.db.Eager().Where("user_id = ?", &userId).All(&credentials)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/backend/persistence/webauthn_session_data_persister.go
+++ b/backend/persistence/webauthn_session_data_persister.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
@@ -27,7 +28,7 @@ func NewWebauthnSessionDataPersister(db *pop.Connection) WebauthnSessionDataPers
 func (p *webauthnSessionDataPersister) Get(id uuid.UUID) (*models.WebauthnSessionData, error) {
 	sessionData := models.WebauthnSessionData{}
 	err := p.db.Eager().Find(&sessionData, id)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -40,6 +41,9 @@ func (p *webauthnSessionDataPersister) Get(id uuid.UUID) (*models.WebauthnSessio
 func (p *webauthnSessionDataPersister) GetByChallenge(challenge string) (*models.WebauthnSessionData, error) {
 	var sessionData []models.WebauthnSessionData
 	err := p.db.Eager().Where("challenge = ?", challenge).All(&sessionData)
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sessionData: %w", err)
 	}


### PR DESCRIPTION

# Description

Check if the error returned by pop contains a wrapped `sql.ErrNoRows` error 
Fixes #334 

# Implementation

Use the [`errors.Is`](https://pkg.go.dev/errors#Is) function to check if the returned error contains a wrapped `sql.ErrNoRows`.

# Tests
See #334 
