### PR TITLE
fix(hanko-auth): don't overwrite existing 'lang' property with a poss…

### DIFF
--- a/frontend/elements/package-lock.json
+++ b/frontend/elements/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.0.15-alpha",
+  "version": "0.0.16-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamhanko/hanko-elements",
-      "version": "0.0.15-alpha",
+      "version": "0.0.16-alpha",
       "bundleDependencies": [
         "@teamhanko/hanko-frontend-sdk"
       ],

--- a/frontend/elements/package.json
+++ b/frontend/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.0.15-alpha",
+  "version": "0.0.16-alpha",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/frontend/elements/src/ui/HankoAuth.tsx
+++ b/frontend/elements/src/ui/HankoAuth.tsx
@@ -14,7 +14,6 @@ import { translations } from "./Translations";
 
 interface Props {
   api: string;
-  lang?: string;
 }
 
 declare interface HankoAuthElement
@@ -31,7 +30,7 @@ declare global {
   }
 }
 
-export const HankoAuth = ({ api = "", lang = "en" }: Props) => {
+export const HankoAuth = ({ api = "", lang = "en" }: HankoAuthElement) => {
   return (
     <Fragment>
       <AppProvider api={api}>


### PR DESCRIPTION
# Description

Fixes the issue (investigated on Angular environments) where the project fails to compile with the following error message:

```
Interface ‘HankoAuthElement’ cannot simultaneously extend types ‘HTMLAttributes<HTMLElement>’ and ‘Props’
Named property ‘lang’ of types ‘HTMLAttributes<HTMLElement>’ and ‘Props’ are not identical.
```

