### PR TITLE
ci: fix elements workflow by adding frontend sdk build step

### DIFF
--- a/.github/workflows/release-hanko-elements.yml
+++ b/.github/workflows/release-hanko-elements.yml
@@ -46,7 +46,7 @@ jobs:
       - run: npm run build
 
   build:
-    needs: check-matching-versions
+    needs: build-frontendsdk
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Description

Fix elements workflow by adding frontend SDK build step. Building the SDK is required due to the "file" dependency on the SDK in the elements package.


