### PR TITLE
fix(example): do not copy lockfiles not under vc in dockerfiles

### DIFF
--- a/frontend/examples/angular/Dockerfile
+++ b/frontend/examples/angular/Dockerfile
@@ -9,7 +9,6 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 # install app dependencies
 COPY package.json ./
-COPY package-lock.json ./
 RUN npm install
 
 # add app

--- a/frontend/examples/express/Dockerfile
+++ b/frontend/examples/express/Dockerfile
@@ -9,7 +9,6 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 # install app dependencies
 COPY package.json ./
-COPY package-lock.json ./
 RUN npm install --silent
 RUN npm install react-scripts@3.4.1 -g --silent
 

--- a/frontend/examples/nextjs/Dockerfile
+++ b/frontend/examples/nextjs/Dockerfile
@@ -9,7 +9,6 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 # install app dependencies
 COPY package.json ./
-COPY package-lock.json ./
 RUN npm install
 
 # add app

--- a/frontend/examples/react/Dockerfile
+++ b/frontend/examples/react/Dockerfile
@@ -9,7 +9,6 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 # install app dependencies
 COPY package.json ./
-COPY package-lock.json ./
 RUN npm install
 RUN npm install react-scripts@3.4.1 -g --silent
 

--- a/frontend/examples/svelte/Dockerfile
+++ b/frontend/examples/svelte/Dockerfile
@@ -9,7 +9,6 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 # install app dependencies
 COPY package.json ./
-COPY package-lock.json ./
 RUN npm install
 
 # add app

--- a/frontend/examples/vue/Dockerfile
+++ b/frontend/examples/vue/Dockerfile
@@ -9,7 +9,6 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 # install app dependencies
 COPY package.json ./
-COPY package-lock.json ./
 RUN npm install
 
 # add app


### PR DESCRIPTION
# Description

Fixes #660 

# Implementation

Remove copy of `package-lock.json` files (no longer under version control) to container(s).
