### PR TITLE
fix: add same site attribute to workaround cookie

### DIFF
--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -128,6 +128,7 @@ func (h *UserHandler) Create(c echo.Context) error {
 			Domain:   h.cfg.Session.Cookie.Domain,
 			Secure:   h.cfg.Session.Cookie.Secure,
 			HttpOnly: h.cfg.Session.Cookie.HttpOnly,
+			SameSite: http.SameSiteNoneMode,
 		})
 
 		return c.JSON(http.StatusOK, dto.CreateUserResponse{


### PR DESCRIPTION
# Description

Add the SameSite attribute explicitly to the workaround cookie for older frontend versions, so this works also in Chromimum browsers.

