### PR TITLE
feat(hanko-auth): Introduce an attribute to enabled experimental feat…

### DIFF
--- a/frontend/elements/README.md
+++ b/frontend/elements/README.md
@@ -73,6 +73,7 @@ do is adding the `<hanko-auth>` element to your page.
 
 - `api` the location where the Hanko API is running.
 - `lang` Currently supported values are "en" for English and "de" for German. If the value is omitted, "en" is used.
+- `experimental` A space-seperated list of experimental features to be enabled. See [experimental features](#experimental-features).
 
 ## Events
 
@@ -92,7 +93,7 @@ The animation below demonstrates how user registration with passwords enabled lo
 like using the [Hanko API](https://github.com/teamhanko/hanko/blob/main/backend/README.md) configuration file. The registration flow also includes email
 verification via passcodes and the registration of a passkey so that the user can log in without passwords or passcodes.
 
-<img src="https://github.com/teamhanko/hanko/raw/main/elements/demo.gif" width="410"/>
+<img src="https://github.com/teamhanko/hanko/raw/main/frontend/elements/demo.gif" width="410"/>
 
 ## UI Customization
 
@@ -274,6 +275,23 @@ Result:
 
 <img src="https://github.com/teamhanko/hanko/raw/main/frontend/elements/demo-ui.png" width="450"/>
 
+## Experimental Features
+
+### Conditional Mediation / Autofill assisted Requests
+
+```html
+<hanko-auth [...] experimental="conditionalMediation"/>
+```
+
+If the browser supports autofill assisted requests, it will hide the "Sign in with passkey" button on the login page and
+instead present the available passkeys via the email input's autocompletion menu. Enabling this feature will currently
+cause the following issues:
+
+- On iOS 16/Safari you may encounter an issue that WebAuthn credential registration is not working the first time you
+  press the button or only after reloading the page.
+
+- Microsoft Edge v. 108 sometimes crashes or is not able to display the credential name properly.
+
 ## Browser support
 
 - Safari
@@ -293,10 +311,6 @@ To learn more about how to integrate the `<hanko-auth>` element into frontend fr
 E.g. `:disabled` is currently broken. See:
 [chromium-issue-#1131396](https://bugs.chromium.org/p/chromium/issues/detail?id=1131396),
 [chromium-issue-#953648](https://bugs.chromium.org/p/chromium/issues/detail?id=953648)
-- Safari and autofill assisted requests: On iOS 16 and above, Safari is not able to abort or reject the `Promise`
-returned by `navigator.credentials.get()`. Therefore, you may encounter an issue that the WebAuthn credential
-registration is not working the first time or only after reloading the page, because the initial autofill assisted
-request is still pending and there is only one request allowed at the same time.
 
 Found a bug? Please report on our [GitHub](https://github.com/teamhanko/hanko/issues) page.
 

--- a/frontend/elements/src/ui/HankoAuth.tsx
+++ b/frontend/elements/src/ui/HankoAuth.tsx
@@ -15,6 +15,7 @@ import { translations } from "./Translations";
 interface Props {
   api: string;
   lang?: string;
+  experimental?: string;
 }
 
 declare interface HankoAuthElement
@@ -31,10 +32,14 @@ declare global {
   }
 }
 
-export const HankoAuth = ({ api = "", lang = "en" }: Props) => {
+export const HankoAuth = ({
+  api = "",
+  lang = "en",
+  experimental = "",
+}: Props) => {
   return (
     <Fragment>
-      <AppProvider api={api}>
+      <AppProvider api={api} experimental={experimental}>
         <TranslateProvider translations={translations} fallbackLang={"en"}>
           <UserProvider>
             <PasswordProvider>
@@ -62,9 +67,14 @@ export const register = ({
 
   return new Promise<void>((resolve, reject) => {
     if (!customElements.get(tagName)) {
-      registerCustomElement(HankoAuth, tagName, ["api", "lang"], {
-        shadow,
-      });
+      registerCustomElement(
+        HankoAuth,
+        tagName,
+        ["api", "lang", "experimental"],
+        {
+          shadow,
+        }
+      );
     }
 
     if (injectStyles) {

--- a/frontend/elements/src/ui/contexts/AppProvider.tsx
+++ b/frontend/elements/src/ui/contexts/AppProvider.tsx
@@ -4,21 +4,26 @@ import { useCallback, useMemo, useState } from "preact/compat";
 
 import { Hanko, Config } from "@teamhanko/hanko-frontend-sdk";
 
+type ExperimentalFeature = "conditionalMediation";
+type ExperimentalFeatures = ExperimentalFeature[];
+
 interface Props {
   api?: string;
   lang?: string;
+  experimental?: string;
   children: ComponentChildren;
 }
 
 interface Context {
   config: Config;
+  experimentalFeatures?: ExperimentalFeatures;
   configInitialize: () => Promise<Config>;
   hanko: Hanko;
 }
 
 export const AppContext = createContext<Context>(null);
 
-const AppProvider = ({ api, children }: Props) => {
+const AppProvider = ({ api, children, experimental = "" }: Props) => {
   const [config, setConfig] = useState<Config>(null);
 
   const hanko = useMemo(() => {
@@ -27,6 +32,15 @@ const AppProvider = ({ api, children }: Props) => {
     }
     return null;
   }, [api]);
+
+  const experimentalFeatures = useMemo(
+    () =>
+      experimental
+        .split(" ")
+        .filter((feature) => feature.length)
+        .map((feature) => feature as ExperimentalFeature),
+    [experimental]
+  );
 
   const configInitialize = useCallback(() => {
     return new Promise<Config>((resolve, reject) => {
@@ -46,7 +60,14 @@ const AppProvider = ({ api, children }: Props) => {
   }, [hanko]);
 
   return (
-    <AppContext.Provider value={{ config, configInitialize, hanko }}>
+    <AppContext.Provider
+      value={{
+        config,
+        configInitialize,
+        hanko,
+        experimentalFeatures,
+      }}
+    >
       {children}
     </AppContext.Provider>
   );


### PR DESCRIPTION
# Description

- Introduces an attribute to enable experimental features
- Conditional mediation is now an experimental feature 
- Enables "Sign in with passkey" on Android

We encountered serval issues with the newly introduced support for autofill assisted requests in cases where the check via `PublicKeyCredential.isConditionalMediationAvailable()`says support is there, but at least in combination with `<hanko-auth>` it's not working properly. On iOS 16 the "Register passkey" button is broken (because the unresolved `Promise` returned by `navigator.credentials.get()`, which is needed for conditional mediation, can't be aborted in order to call `navigator.credentials.create()`, which we are trying after creating a new account) and Microsoft Edge v. 108 sometimes crashes, so we decided to disable our support by default and make it available through the introduced "experimental" attribute. 

Relates to #[<351>](https://github.com/teamhanko/hanko/issues/351)

Additionally passkey support on Android is now always enabled, because resident keys are now supported on newer Android versions.

# Implementation

Autofill assisted requests will now only be enabled, when the space-separated list of the introduced "experimental" attribute is containing the string "conditionalMediation" and `PublicKeyCredential.isConditionalMediationAvailable()` resolves to true.
I could have created an attribute called something like "experimentalConditionalMediationEnabled" instead, but we sadly can only pass strings to the web component and I would have had to parse the value anyway and maybe we have other use cases for the "experimental" attribute in the future. So I came up with this solution, but it's questionable and I am open for suggestions.