### PR TITLE
docs: fix links to elements readme in frontend guides

### DIFF
--- a/docs/docs/guides/angular.mdx
+++ b/docs/docs/guides/angular.mdx
@@ -163,7 +163,7 @@ export class LoginComponent {
 ## UI customization
 
 The styles of the `hanko-auth` element can be customized using CSS variables and parts. See our guide
-on customization [here](https://github.com/teamhanko/hanko/tree/main/elements#ui-customization).
+on customization [here](https://github.com/teamhanko/hanko/tree/main/frontend/elements#ui-customization).
 
 ## Backend request authentication
 

--- a/docs/docs/guides/next.mdx
+++ b/docs/docs/guides/next.mdx
@@ -121,7 +121,7 @@ export default function HankoAuth() {
 ## UI customization
 
 The styles of the `hanko-auth` element can be customized using CSS variables and parts. See our guide
-on customization [here](https://github.com/teamhanko/hanko/tree/main/elements#ui-customization).
+on customization [here](https://github.com/teamhanko/hanko/tree/main/frontend/elements#ui-customization).
 
 ## Backend request authentication
 

--- a/docs/docs/guides/react.mdx
+++ b/docs/docs/guides/react.mdx
@@ -94,7 +94,7 @@ export default function HankoAuth() {
 ## UI customization
 
 The styles of the `hanko-auth` element can be customized using CSS variables and parts. See our guide
-on customization [here](https://github.com/teamhanko/hanko/tree/main/elements#ui-customization).
+on customization [here](https://github.com/teamhanko/hanko/tree/main/frontend/elements#ui-customization).
 
 ## Backend request authentication
 

--- a/docs/docs/guides/vue.mdx
+++ b/docs/docs/guides/vue.mdx
@@ -147,7 +147,7 @@ const redirectAfterLogin = () => {
 ## UI customization
 
 The styles of the `hanko-auth` element can be customized using CSS variables and parts. See our guide
-on customization [here](https://github.com/teamhanko/hanko/tree/main/elements#ui-customization).
+on customization [here](https://github.com/teamhanko/hanko/tree/main/frontend/elements#ui-customization).
 
 ## Backend request authentication
 


### PR DESCRIPTION
# Description

Fix links to elements readme in frontend guides
