### PR TITLE
fix: make compose debug file work with new frontend lib dir structure

### DIFF
--- a/deploy/docker-compose/quickstart.debug.yaml
+++ b/deploy/docker-compose/quickstart.debug.yaml
@@ -55,16 +55,10 @@ services:
       - intranet
   elements:
     build:
-      context: ../../elements
+      context: ../../frontend
       dockerfile: Dockerfile.debug
     ports:
       - "9500:80"
-    networks:
-      - intranet
-  frontendsdk:
-    build: ../../frontend-sdk
-    ports:
-      - "9501:80"
     networks:
       - intranet
   quickstart:


### PR DESCRIPTION
# Description

Make compose debug file work with new frontend lib dir structure (introduced in a37219a0)
