### PR TITLE
Adjust method to parse the retry after header

### DIFF
--- a/docs/static/jsdoc/hanko-frontend-sdk/HttpClient.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/HttpClient.html
@@ -269,7 +269,7 @@ we can easily return to the fetch API.</div>
         <p class="tag-source">
             <a href="lib_client_HttpClient.ts.html" class="button">View Source</a>
             <span>
-                <a href="lib_client_HttpClient.ts.html">lib/client/HttpClient.ts</a>, <a href="lib_client_HttpClient.ts.html#line111">line 111</a>
+                <a href="lib_client_HttpClient.ts.html">lib/client/HttpClient.ts</a>, <a href="lib_client_HttpClient.ts.html#line112">line 112</a>
             </span>
         </p>
     
@@ -331,7 +331,7 @@ we can easily return to the fetch API.</div>
         
         <span class="code-name">
             
-                delete<span class="signature">(path, body<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Promise.&lt;<a href="Response.html">Response</a>>}</span>
+                delete<span class="signature">(path)</span><span class="type-signature"> &rarr; {Promise.&lt;<a href="Response.html">Response</a>>}</span>
             
         </span>
     </h4>
@@ -365,8 +365,6 @@ we can easily return to the fetch API.</div>
             <th>Type</th>
 
             
-            <th>Attributes</th>
-            
 
             
 
@@ -393,53 +391,10 @@ we can easily return to the fetch API.</div>
   </td>
 
   
-      <td class="attributes">
-      
-
-      
-
-      
-      </td>
-  
 
   
 
   <td class="description last">The path to the requested resource.</td>
-</tr>
-
-
-        
-
-            
-<tr class="deep-level-0">
-  
-      <td class="name"><code>body</code></td>
-  
-
-  <td class="type">
-  
-      
-<code class="param-type">any</code>
-
-
-  
-  </td>
-
-  
-      <td class="attributes">
-      
-          &lt;optional><br>
-      
-
-      
-
-      
-      </td>
-  
-
-  
-
-  <td class="description last">The request body.</td>
 </tr>
 
 
@@ -487,7 +442,7 @@ we can easily return to the fetch API.</div>
         <p class="tag-source">
             <a href="lib_client_HttpClient.ts.html" class="button">View Source</a>
             <span>
-                <a href="lib_client_HttpClient.ts.html">lib/client/HttpClient.ts</a>, <a href="lib_client_HttpClient.ts.html#line311">line 311</a>
+                <a href="lib_client_HttpClient.ts.html">lib/client/HttpClient.ts</a>, <a href="lib_client_HttpClient.ts.html#line310">line 310</a>
             </span>
         </p>
     

--- a/docs/static/jsdoc/hanko-frontend-sdk/Response.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/Response.html
@@ -774,12 +774,12 @@
 
 
     
-    <h4 class="name" id="parseXRetryAfterHeader">
-        <a class="href-link" href="#parseXRetryAfterHeader">#</a>
+    <h4 class="name" id="parseRetryAfterHeader">
+        <a class="href-link" href="#parseRetryAfterHeader">#</a>
         
         <span class="code-name">
             
-                parseXRetryAfterHeader<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span>
+                parseRetryAfterHeader<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span>
             
         </span>
     </h4>
@@ -788,7 +788,7 @@
     
     
     <div class="description">
-        Returns the value for X-Retry-After contained in the response header.
+        Returns the value for Retry-After contained in the response header.
     </div>
     
 

--- a/docs/static/jsdoc/hanko-frontend-sdk/lib_client_HttpClient.ts.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/lib_client_HttpClient.ts.html
@@ -179,12 +179,13 @@ class Response {
   }
 
   /**
-   * Returns the value for X-Retry-After contained in the response header.
+   * Returns the value for Retry-After contained in the response header.
    *
    * @return {number}
    */
-  parseXRetryAfterHeader(): number {
-    return parseInt(this.headers.get("X-Retry-After") || "0", 10);
+  parseRetryAfterHeader(): number {
+    const result = parseInt(this.headers.get("Retry-After"), 10);
+    return isNaN(result) ? 0 : result;
   }
 }
 
