### PR TITLE
fix: set correct frontend sdk url env var in compose debug file

### DIFF
--- a/deploy/docker-compose/quickstart.debug.yaml
+++ b/deploy/docker-compose/quickstart.debug.yaml
@@ -69,7 +69,7 @@ services:
       - HANKO_URL=http://localhost:8000
       - HANKO_URL_INTERNAL=http://hanko:8000
       - HANKO_ELEMENT_URL=http://localhost:9500/element.hanko-auth.js
-      - HANKO_FRONTEND_SDK_URL=http://localhost:9501/sdk.umd.js
+      - HANKO_FRONTEND_SDK_URL=http://localhost:9500/sdk.umd.js
     networks:
       - intranet
   mailslurper:


### PR DESCRIPTION
# Description

Set the correct frontend SDK URL environment variable in the compose debug file.
