### PR TITLE
Add total count & link header for pagination

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,6 +18,7 @@ COPY dto dto/
 COPY session session/
 COPY mail mail/
 COPY audit_log audit_log/
+COPY pagination pagination/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o hanko main.go

--- a/backend/Dockerfile.debug
+++ b/backend/Dockerfile.debug
@@ -21,6 +21,7 @@ COPY dto dto/
 COPY session session/
 COPY mail mail/
 COPY audit_log audit_log/
+COPY pagination pagination/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags="all=-N -l" -a -o hanko main.go

--- a/backend/handler/audit_log.go
+++ b/backend/handler/audit_log.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"github.com/labstack/echo/v4"
 	"github.com/teamhanko/hanko/backend/dto"
+	"github.com/teamhanko/hanko/backend/pagination"
 	"github.com/teamhanko/hanko/backend/persistence"
 	"net/http"
+	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -33,10 +36,28 @@ func (h AuditLogHandler) List(c echo.Context) error {
 		return dto.ToHttpError(err)
 	}
 
+	if request.Page == 0 {
+		request.Page = 1
+	}
+
+	if request.PerPage == 0 {
+		request.PerPage = 20
+	}
+
 	auditLogs, err := h.persister.GetAuditLogPersister().List(request.Page, request.PerPage, request.StartTime, request.EndTime)
 	if err != nil {
 		return fmt.Errorf("failed to get list of audit logs: %w", err)
 	}
+
+	logCount, err := h.persister.GetAuditLogPersister().Count(request.StartTime, request.EndTime)
+	if err != nil {
+		return fmt.Errorf("failed to get total count of audit logs: %w", err)
+	}
+
+	u, _ := url.Parse(fmt.Sprintf("%s://%s%s", c.Scheme(), c.Request().Host, c.Request().RequestURI))
+
+	c.Response().Header().Set("Link", pagination.CreateHeader(u, logCount, request.Page, request.PerPage))
+	c.Response().Header().Set("X-Total-Count", strconv.FormatInt(int64(logCount), 10))
 
 	return c.JSON(http.StatusOK, auditLogs)
 }

--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -103,8 +103,6 @@ type UserListRequest struct {
 }
 
 func (h *UserHandlerAdmin) List(c echo.Context) error {
-	// TODO: return 'X-Total-Count' header, which includes the all users count
-	// TODO; return 'Link' header, which includes links to next, previous, current(???), first, last page (example https://docs.github.com/en/rest/guides/traversing-with-pagination)
 	var request UserListRequest
 	err := (&echo.DefaultBinder{}).BindQueryParams(c, &request)
 	if err != nil {

--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -5,8 +5,11 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/teamhanko/hanko/backend/dto"
+	"github.com/teamhanko/hanko/backend/pagination"
 	"github.com/teamhanko/hanko/backend/persistence"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -108,10 +111,28 @@ func (h *UserHandlerAdmin) List(c echo.Context) error {
 		return dto.ToHttpError(err)
 	}
 
+	if request.Page == 0 {
+		request.Page = 1
+	}
+
+	if request.PerPage == 0 {
+		request.PerPage = 20
+	}
+
 	users, err := h.persister.GetUserPersister().List(request.Page, request.PerPage)
 	if err != nil {
-		return fmt.Errorf("failed to get lsist of users: %w", err)
+		return fmt.Errorf("failed to get list of users: %w", err)
 	}
+
+	userCount, err := h.persister.GetUserPersister().Count()
+	if err != nil {
+		return fmt.Errorf("failed to get total count of users: %w", err)
+	}
+
+	u, _ := url.Parse(fmt.Sprintf("%s://%s%s", c.Scheme(), c.Request().Host, c.Request().RequestURI))
+
+	c.Response().Header().Set("Link", pagination.CreateHeader(u, userCount, request.Page, request.PerPage))
+	c.Response().Header().Set("X-Total-Count", strconv.FormatInt(int64(userCount), 10))
 
 	return c.JSON(http.StatusOK, users)
 }

--- a/backend/handler/user_admin_test.go
+++ b/backend/handler/user_admin_test.go
@@ -281,6 +281,7 @@ func TestUserHandlerAdmin_List(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(users))
 		assert.Equal(t, "2", rec.Header().Get("X-Total-Count"))
+		assert.Equal(t, "<http://example.com/users?page=1&per_page=20>; rel=\"first\"", rec.Header().Get("Link"))
 	}
 }
 
@@ -325,6 +326,7 @@ func TestUserHandlerAdmin_List_Pagination(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(got))
 		assert.Equal(t, "2", rec.Header().Get("X-Total-Count"))
+		assert.Equal(t, "<http://example.com/users?page=1&per_page=1>; rel=\"first\",<http://example.com/users?page=1&per_page=1>; rel=\"prev\"", rec.Header().Get("Link"))
 	}
 }
 
