### PR TITLE
feat: add query parameter for searching audit logs

### DIFF
--- a/backend/handler/audit_log.go
+++ b/backend/handler/audit_log.go
@@ -23,10 +23,15 @@ func NewAuditLogHandler(persister persistence.Persister) *AuditLogHandler {
 }
 
 type AuditLogListRequest struct {
-	Page      int        `query:"page"`
-	PerPage   int        `query:"per_page"`
-	StartTime *time.Time `query:"start_time"`
-	EndTime   *time.Time `query:"end_time"`
+	Page         int        `query:"page"`
+	PerPage      int        `query:"per_page"`
+	StartTime    *time.Time `query:"start_time"`
+	EndTime      *time.Time `query:"end_time"`
+	Types        []string   `query:"type"`
+	UserId       string     `query:"actor_user_id"`
+	Email        string     `query:"actor_email"`
+	IP           string     `query:"meta_source_ip"`
+	SearchString string     `query:"q"`
 }
 
 func (h AuditLogHandler) List(c echo.Context) error {
@@ -44,12 +49,12 @@ func (h AuditLogHandler) List(c echo.Context) error {
 		request.PerPage = 20
 	}
 
-	auditLogs, err := h.persister.GetAuditLogPersister().List(request.Page, request.PerPage, request.StartTime, request.EndTime)
+	auditLogs, err := h.persister.GetAuditLogPersister().List(request.Page, request.PerPage, request.StartTime, request.EndTime, request.Types, request.UserId, request.Email, request.IP, request.SearchString)
 	if err != nil {
 		return fmt.Errorf("failed to get list of audit logs: %w", err)
 	}
 
-	logCount, err := h.persister.GetAuditLogPersister().Count(request.StartTime, request.EndTime)
+	logCount, err := h.persister.GetAuditLogPersister().Count(request.StartTime, request.EndTime, request.Types, request.UserId, request.Email, request.IP, request.SearchString)
 	if err != nil {
 		return fmt.Errorf("failed to get total count of audit logs: %w", err)
 	}

--- a/backend/test/audit_log_persister.go
+++ b/backend/test/audit_log_persister.go
@@ -34,7 +34,7 @@ func (p *auditLogPersister) Get(id uuid.UUID) (*models.AuditLog, error) {
 	return found, nil
 }
 
-func (p *auditLogPersister) List(page int, perPage int, startTime *time.Time, endTime *time.Time) ([]models.AuditLog, error) {
+func (p *auditLogPersister) List(page int, perPage int, startTime *time.Time, endTime *time.Time, types []string, userId string, email string, ip string, searchString string) ([]models.AuditLog, error) {
 	if len(p.logs) == 0 {
 		return p.logs, nil
 	}
@@ -76,6 +76,6 @@ func (p *auditLogPersister) Delete(auditLog models.AuditLog) error {
 	return nil
 }
 
-func (p *auditLogPersister) Count(startTime *time.Time, endTime *time.Time) (int, error) {
+func (p *auditLogPersister) Count(startTime *time.Time, endTime *time.Time, types []string, userId string, email string, ip string, searchString string) (int, error) {
 	return len(p.logs), nil
 }

--- a/docs/static/spec/admin.yaml
+++ b/docs/static/spec/admin.yaml
@@ -137,6 +137,47 @@ paths:
             type: string
             example: 2022-09-15T12:48:48Z
           description: Date and time to which the logs are included
+        - in: query
+          name: actor_user_id
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/UUID4'
+            example: c339547d-e17d-4ba7-8a1d-b3d5a4d17c1c
+          description: Only audit logs with the specified user_id are included
+        - in: query
+          name: actor_email
+          schema:
+            type: string
+            format: email
+            example: example@example.com
+          description: Only audit logs with the specified email are included
+        - in: query
+          name: meta_source_ip
+          schema:
+            allOf:
+              - type: string
+                format: ipv4
+              - type: string
+                format: ipv6
+            example: 127.0.0.1
+          description: Only audit logs with the specified ip address are included
+        - in: query
+          name: q
+          schema:
+            type: string
+            example: example.com
+          description: Only audit logs are included when the search string matches values in meta_source_ip or actor_user_id or actor_email
+        - in: query
+          name: type
+          schema:
+            type: array
+            items:
+              allOf:
+                - $ref: '#/components/schemas/AuditLogTypes'
+            example: user_created
+          style: form
+          explode: true
+          description: Only audit logs with the specified type are included
       responses:
         '200':
           description: 'Details about audit logs'
@@ -234,26 +275,8 @@ components:
           allOf:
             - $ref: '#/components/schemas/UUID4'
         type:
-          description: The type of the audit log
-          type: string
-          enum:
-            - user_created
-            - password_set_succeeded
-            - password_set_failed
-            - password_login_succeeded
-            - password_login_failed
-            - passcode_login_init_succeeded
-            - passcode_login_init_failed
-            - passcode_login_final_succeeded
-            - passcode_login_final_failed
-            - webauthn_registration_init_succeeded
-            - webauthn_registration_init_failed
-            - webauthn_registration_final_succeeded
-            - webauthn_registration_final_failed
-            - webauthn_authentication_init_succeeded
-            - webauthn_authentication_init_failed
-            - webauthn_authentication_final_succeeded
-            - webauthn_authentication_final_failed
+          allOf:
+            - $ref: '#/components/schemas/AuditLogTypes'
         error:
           description: A more detailed message why something failed
           type: string
@@ -302,6 +325,27 @@ components:
           format: int32
         message:
           type: string
+    AuditLogTypes:
+      description: The type of the audit log
+      type: string
+      enum:
+        - user_created
+        - password_set_succeeded
+        - password_set_failed
+        - password_login_succeeded
+        - password_login_failed
+        - passcode_login_init_succeeded
+        - passcode_login_init_failed
+        - passcode_login_final_succeeded
+        - passcode_login_final_failed
+        - webauthn_registration_init_succeeded
+        - webauthn_registration_init_failed
+        - webauthn_registration_final_succeeded
+        - webauthn_registration_final_failed
+        - webauthn_authentication_init_succeeded
+        - webauthn_authentication_init_failed
+        - webauthn_authentication_final_succeeded
+        - webauthn_authentication_final_failed
   headers:
     X-Total-Count:
       schema:


### PR DESCRIPTION
# Description

Add query parameters to the audit log endpoint in the admin API, so someone is able to search for specific audit logs.

# Implementation

I added some query parameter to the audit log endpoint which are used in the database queries. 

The `type` query parameter can be added multiple times so someone can search for multiple audit log types at the same time. One thing to note is, that to achieve this, the sql query (only for this part) was created using string concatenation, so the values might not be escaped and is a security vulnerability. This was necessary because of how the values are handed over to the database driver. But since this is an endpoint at in the admin API, this is fine (IMO).

# Tests

To test this, just call the audit log endpoint with the queries you want.
