### PR TITLE
fix(hanko-elements): change passcode button text

### DIFF
--- a/e2e/pages/LoginPasscode.ts
+++ b/e2e/pages/LoginPasscode.ts
@@ -4,7 +4,7 @@ import { BasePage } from "./BasePage.js";
 import Endpoints from "../helper/Endpoints.js";
 
 export class LoginPasscode extends BasePage {
-  readonly signInButton: Locator;
+  readonly continueButton: Locator;
   readonly sendNewCodeLink: Locator;
   readonly headline: Locator;
   readonly mailSlurperClient: MailSlurper;
@@ -14,8 +14,8 @@ export class LoginPasscode extends BasePage {
     super(page);
     this.passcodeInputs = page.locator("input[name*='passcode']");
     this.mailSlurperClient = mailSlurperClient;
-    this.signInButton = page.locator("button[type=submit]", {
-      hasText: "Sign in",
+    this.continueButton = page.locator("button[type=submit]", {
+      hasText: "Continue",
     });
     this.sendNewCodeLink = page.locator("button", {
       hasText: "Send new code",

--- a/e2e/tests/common.spec.ts
+++ b/e2e/tests/common.spec.ts
@@ -88,7 +88,7 @@ test.describe("@common", () => {
       });
 
       await test.step("And input elements should be disabled", async () => {
-        await expect(loginPasscodePage.signInButton).toBeDisabled();
+        await expect(loginPasscodePage.continueButton).toBeDisabled();
         for (let i = 0; i < 6; ++i)
           await expect(
             loginPasscodePage.page.locator(`input[name=passcode${i}]`)
@@ -104,7 +104,7 @@ test.describe("@common", () => {
       });
 
       await test.step("And input elements should be enabled", async () => {
-        await expect(loginPasscodePage.signInButton).toBeEnabled();
+        await expect(loginPasscodePage.continueButton).toBeEnabled();
         for (let i = 0; i < 6; ++i)
           await expect(
             loginPasscodePage.page.locator(`input[name=passcode${i}]`)

--- a/frontend/elements/src/pages/LoginPasscodePage.tsx
+++ b/frontend/elements/src/pages/LoginPasscodePage.tsx
@@ -176,7 +176,7 @@ const LoginPasscodePage = ({
             isLoading={isLoading}
             isSuccess={isSuccess}
           >
-            {t("labels.signIn")}
+            {t("labels.continue")}
           </Button>
         </Form>
       </Content>


### PR DESCRIPTION
# Description

Changes the button text on the passcode page from "Sign In" to "Continue".

# Implementation

I just changed the translation key in the `LoginPasscodePage`component