@@ -348,6 +350,7 @@ func TestUserHandlerAdmin_List_NoUsers(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(got))
 		assert.Equal(t, "0", rec.Header().Get("X-Total-Count"))
+		assert.Equal(t, "<http://example.com/users?page=1&per_page=1>; rel=\"first\"", rec.Header().Get("Link"))
 	}
 }
 

--- a/backend/handler/user_admin_test.go
+++ b/backend/handler/user_admin_test.go
@@ -280,6 +280,7 @@ func TestUserHandlerAdmin_List(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &users)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(users))
+		assert.Equal(t, "2", rec.Header().Get("X-Total-Count"))
 	}
 }
 
@@ -323,6 +324,7 @@ func TestUserHandlerAdmin_List_Pagination(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &got)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(got))
+		assert.Equal(t, "2", rec.Header().Get("X-Total-Count"))
 	}
 }
 
@@ -345,6 +347,7 @@ func TestUserHandlerAdmin_List_NoUsers(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &got)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(got))
+		assert.Equal(t, "0", rec.Header().Get("X-Total-Count"))
 	}
 }
 

--- a/backend/pagination/header.go
+++ b/backend/pagination/header.go
@@ -1,0 +1,48 @@
+package pagination
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func CreateHeader(u *url.URL, total int, page int, itemsPerPage int) string {
+	var lastPage int
+
+	if total%itemsPerPage == 0 {
+		lastPage = total / itemsPerPage
+	} else {
+		lastPage = total/itemsPerPage + 1
+	}
+
+	if lastPage == 0 {
+		lastPage = 1
+	}
+
+	var links []string
+	if page != 1 || page == lastPage {
+		links = append(links, formatter(u, "first", itemsPerPage, 1))
+	}
+
+	if page != lastPage {
+		links = append(links, formatter(u, "last", itemsPerPage, lastPage))
+	}
+
+	if page < lastPage {
+		links = append(links, formatter(u, "next", itemsPerPage, page+1))
+	}
+
+	if page > 1 {
+		links = append(links, formatter(u, "prev", itemsPerPage, page-1))
+	}
+
+	return strings.Join(links, ",")
+}
+
+func formatter(u *url.URL, rel string, perPage int, page int) string {
+	q := u.Query()
+	q.Set("page", fmt.Sprintf("%d", page))
+	q.Set("per_page", fmt.Sprintf("%d", perPage))
+	u.RawQuery = q.Encode()
+	return fmt.Sprintf("<%s>; rel=\"%s\"", u.String(), rel)
+}

--- a/backend/pagination/header_test.go
+++ b/backend/pagination/header_test.go
@@ -1,0 +1,43 @@
+package pagination
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/url"
+	"testing"
+)
+
+func TestCreateHeader_FirstPage(t *testing.T) {
+	u, _ := url.Parse("http://localhost:8080")
+	header := CreateHeader(u, 95, 1, 10)
+	assert.Equal(t, "<http://localhost:8080?page=10&per_page=10>; rel=\"last\",<http://localhost:8080?page=2&per_page=10>; rel=\"next\"", header)
+}
+
+func TestCreateHeader_LastPage(t *testing.T) {
+	u, _ := url.Parse("http://localhost:8080")
+	header := CreateHeader(u, 95, 10, 10)
+	assert.Equal(t, "<http://localhost:8080?page=1&per_page=10>; rel=\"first\",<http://localhost:8080?page=9&per_page=10>; rel=\"prev\"", header)
+}
+
+func TestCreateHeader_MiddlePage(t *testing.T) {
+	u, _ := url.Parse("http://localhost:8080")
+	header := CreateHeader(u, 95, 4, 10)
+	assert.Equal(t, "<http://localhost:8080?page=1&per_page=10>; rel=\"first\",<http://localhost:8080?page=10&per_page=10>; rel=\"last\",<http://localhost:8080?page=5&per_page=10>; rel=\"next\",<http://localhost:8080?page=3&per_page=10>; rel=\"prev\"", header)
+}
+
+func TestCreateHeader_TotalCountZero(t *testing.T) {
+	u, _ := url.Parse("http://localhost:8080")
+	header := CreateHeader(u, 0, 1, 10)
+	assert.Equal(t, "<http://localhost:8080?page=1&per_page=10>; rel=\"first\"", header)
+}
+
+func TestCreateHeader_ItemsPerPageGreaterTotalCount(t *testing.T) {
+	u, _ := url.Parse("http://localhost:8080")
+	header := CreateHeader(u, 10, 1, 20)
+	assert.Equal(t, "<http://localhost:8080?page=1&per_page=20>; rel=\"first\"", header)
+}
+
+func TestCreateHeader_UrlWithQuery(t *testing.T) {
+	u, _ := url.Parse("http://localhost:8080?start_time=2022-09-12T12:48:48Z&end_time=2022-09-12T14:48:48Z")
+	header := CreateHeader(u, 95, 1, 10)
+	assert.Equal(t, "<http://localhost:8080?end_time=2022-09-12T14%3A48%3A48Z&page=10&per_page=10&start_time=2022-09-12T12%3A48%3A48Z>; rel=\"last\",<http://localhost:8080?end_time=2022-09-12T14%3A48%3A48Z&page=2&per_page=10&start_time=2022-09-12T12%3A48%3A48Z>; rel=\"next\"", header)
+}

