### PR TITLE
Default line-height for headlines 

### DIFF
--- a/frontend/elements/package-lock.json
+++ b/frontend/elements/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.0.17-alpha",
+  "version": "0.0.18-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamhanko/hanko-elements",
-      "version": "0.0.17-alpha",
+      "version": "0.0.18-alpha",
       "bundleDependencies": [
         "@teamhanko/hanko-frontend-sdk"
       ],

--- a/frontend/elements/package.json
+++ b/frontend/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.0.17-alpha",
+  "version": "0.0.18-alpha",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/frontend/elements/src/ui/components/Headline.sass
+++ b/frontend/elements/src/ui/components/Headline.sass
@@ -9,4 +9,5 @@
   margin: default.$headline-margin
   text-align: left
   letter-spacing: 0
+  line-height: 1.1
   font-style: normal


### PR DESCRIPTION
# Description

Sets a default `line-height` of `1.1`, to prevent the headline from inheriting the `line-height` property from other classes.

Fixes #339 