### PR TITLE
Validate password min and max length

### DIFF
--- a/docs/static/jsdoc/hanko-frontend-sdk/Config.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/Config.html
@@ -185,7 +185,7 @@
         <p class="tag-source">
             <a href="lib_Dto.ts.html" class="button">View Source</a>
             <span>
-                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line12">line 12</a>
+                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line13">line 13</a>
             </span>
         </p>
     

--- a/docs/static/jsdoc/hanko-frontend-sdk/Credential.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/Credential.html
@@ -185,7 +185,7 @@
         <p class="tag-source">
             <a href="lib_Dto.ts.html" class="button">View Source</a>
             <span>
-                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line44">line 44</a>
+                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line45">line 45</a>
             </span>
         </p>
     

--- a/docs/static/jsdoc/hanko-frontend-sdk/Passcode.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/Passcode.html
@@ -208,7 +208,7 @@
         <p class="tag-source">
             <a href="lib_Dto.ts.html" class="button">View Source</a>
             <span>
-                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line60">line 60</a>
+                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line61">line 61</a>
             </span>
         </p>
     

--- a/docs/static/jsdoc/hanko-frontend-sdk/PasswordConfig.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/PasswordConfig.html
@@ -144,6 +144,29 @@
 </tr>
 
         
+            
+<tr class="deep-level-0">
+    
+        <td class="name"><code>min_password_length</code></td>
+    
+
+    <td class="type">
+    
+        
+<code class="param-type">number</code>
+
+
+    
+    </td>
+
+    
+
+    
+
+    <td class="description last">The minimum length of a password. Can be used for password validation.</td>
+</tr>
+
+        
         </tbody>
     </table>
 </div>

--- a/docs/static/jsdoc/hanko-frontend-sdk/User.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/User.html
@@ -231,7 +231,7 @@
         <p class="tag-source">
             <a href="lib_Dto.ts.html" class="button">View Source</a>
             <span>
-                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line51">line 51</a>
+                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line52">line 52</a>
             </span>
         </p>
     

--- a/docs/static/jsdoc/hanko-frontend-sdk/UserInfo.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/UserInfo.html
@@ -231,7 +231,7 @@
         <p class="tag-source">
             <a href="lib_Dto.ts.html" class="button">View Source</a>
             <span>
-                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line27">line 27</a>
+                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line28">line 28</a>
             </span>
         </p>
     

--- a/docs/static/jsdoc/hanko-frontend-sdk/WebauthnFinalized.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/WebauthnFinalized.html
@@ -208,7 +208,7 @@
         <p class="tag-source">
             <a href="lib_Dto.ts.html" class="button">View Source</a>
             <span>
-                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line19">line 19</a>
+                <a href="lib_Dto.ts.html">lib/Dto.ts</a>, <a href="lib_Dto.ts.html#line20">line 20</a>
             </span>
         </p>
     

--- a/docs/static/jsdoc/hanko-frontend-sdk/lib_Dto.ts.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/lib_Dto.ts.html
@@ -92,9 +92,11 @@
  * @category SDK
  * @subcategory DTO
  * @property {boolean} enabled - Indicates passwords are enabled, so the API accepts login attempts using passwords.
