### PR TITLE
fix: fix button width

### DIFF
--- a/frontend/elements/src/_preset.sass
+++ b/frontend/elements/src/_preset.sass
@@ -51,4 +51,4 @@ $link-text-decoration-hover: underline
 $input-min-width: 14em
 
 // Button Styles
-$button-min-width: max-content
+$button-min-width: 7em

--- a/frontend/elements/src/components/form/styles.sass
+++ b/frontend/elements/src/components/form/styles.sass
@@ -27,6 +27,7 @@
   @include mixins.border
 
   white-space: nowrap
+  width: 100%
   min-width: variables.$button-min-width
   height: variables.$item-height
   outline: none


### PR DESCRIPTION
# Description

Button preset min-width set to a fixed value, so the button width remains the same, even when the loading spinner is displayed. Also the button width has been set to 100%, so it takes the available space.

# Tests

Manually tested in Chrome, Firefox and Safari, also I checked the Quickstart app looks like before (except the button takes the available space)
