### PR TITLE
feat: add order query for user list

### DIFF
--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -51,6 +51,7 @@ type UserListRequest struct {
 	Page    int    `query:"page"`
 	Email   string `query:"email"`
 	UserId  string `query:"user_id"`
+	Order   string `query:"order"`
 }
 
 func (h *UserHandlerAdmin) List(c echo.Context) error {
@@ -76,9 +77,19 @@ func (h *UserHandlerAdmin) List(c echo.Context) error {
 		}
 	}
 
+	if request.Order == "" {
+		request.Order = "desc"
+	}
+
+	switch request.Order {
+	case "desc", "asc":
+	default:
+		return dto.NewHTTPError(http.StatusBadRequest, "order must be desc or asc")
+	}
+
 	email := strings.ToLower(request.Email)
 
-	users, err := h.persister.GetUserPersister().List(request.Page, request.PerPage, userId, email)
+	users, err := h.persister.GetUserPersister().List(request.Page, request.PerPage, userId, email, request.Order)
 	if err != nil {
 		return fmt.Errorf("failed to get list of users: %w", err)
 	}

--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -84,7 +84,7 @@ func (h *UserHandlerAdmin) List(c echo.Context) error {
 	switch request.SortDirection {
 	case "desc", "asc":
 	default:
-		return dto.NewHTTPError(http.StatusBadRequest, "order must be desc or asc")
+		return dto.NewHTTPError(http.StatusBadRequest, "sort_direction must be desc or asc")
 	}
 
 	email := strings.ToLower(request.Email)

--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -47,11 +47,11 @@ func (h *UserHandlerAdmin) Delete(c echo.Context) error {
 }
 
 type UserListRequest struct {
-	PerPage int    `query:"per_page"`
-	Page    int    `query:"page"`
-	Email   string `query:"email"`
-	UserId  string `query:"user_id"`
-	Order   string `query:"order"`
+	PerPage       int    `query:"per_page"`
+	Page          int    `query:"page"`
+	Email         string `query:"email"`
+	UserId        string `query:"user_id"`
+	SortDirection string `query:"sort_direction"`
 }
 
 func (h *UserHandlerAdmin) List(c echo.Context) error {
@@ -77,11 +77,11 @@ func (h *UserHandlerAdmin) List(c echo.Context) error {
 		}
 	}
 
-	if request.Order == "" {
-		request.Order = "desc"
+	if request.SortDirection == "" {
+		request.SortDirection = "desc"
 	}
 
-	switch request.Order {
+	switch request.SortDirection {
 	case "desc", "asc":
 	default:
 		return dto.NewHTTPError(http.StatusBadRequest, "order must be desc or asc")
@@ -89,7 +89,7 @@ func (h *UserHandlerAdmin) List(c echo.Context) error {
 
 	email := strings.ToLower(request.Email)
 
-	users, err := h.persister.GetUserPersister().List(request.Page, request.PerPage, userId, email, request.Order)
+	users, err := h.persister.GetUserPersister().List(request.Page, request.PerPage, userId, email, request.SortDirection)
 	if err != nil {
 		return fmt.Errorf("failed to get list of users: %w", err)
 	}

--- a/backend/persistence/user_persister.go
+++ b/backend/persistence/user_persister.go
@@ -14,7 +14,7 @@ type UserPersister interface {
 	Create(models.User) error
 	Update(models.User) error
 	Delete(models.User) error
-	List(page int, perPage int, userId uuid.UUID, email string) ([]models.User, error)
+	List(page int, perPage int, userId uuid.UUID, email string, order string) ([]models.User, error)
 	Count(userId uuid.UUID, email string) (int, error)
 }
 
@@ -87,7 +87,7 @@ func (p *userPersister) Delete(user models.User) error {
 	return nil
 }
 
-func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string) ([]models.User, error) {
+func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, order string) ([]models.User, error) {
 	users := []models.User{}
 
 	query := p.db.
@@ -96,6 +96,7 @@ func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email stri
 		LeftJoin("emails", "emails.user_id = users.id")
 	query = p.addQueryParamsToSqlQuery(query, userId, email)
 	err := query.GroupBy("users.id").
+		Order(fmt.Sprintf("users.created_at %s", order)).
 		Paginate(page, perPage).
 		All(&users)
 

--- a/backend/persistence/user_persister.go
+++ b/backend/persistence/user_persister.go
@@ -14,7 +14,7 @@ type UserPersister interface {
 	Create(models.User) error
 	Update(models.User) error
 	Delete(models.User) error
-	List(page int, perPage int, userId uuid.UUID, email string, order string) ([]models.User, error)
+	List(page int, perPage int, userId uuid.UUID, email string, sortDirection string) ([]models.User, error)
 	Count(userId uuid.UUID, email string) (int, error)
 }
 
@@ -87,7 +87,7 @@ func (p *userPersister) Delete(user models.User) error {
 	return nil
 }
 
-func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, order string) ([]models.User, error) {
+func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, sortDirection string) ([]models.User, error) {
 	users := []models.User{}
 
 	query := p.db.
@@ -96,7 +96,7 @@ func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email stri
 		LeftJoin("emails", "emails.user_id = users.id")
 	query = p.addQueryParamsToSqlQuery(query, userId, email)
 	err := query.GroupBy("users.id").
-		Order(fmt.Sprintf("users.created_at %s", order)).
+		Order(fmt.Sprintf("users.created_at %s", sortDirection)).
 		Paginate(page, perPage).
 		All(&users)
 

--- a/backend/test/user_persister.go
+++ b/backend/test/user_persister.go
@@ -53,7 +53,7 @@ func (p *userPersister) Delete(user models.User) error {
 	return nil
 }
 
-func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string) ([]models.User, error) {
+func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, order string) ([]models.User, error) {
 	if len(p.users) == 0 {
 		return p.users, nil
 	}

--- a/backend/test/user_persister.go
+++ b/backend/test/user_persister.go
@@ -53,7 +53,7 @@ func (p *userPersister) Delete(user models.User) error {
 	return nil
 }
 
-func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, order string) ([]models.User, error) {
+func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, sortDirection string) ([]models.User, error) {
 	if len(p.users) == 0 {
 		return p.users, nil
 	}

--- a/docs/static/spec/admin.yaml
+++ b/docs/static/spec/admin.yaml
@@ -58,13 +58,13 @@ paths:
             example: example@example.com
           description: Only users with the specified email are included
         - in: query
-          name: order
+          name: sort_direction
           schema:
             type: string
             enum:
               - asc
               - desc
-          description: The order direction of the returned list (always order by created_at)
+          description: The sort direction of the returned list (always sorted by created_at)
       responses:
         '200':
           description: 'Details about users'

--- a/docs/static/spec/admin.yaml
+++ b/docs/static/spec/admin.yaml
@@ -57,6 +57,14 @@ paths:
             format: email
             example: example@example.com
           description: Only users with the specified email are included
+        - in: query
+          name: order
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          description: The order direction of the returned list (always order by created_at)
       responses:
         '200':
           description: 'Details about users'


### PR DESCRIPTION
# Description

Add `order` query parameter to the list user admin endpoint to control the order of the returned list.
The list is ordered by `created_at`, default = `desc`

# Implementation

Added the `order` query parameter and set default value to `desc`

# Tests

Call the list user endpoint in the admin API and add the `order` query param and check the result.