--- a/backend/persistence/audit_log_persister.go
+++ b/backend/persistence/audit_log_persister.go
@@ -15,6 +15,7 @@ type AuditLogPersister interface {
 	Get(id uuid.UUID) (*models.AuditLog, error)
 	List(page int, perPage int, startTime *time.Time, endTime *time.Time) ([]models.AuditLog, error)
 	Delete(auditLog models.AuditLog) error
+	Count(startTime *time.Time, endTime *time.Time) (int, error)
 }
 
 type auditLogPersister struct {
@@ -79,4 +80,20 @@ func (p *auditLogPersister) Delete(auditLog models.AuditLog) error {
 	}
 
 	return nil
+}
+
+func (p *auditLogPersister) Count(startTime *time.Time, endTime *time.Time) (int, error) {
+	query := p.db.Q()
+	if startTime != nil {
+		query = query.Where("created_at > ?", startTime)
+	}
+	if endTime != nil {
+		query = query.Where("created_at < ?", endTime)
+	}
+	count, err := query.Count(&models.AuditLog{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get auditLog count: %w", err)
+	}
+
+	return count, nil
 }

--- a/backend/persistence/user_persister.go
+++ b/backend/persistence/user_persister.go
@@ -16,6 +16,7 @@ type UserPersister interface {
 	Update(models.User) error
 	Delete(models.User) error
 	List(page int, perPage int) ([]models.User, error)
+	Count() (int, error)
 }
 
 type userPersister struct {
@@ -100,4 +101,13 @@ func (p *userPersister) List(page int, perPage int) ([]models.User, error) {
 	}
 
 	return users, nil
+}
+
+func (p *userPersister) Count() (int, error) {
+	count, err := p.db.Count(&models.User{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get user count: %w", err)
+	}
+
+	return count, nil
 }

--- a/backend/test/audit_log_persister.go
+++ b/backend/test/audit_log_persister.go
@@ -75,3 +75,7 @@ func (p *auditLogPersister) Delete(auditLog models.AuditLog) error {
 
 	return nil
 }
+
+func (p *auditLogPersister) Count(startTime *time.Time, endTime *time.Time) (int, error) {
+	return len(p.logs), nil
+}

--- a/backend/test/user_persister.go
+++ b/backend/test/user_persister.go
@@ -91,3 +91,7 @@ func (p *userPersister) List(page int, perPage int) ([]models.User, error) {
 	}
 	return result[page-1], nil
 }
+
+func (p *userPersister) Count() (int, error) {
+	return len(p.users), nil
+}

--- a/docs/static/spec/admin.yaml
+++ b/docs/static/spec/admin.yaml
@@ -40,6 +40,13 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
+          headers:
+            X-Total-Count:
+              schema:
+                $ref: '#/components/headers/X-Total-Count'
+            Link:
+              schema:
+                $ref: '#/components/headers/Link'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /users/{id}:
@@ -139,6 +146,13 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AuditLog'
+          headers:
+            X-Total-Count:
+              schema:
+                $ref: '#/components/headers/X-Total-Count'
+            Link:
+              schema:
+                $ref: '#/components/headers/Link'
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:
@@ -288,3 +302,14 @@ components:
           format: int32
         message:
           type: string
+  headers:
+    X-Total-Count:
+      schema:
+        type: string
+      description: The total count of the requested resource considering query parameter
+      example: 1234
+    Link:
+      schema:
+        type: string
+      description: Web Linking as described in RFC5988
+      example: <http://localhost:8001/resource?page=1&per_page=10>; rel="first",<http://localhost:8001/resource?page=16&per_page=10>; rel="last",<http://localhost:8001/resource?page=6&per_page=10>; rel="next",<http://localhost:8001/resource?page=4&per_page=10>; rel="prev"


### PR DESCRIPTION
# Description

Adds the `Link` and `X-Total-Count` header to list audit logs and list users. The `X-Total-Count` header returns the total count of the requested resource. The `Link` header returns urls which can be used for pagination. 

E.g. there are 155 registered users and the user list is requested with `?page=5&per_page=10`, then
- the `X-Total-Count` header returns 155
- the `Link` header returns `<http://localhost:8001/users?page=1&per_page=10>; rel="first",<http://localhost:8001/users?page=16&per_page=10>; rel="last",<http://localhost:8001/users?page=6&per_page=10>; rel="next",<http://localhost:8001/users?page=4&per_page=10>; rel="prev"`

# Tests

To test this just use the admin audit_log and admin users api and look into the returned headers.

# Additional context

https://docs.github.com/en/rest/guides/traversing-with-pagination
