### PR TITLE
Show loading spinner until the api attribute is defined

### DIFF
--- a/frontend/elements/package-lock.json
+++ b/frontend/elements/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.2.0-alpha",
+  "version": "0.2.1-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamhanko/hanko-elements",
-      "version": "0.2.0-alpha",
+      "version": "0.2.1-alpha",
       "bundleDependencies": [
         "@teamhanko/hanko-frontend-sdk"
       ],

--- a/frontend/elements/package.json
+++ b/frontend/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamhanko/hanko-elements",
-  "version": "0.2.0-alpha",
+  "version": "0.2.1-alpha",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -77,7 +77,7 @@ const AppProvider = ({
   const ref = useRef<HTMLElement>(null);
 
   const hanko = useMemo(() => {
-    if (api.length) {
+    if (api) {
       return new Hanko(api, 13000);
     }
     return null;

--- a/frontend/elements/src/pages/InitPage.tsx
+++ b/frontend/elements/src/pages/InitPage.tsx
@@ -31,7 +31,7 @@ const InitPage = () => {
         .then((shouldRegister) =>
           shouldRegister ? <RegisterPasskeyPage /> : <LoginFinishedPage />
         ),
-    [hanko.webauthn]
+    [hanko]
   );
 
   const initHankoAuth = useCallback(() => {
@@ -56,7 +56,7 @@ const InitPage = () => {
       }
       return <LoginEmailPage />;
     });
-  }, [afterLogin, hanko.config, hanko.user, setConfig, setUser]);
+  }, [afterLogin, hanko, setConfig, setUser]);
 
   const initHankoProfile = useCallback(
     () =>
@@ -81,13 +81,14 @@ const InitPage = () => {
   }, [componentName, initHankoAuth, initHankoProfile]);
 
   useEffect(() => {
+    if (!hanko) return;
     const initializer = getInitializer();
     if (initializer) {
       initializer()
         .then(setPage)
         .catch((e) => setPage(<ErrorPage initialError={e} />));
     }
-  }, [getInitializer, setPage]);
+  }, [hanko, getInitializer, setPage]);
 
   return <LoadingSpinner isLoading />;
 };


### PR DESCRIPTION
# Description
In some Frameworks the `api` attribute is not set immediately, which causes `<hanko-auth>`and `<hanko-profile>` to throw an error.

# Implementation

* Show the loading spinner until the `api` attribute is defined.
* Do not access SDK properties (e.g. via useEffect dependencies) until the frontend-sdk object is available.