### PR TITLE
Multiplatform docker

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1.2
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,15 +48,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v1.6.0
+        uses: docker/setup-buildx-action@v2
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v1.2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -75,13 +77,13 @@ jobs:
             type=ref,event=tag
             type=ref,event=pr
 
-
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@v3
         with:
+          platforms: linux/amd64,linux/arm64
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 # Build the hanko binary
-FROM golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
+
+ARG TARGETARCH
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -21,7 +23,7 @@ COPY audit_log audit_log/
 COPY pagination pagination/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o hanko main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o hanko main.go
 
 # Use distroless as minimal base image to package hanko binary
 # See https://github.com/GoogleContainerTools/distroless for details

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.16-alpine as build
+FROM --platform=$BUILDPLATFORM node:16.16-alpine as build
 
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH

--- a/frontend/frontend-sdk/Dockerfile
+++ b/frontend/frontend-sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.16-alpine as build
+FROM --platform=$BUILDPLATFORM node:16.16-alpine as build
 
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH

--- a/quickstart/Dockerfile
+++ b/quickstart/Dockerfile
@@ -1,6 +1,8 @@
 # Build the quickstart binary
 FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
+ARG TARGETARCH
+
 WORKDIR /workspace
 COPY . .
 

--- a/quickstart/Dockerfile
+++ b/quickstart/Dockerfile
@@ -1,10 +1,10 @@
 # Build the quickstart binary
-FROM golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /workspace
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o quickstart main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o quickstart main.go
 
 # Use distroless as minimal base image to package quickstart binary
 # See https://github.com/GoogleContainerTools/distroless for details


### PR DESCRIPTION
# Description

I am doing development on an Apple Silicon Mac and doing deploys to other ARM based hosts. I have previously build the images myself, but figured that I can't be the only one who would like hanko on more than one architecture.

# Implementation

- Added parameter in the Dockerfile's to enable building for multiple architectures
  - Fixing the builder to the BUILDPLATFORM
  - Utilizing GOs crossplatform builder to target TARGETARCH
  - Let `buildx` handle the matrix (1x2, but not the less :)) from there
- Bumped Docker's Github Actions versions to get rid of warnings, hopefully
- Bumped the go version to 1.19 in the Dockerfile

# Tests

<!-- Describe how to verify your changes. Provide instructions for the purpose of reproducibility. List any relevant
details for your test configuration. -->
Try running the action related to the workflow on this branch. There should be bulds for both amd64 and arm64 on ghcr.io afterwards.

# Todos

<!-- Are there any other outstanding issues or tasks that must be solved before this change can be possibly merged? -->
There are other architectures available (linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6), which could be added to the matrix, but I would wait with that until there is a need for it.
