### PR TITLE
feat: add database url config variable

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -274,9 +274,13 @@ type Database struct {
 	Host     string `yaml:"host" json:"host" koanf:"host"`
 	Port     string `yaml:"port" json:"port" koanf:"port"`
 	Dialect  string `yaml:"dialect" json:"dialect" koanf:"dialect"`
+	Url      string `yaml:"url" json:"url" koanf:"url"`
 }
 
 func (d *Database) Validate() error {
+	if len(strings.TrimSpace(d.Url)) > 0 {
+		return nil
+	}
 	if len(strings.TrimSpace(d.Database)) == 0 {
 		return errors.New("database must not be empty")
 	}

--- a/backend/docs/Config.md
+++ b/backend/docs/Config.md
@@ -80,7 +80,7 @@ database:
   ## url ##
   #
   # Instead of using the individual fields above this field can be used.
-  # When this field is set, it will be used and the fields above have no affect.
+  # When this field is set, it will be used and the fields above have no effect.
   #
   # Url schema: `dialect://username:password@host:port/database`
   #

--- a/backend/docs/Config.md
+++ b/backend/docs/Config.md
@@ -77,6 +77,17 @@ database:
   user: "CHANGE-ME"
   password: "CHANGE-ME"
   database: "CHANGE-ME"
+  ## url ##
+  #
+  # Instead of using the individual fields above this field can be used.
+  # When this field is set, it will be used and the fields above have no affect.
+  #
+  # Url schema: `dialect://username:password@host:port/database`
+  #
+  # Examples:
+  # - postgres://hanko:hanko@localhost:5432/hanko
+  #
+  url: "CHANGE-ME"
 service:
   ## name ##
   #

--- a/backend/persistence/persister.go
+++ b/backend/persistence/persister.go
@@ -43,18 +43,24 @@ type Storage interface {
 	Persister
 }
 
-//New return a new Persister Object with given configuration
+// New return a new Persister Object with given configuration
 func New(config config.Database) (Storage, error) {
-	DB, err := pop.NewConnection(&pop.ConnectionDetails{
-		Dialect:  config.Dialect,
-		Database: config.Database,
-		Host:     config.Host,
-		Port:     config.Port,
-		User:     config.User,
-		Password: config.Password,
+	connectionDetails := &pop.ConnectionDetails{
 		Pool:     5,
 		IdlePool: 0,
-	})
+	}
+	if len(config.Url) > 0 {
+		connectionDetails.URL = config.Url
+	} else {
+		connectionDetails.Dialect = config.Dialect
+		connectionDetails.Database = config.Database
+		connectionDetails.Host = config.Host
+		connectionDetails.Port = config.Port
+		connectionDetails.User = config.User
+		connectionDetails.Password = config.Password
+	}
+
+	DB, err := pop.NewConnection(connectionDetails)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Adds a database url config variable for easier database configuration. As mentioned in #438 sometimes its easier just to use a url instead of different variables for all the config stuff.

# Tests

Instead of the current database config use the new url variable with the scheme `dialect://username:password@localhost:port/database?sslmode=disable`.

Example:

```
database:
  url: postgres://hanko:hanko@localhost:5432/hanko?sslmode=disable
```


Fixes #438 