### PR TITLE
fix(frontend): make compose debug work again

### DIFF
--- a/frontend/Dockerfile.debug
+++ b/frontend/Dockerfile.debug
@@ -1,26 +1,21 @@
-FROM node:16.16-alpine as build
+FROM --platform=$BUILDPLATFORM node:18.14-alpine as build
+RUN apk add --no-cache libc6-compat
+RUN apk update
+
+RUN npm install turbo --global
 
 WORKDIR /app
-ENV PATH /app/node_modules/.bin:$PATH
+ENV PATH=/app/node_modules/.bin:$PATH
 
-# frontend-sdk
-WORKDIR /app/frontend-sdk
-COPY frontend-sdk/package.json ./
-COPY frontend-sdk/package-lock.json ./
-
-RUN npm ci --silent
-COPY ./frontend-sdk ./
-RUN npm run build
-
-
-# elements
-WORKDIR /app/elements
-COPY elements/package.json ./
-COPY elements/package-lock.json ./
+COPY package.json ./
+COPY package-lock.json ./
+COPY ./frontend-sdk/package.json ./frontend-sdk/package.json
+COPY ./elements/package.json ./elements/package.json
 
 RUN npm ci --silent
-COPY ./elements ./
-RUN npm run build:dev
+
+COPY . .
+RUN npm run build:elements:dev
 
 FROM nginx:stable-alpine
 COPY --from=build /app/elements/dist/elements.js /usr/share/nginx/html

--- a/frontend/elements/webpack.config.dev.cjs
+++ b/frontend/elements/webpack.config.dev.cjs
@@ -1,77 +1,12 @@
-const path = require("path");
+const baseConfig = require("./webpack.config.cjs");
+
+baseConfig.module.rules.push({
+  test: /\.c?js$/,
+  enforce: "pre",
+  use: ["source-map-loader"],
+})
 
 module.exports = {
   devtool: 'eval-source-map',
-  entry: {
-    elements: {
-      filename: 'elements.js',
-      import: './src/index.ts',
-      library: {
-        name: 'Elements',
-        type: 'umd',
-        umdNamedDefine: true,
-      },
-    }
-  },
-  module: {
-    rules: [
-      {
-        test: /\.c?js$/,
-        enforce: "pre",
-        use: ["source-map-loader"],
-      },
-      {
-        test: /\.(tsx?)$/,
-        use: 'ts-loader',
-        exclude: [/node_modules/, /dist/],
-        resolve: {
-          fullySpecified: false
-        },
-      },
-      {
-        test: /\.(sass)$/,
-        use: [
-          {
-            loader: "style-loader",
-            options: {
-              injectType: 'singletonStyleTag',
-              insert: (styleTag) => {
-                // eslint-disable-next-line no-underscore-dangle
-                window._hankoStyle = styleTag;
-              },
-            },
-          },
-          {
-            loader: 'css-loader',
-            options: {
-              modules: {
-                localIdentName: "hanko_[local]",
-                localIdentContext: path.resolve(__dirname, "src"),
-              },
-              importLoaders: 1,
-            }
-          },
-          {
-            loader: "sass-loader",
-            options: {
-              sourceMap: true,
-            }
-          }
-        ]
-      },
-    ]
-  },
-  resolve: {
-    extensions: [
-      '.ts',
-      '.tsx',
-      '.js',
-      '.sass',
-      "declarations.d.ts"
-    ],
-  },
-  output: {
-    clean: true,
-    path: path.resolve(__dirname, 'dist'),
-  },
+  ...baseConfig
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "build": "turbo run build",
     "lint": "turbo run lint",
     "test": "turbo run test",
-    "build:elements": "turbo build --filter=./frontend-sdk --filter=./elements"
+    "build:elements": "turbo build --filter=./frontend-sdk --filter=./elements",
+    "build:elements:dev": "turbo build:dev --filter=./elements"
   },
   "devDependencies": {
     "turbo": "^1.8.3"

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "build:dev": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
     "test": {
       "dependsOn": ["build"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]


### PR DESCRIPTION
# Description

Fixes #640 

# Implementation

- Add turbo and top level npm script for building the "dev"/debug version (i.e. plus sourcemaps) of the elements package
- Adjust Dockerfile to use said script
- Simplify elements webpack "dev"/debug config to make differences to base config explicit
