### PR TITLE
ci: add npm publishing/release workflows for elements and frontend-sdk

### DIFF
--- a/.github/workflows/release-frontend-sdk.yml
+++ b/.github/workflows/release-frontend-sdk.yml
@@ -1,0 +1,58 @@
+name: Release @teamhanko/frontend-sdk
+
+on:
+  push:
+    tags:
+      - '@teamhanko/frontend-sdk@*'
+
+defaults:
+  run:
+    working-directory: frontend/frontend-sdk
+
+jobs:
+  check-matching-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
+        with:
+          path: frontend/frontend-sdk
+      - run: |
+          version=$(echo $GITHUB_REF | cut -f3 -d'@')
+          echo "git_tag_version=$version" >> $GITHUB_OUTPUT
+        id: tag-version
+      - run: echo ${{ steps.tag-version.outputs.git_tag_version }}
+      - name: Version correctly set check
+        if: steps.package-version.outputs.current-version != steps.tag-version.outputs.git_tag_version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed('version in package.json is not equal to git tag version!')
+
+  build:
+    needs: check-matching-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_SECRET }}
+

--- a/.github/workflows/release-hanko-elements.yml
+++ b/.github/workflows/release-hanko-elements.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
-      - run: npm test
 
   publish-npm:
     needs: build

--- a/.github/workflows/release-hanko-elements.yml
+++ b/.github/workflows/release-hanko-elements.yml
@@ -1,0 +1,58 @@
+name: Release @teamhanko/hanko-elements
+
+on:
+  push:
+    tags:
+      - '@teamhanko/hanko-elements@*'
+
+defaults:
+  run:
+    working-directory: frontend/elements
+
+jobs:
+  check-matching-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
+        with:
+          path: frontend/elements
+      - run: |
+          version=$(echo $GITHUB_REF | cut -f3 -d'@')
+          echo "git_tag_version=$version" >> $GITHUB_OUTPUT
+        id: tag-version
+      - run: echo ${{ steps.tag-version.outputs.git_tag_version }}
+      - name: Version correctly set check
+        if: steps.package-version.outputs.current-version != steps.tag-version.outputs.git_tag_version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed('version in package.json is not equal to git tag version!')
+
+  build:
+    needs: check-matching-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_SECRET }}
+


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

Triggers a workflow on tags that have the form @teamhanko/elements@VERSION or @teamhanko/frontend-sdk@VERSION
When the version in the package.json differs from the VERSION in the tag the workflow fails. Otherwise the project is build and published to npm.

# Implementation

<!-- Brief description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need
to refactor something? What tradeoffs did you take? Are there any caveats/downsides to your solution? Are there things
in here which you’d particularly like people to pay close attention to? -->

# Tests

<!-- Describe how to verify your changes. Provide instructions for the purpose of reproducibility. List any relevant
details for your test configuration. -->

# Todos

<!-- Are there any other outstanding issues or tasks that must be solved before this change can be possibly merged? -->

# Additional context

<!-- Add any other relevant context pertaining to the proposed change. For example, if the change can be visualized,
include screenshots or diagrams to indicate the state before and after the change. -->