+ * @property {number} min_password_length - The minimum length of a password. Can be used for password validation.
  */
 interface PasswordConfig {
   enabled: boolean;
+  min_password_length: number;
 }
 
 /**

--- a/frontend/elements/package-lock.json
+++ b/frontend/elements/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.0.17-alpha",
+  "version": "0.0.18-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamhanko/hanko-elements",
-      "version": "0.0.17-alpha",
+      "version": "0.0.18-alpha",
       "bundleDependencies": [
         "@teamhanko/hanko-frontend-sdk"
       ],
@@ -40,7 +40,7 @@
     },
     "../frontend-sdk": {
       "name": "@teamhanko/hanko-frontend-sdk",
-      "version": "0.0.9-alpha",
+      "version": "0.0.10-alpha",
       "license": "MIT",
       "dependencies": {
         "@types/js-cookie": "^3.0.2"

--- a/frontend/elements/package.json
+++ b/frontend/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.0.17-alpha",
+  "version": "0.0.18-alpha",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/frontend/elements/src/ui/Translations.ts
+++ b/frontend/elements/src/ui/Translations.ts
@@ -16,7 +16,8 @@ export const translations = {
         "Sign in to your account easily and securely with a passkey. Note: Your biometric data is only stored on your devices and will never be shared with anyone.",
       createAccount:
         'No account exists for "{email}". Do you want to create a new account?',
-      passwordFormatHint: "Must be at least 10 characters long.",
+      passwordFormatHint:
+        "Must be between {minLength} and {maxLength} characters long.",
     },
     labels: {
       or: "or",
@@ -69,7 +70,8 @@ export const translations = {
         "Ihr Gerät unterstützt die sichere Anmeldung mit Passkeys. Hinweis: Ihre biometrischen Daten verbleiben sicher auf Ihrem Gerät und werden niemals an unseren Server gesendet.",
       createAccount:
         'Es existiert kein Konto für "{email}". Möchten Sie ein neues Konto erstellen?',
-      passwordFormatHint: "mindestens 10 Zeichen",
+      passwordFormatHint:
+        "Das Passwort muss zwischen {minLength} und {maxLength} Zeichen lang sein.",
     },
     labels: {
       or: "oder",

--- a/frontend/elements/src/ui/pages/RegisterPassword.tsx
+++ b/frontend/elements/src/ui/pages/RegisterPassword.tsx
@@ -1,5 +1,5 @@
 import * as preact from "preact";
-import { useContext, useState } from "preact/compat";
+import { useContext, useMemo, useState } from "preact/compat";
 
 import {
   User,
@@ -26,7 +26,7 @@ type Props = {
 
 const RegisterPassword = ({ user, registerAuthenticator }: Props) => {
   const { t } = useContext(TranslateContext);
-  const { hanko } = useContext(AppContext);
+  const { hanko, config } = useContext(AppContext);
   const { renderError, emitSuccessEvent, renderRegisterAuthenticator } =
     useContext(RenderContext);
 
@@ -71,6 +71,14 @@ const RegisterPassword = ({ user, registerAuthenticator }: Props) => {
       });
   };
 
+  const passwordLength = useMemo(
+    () => ({
+      minLength: config.password.min_password_length,
+      maxLength: 72,
+    }),
+    [config.password.min_password_length]
+  );
+
   return (
     <Content>
       <Headline>{t("headlines.registerPassword")}</Headline>
@@ -84,11 +92,10 @@ const RegisterPassword = ({ user, registerAuthenticator }: Props) => {
           label={t("labels.password")}
           onInput={onPasswordInput}
           disabled={isSuccess || isLoading}
-          minLength={10}
-          maxLength={32}
           autofocus
+          {...passwordLength}
         />
-        <Paragraph>{t("texts.passwordFormatHint")}</Paragraph>
+        <Paragraph>{t("texts.passwordFormatHint", passwordLength)}</Paragraph>
         <Button isSuccess={isSuccess} isLoading={isLoading}>
           {t("labels.continue")}
         </Button>

--- a/frontend/frontend-sdk/package-lock.json
+++ b/frontend/frontend-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamhanko/hanko-frontend-sdk",
-  "version": "0.0.9-alpha",
+  "version": "0.0.10-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamhanko/hanko-frontend-sdk",
-      "version": "0.0.9-alpha",
+      "version": "0.0.10-alpha",
       "license": "MIT",
       "dependencies": {
         "@types/js-cookie": "^3.0.2"

--- a/frontend/frontend-sdk/package.json
+++ b/frontend/frontend-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamhanko/hanko-frontend-sdk",
-  "version": "0.0.9-alpha",
+  "version": "0.0.10-alpha",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/frontend/frontend-sdk/src/lib/Dto.ts
+++ b/frontend/frontend-sdk/src/lib/Dto.ts
@@ -5,9 +5,11 @@ import { PublicKeyCredentialWithAttestationJSON } from "@github/webauthn-json";
  * @category SDK
  * @subcategory DTO
  * @property {boolean} enabled - Indicates passwords are enabled, so the API accepts login attempts using passwords.
+ * @property {number} min_password_length - The minimum length of a password. Can be used for password validation.
  */
 interface PasswordConfig {
   enabled: boolean;
+  min_password_length: number;
 }
 
 /**


### PR DESCRIPTION
# Description

The Hanko API provides the config value of the minimum password length to the frontend and accepts passwords up to a length of 72 characters. This MR makes that the frontend-sdk accepts the config value and that `<hanko-auth>` validates the password accordingly. 

Fixes #273 

# Implementation

The validation behaves like on the Email login page. The browser's validation API is used and the submit button will trigger the validation, so that a tooltip will appear, when the password doesn't have the minimum length.
