### PR TITLE
Fix conditional UI stops working on error

### DIFF
--- a/frontend/elements/package-lock.json
+++ b/frontend/elements/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.0.15-alpha",
+  "version": "0.0.16-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamhanko/hanko-elements",
-      "version": "0.0.15-alpha",
+      "version": "0.0.16-alpha",
       "bundleDependencies": [
         "@teamhanko/hanko-frontend-sdk"
       ],

--- a/frontend/elements/package.json
+++ b/frontend/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.0.15-alpha",
+  "version": "0.0.16-alpha",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/frontend/elements/src/ui/pages/LoginEmail.tsx
+++ b/frontend/elements/src/ui/pages/LoginEmail.tsx
@@ -7,6 +7,7 @@ import {
   TechnicalError,
   NotFoundError,
   WebauthnRequestCancelledError,
+  InvalidWebauthnCredentialError,
   WebauthnSupport,
 } from "@teamhanko/hanko-frontend-sdk";
 
@@ -145,6 +146,7 @@ const LoginEmail = () => {
     hanko.webauthn
       .login()
       .then(() => {
+        setError(null);
         setIsPasskeyLoginLoading(false);
         setIsPasskeyLoginSuccess(true);
         emitSuccessEvent();
@@ -181,12 +183,18 @@ const LoginEmail = () => {
     hanko.webauthn
       .login(null, true)
       .then(() => {
+        setError(null);
         emitSuccessEvent();
         setIsEmailLoginSuccess(true);
 
         return;
       })
       .catch((e) => {
+        if (e instanceof InvalidWebauthnCredentialError) {
+          // An invalid WebAuthn credential has been used. Retry the login procedure, so another credential can be
+          // chosen by the user via conditional UI.
+          loginViaConditionalUI();
+        }
         setError(e instanceof WebauthnRequestCancelledError ? null : e);
       });
   }, [emitSuccessEvent, hanko, isConditionalMediationSupported]);


### PR DESCRIPTION
# Description

Call the `login()` function again in case a conditional UI login failed, because an invalid WebAuthn credential has been used.
The autocompletion menu will appear again and you'll be able to select another credential.

Fixes #441