@@ -325,7 +326,6 @@ class HttpClient {
    * Performs a DELETE request.
    *
    * @param {string} path - The path to the requested resource.
-   * @param {any=} body - The request body.
    * @return {Promise&lt;Response>}
    * @throws {RequestTimeoutError}
    * @throws {TechnicalError}

--- a/docs/static/jsdoc/hanko-frontend-sdk/lib_client_PasscodeClient.ts.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/lib_client_PasscodeClient.ts.html
@@ -163,7 +163,7 @@ class PasscodeClient extends Client {
     const response = await this.client.post(`/passcode/login/initialize`, body);
 
     if (response.status === 429) {
-      retryAfter = response.parseXRetryAfterHeader();
+      retryAfter = response.parseRetryAfterHeader();
       this.state.setResendAfter(userID, retryAfter).write();
       throw new TooManyRequestsError(retryAfter);
     } else if (response.status === 401) {

--- a/docs/static/jsdoc/hanko-frontend-sdk/lib_client_PasswordClient.ts.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/lib_client_PasswordClient.ts.html
@@ -142,7 +142,7 @@ class PasswordClient extends Client {
     if (response.status === 401) {
       throw new InvalidPasswordError();
     } else if (response.status === 429) {
-      const retryAfter = response.parseXRetryAfterHeader();
+      const retryAfter = response.parseRetryAfterHeader();
       this.passwordState.read().setRetryAfter(userID, retryAfter).write();
       throw new TooManyRequestsError(retryAfter);
     } else if (!response.ok) {

--- a/frontend/frontend-sdk/src/lib/client/HttpClient.ts
+++ b/frontend/frontend-sdk/src/lib/client/HttpClient.ts
@@ -96,8 +96,9 @@ class Response {
    *
    * @return {number}
    */
-  parseXRetryAfterHeader(): number {
-    return parseInt(this.headers.get("Retry-After") || "0", 10);
+  parseRetryAfterHeader(): number {
+    const result = parseInt(this.headers.get("Retry-After"), 10);
+    return isNaN(result) ? 0 : result;
   }
 }
 
@@ -238,7 +239,6 @@ class HttpClient {
    * Performs a DELETE request.
    *
    * @param {string} path - The path to the requested resource.
-   * @param {any=} body - The request body.
    * @return {Promise<Response>}
    * @throws {RequestTimeoutError}
    * @throws {TechnicalError}

--- a/frontend/frontend-sdk/src/lib/client/PasscodeClient.ts
+++ b/frontend/frontend-sdk/src/lib/client/PasscodeClient.ts
@@ -76,7 +76,7 @@ class PasscodeClient extends Client {
     const response = await this.client.post(`/passcode/login/initialize`, body);
 
     if (response.status === 429) {
-      retryAfter = response.parseXRetryAfterHeader();
+      retryAfter = response.parseRetryAfterHeader();
       this.state.setResendAfter(userID, retryAfter).write();
       throw new TooManyRequestsError(retryAfter);
     } else if (response.status === 401) {

--- a/frontend/frontend-sdk/src/lib/client/PasswordClient.ts
+++ b/frontend/frontend-sdk/src/lib/client/PasswordClient.ts
@@ -55,7 +55,7 @@ class PasswordClient extends Client {
     if (response.status === 401) {
       throw new InvalidPasswordError();
     } else if (response.status === 429) {
-      const retryAfter = response.parseXRetryAfterHeader();
+      const retryAfter = response.parseRetryAfterHeader();
       this.passwordState.read().setRetryAfter(userID, retryAfter).write();
       throw new TooManyRequestsError(retryAfter);
     } else if (!response.ok) {

--- a/frontend/frontend-sdk/tests/lib/client/HttpClient.spec.ts
+++ b/frontend/frontend-sdk/tests/lib/client/HttpClient.spec.ts
@@ -1,4 +1,8 @@
-import { Headers, HttpClient } from "../../../src/lib/client/HttpClient";
+import {
+  Headers,
+  Response,
+  HttpClient,
+} from "../../../src/lib/client/HttpClient";
 import { RequestTimeoutError, TechnicalError } from "../../../src";
 import Cookies from "js-cookie";
 
@@ -186,5 +190,21 @@ describe("headers.get()", () => {
     jest.spyOn(xhr, "getResponseHeader").mockReturnValue("bar");
 
     expect(header.get("foo")).toEqual("bar");
+  });
+});
+
+describe("response.parseRetryAfterHeader()", () => {
+  it.each`
+    headerValue  | expected
+    ${""}        | ${0}
+    ${"0"}       | ${0}
+    ${"3"}       | ${3}
+    ${"invalid"} | ${0}
+  `("should parse retry-after header", async ({ headerValue, expected }) => {
+    const response = new Response(xhr);
+    jest.spyOn(xhr, "getResponseHeader").mockReturnValue(headerValue);
+    const result = response.parseRetryAfterHeader();
+    expect(xhr.getResponseHeader).toHaveBeenCalledWith("Retry-After");
+    expect(result).toBe(expected);
   });
 });

--- a/frontend/frontend-sdk/tests/lib/client/HttpClient.spec.ts
+++ b/frontend/frontend-sdk/tests/lib/client/HttpClient.spec.ts
@@ -199,6 +199,7 @@ describe("response.parseRetryAfterHeader()", () => {
     ${""}        | ${0}
     ${"0"}       | ${0}
     ${"3"}       | ${3}
+    ${"-3"}      | ${-3}
     ${"invalid"} | ${0}
   `("should parse retry-after header", async ({ headerValue, expected }) => {
     const response = new Response(xhr);


### PR DESCRIPTION
# Description

Correct the method to parse the retry after header, so it always returns a number. 

# Implementation

I did the following:

- slightly adjusted the method to parse the value
- renamed the method from `parseXRetryAfterHeader` to `parseRetryAfterHeader`, so it's inline with the header name
- jsdoc removed from a non-existent parameter

# Tests

Unit tests included.
