### PR TITLE
Feat additional confirmation steps

### DIFF
--- a/frontend/elements/src/Translations.ts
+++ b/frontend/elements/src/Translations.ts
@@ -57,6 +57,8 @@ export const translations = {
     },
     labels: {
       or: "or",
+      yes: "yes",
+      no: "no",
       email: "Email",
       continue: "Continue",
       skip: "Skip",
@@ -174,6 +176,8 @@ export const translations = {
     },
     labels: {
       or: "oder",
+      yes: "ja",
+      no: "nein",
       email: "E-Mail",
       continue: "Weiter",
       skip: "Überspringen",

--- a/frontend/elements/src/components/accordion/AddEmailDropdown.tsx
+++ b/frontend/elements/src/components/accordion/AddEmailDropdown.tsx
@@ -95,6 +95,7 @@ const AddEmailDropdown = ({
   };
 
   const addEmailWithoutVerification = () => {
+    setIsLoading(true);
     hanko.email
       .create(newEmail)
       .then(() => hanko.email.list())
@@ -110,6 +111,9 @@ const AddEmailDropdown = ({
           }, 500);
         }, 1000);
         return;
+      })
+      .finally(() => {
+        setIsLoading(false);
       })
       .catch(setError);
   };

--- a/frontend/elements/src/components/link/Link.tsx
+++ b/frontend/elements/src/components/link/Link.tsx
@@ -51,9 +51,8 @@ const Link = ({
       <Fragment>
         {confirmationActive ? (
           <Fragment>
-            <Link onClick={onConfirmation}>✓ yes</Link>&nbsp;
-            <Link onClick={onCancel}>✗ no</Link>
-            &nbsp;
+            <Link onClick={onConfirmation}>yes</Link>&nbsp;/&nbsp;
+            <Link onClick={onCancel}>no</Link>
           </Fragment>
         ) : null}
         <button

--- a/frontend/elements/src/components/link/Link.tsx
+++ b/frontend/elements/src/components/link/Link.tsx
@@ -7,7 +7,8 @@ import LoadingSpinner, {
 } from "../icons/LoadingSpinner";
 
 import styles from "./styles.sass";
-import { useCallback, useState } from "preact/compat";
+import { useCallback, useContext, useState } from "preact/compat";
+import { TranslateContext } from "@denysvuika/preact-translate";
 
 type LoadingSpinnerPosition = "left" | "right";
 
@@ -25,8 +26,9 @@ const Link = ({
   onClick,
   ...props
 }: Props) => {
+  const { t } = useContext(TranslateContext);
   const [confirmationActive, setConfirmationActive] = useState<boolean>();
-
+  let timeoutID: number;
   const dangerousOnClick = (event: Event) => {
     event.preventDefault();
     setConfirmationActive(true);
@@ -51,8 +53,9 @@ const Link = ({
       <Fragment>
         {confirmationActive ? (
           <Fragment>
-            <Link onClick={onConfirmation}>yes</Link>&nbsp;/&nbsp;
-            <Link onClick={onCancel}>no</Link>
+            <Link onClick={onConfirmation}>{t("labels.yes")}</Link>&nbsp;/&nbsp;
+            <Link onClick={onCancel}>{t("labels.no")}</Link>
+            &nbsp;
           </Fragment>
         ) : null}
         <button
@@ -67,8 +70,18 @@ const Link = ({
         </button>
       </Fragment>
     ),
-    [confirmationActive, dangerous, onClick, onConfirmation, props]
+    [confirmationActive, dangerous, onClick, onConfirmation, props, t]
   );
+
+  const handleOnMouseEnter = () => {
+    if (timeoutID) window.clearTimeout(timeoutID);
+  };
+
+  const handleOnMouseLeave = () => {
+    timeoutID = window.setTimeout(() => {
+      setConfirmationActive(false);
+    }, 1000);
+  };
 
   return (
     <Fragment>
@@ -78,6 +91,8 @@ const Link = ({
           loadingSpinnerPosition === "right" ? styles.reverse : null
         )}
         hidden={props.hidden}
+        onMouseEnter={handleOnMouseEnter}
+        onMouseLeave={handleOnMouseLeave}
       >
         {loadingSpinnerPosition && (props.isLoading || props.isSuccess) ? (
           <Fragment>

--- a/frontend/elements/src/components/link/Link.tsx
+++ b/frontend/elements/src/components/link/Link.tsx
@@ -7,12 +7,14 @@ import LoadingSpinner, {
 } from "../icons/LoadingSpinner";
 
 import styles from "./styles.sass";
+import { useCallback, useState } from "preact/compat";
 
 type LoadingSpinnerPosition = "left" | "right";
 
 export interface Props
   extends LoadingSpinnerProps,
     h.JSX.HTMLAttributes<HTMLButtonElement> {
+  onClick(event: Event): void;
   dangerous?: boolean;
   loadingSpinnerPosition?: LoadingSpinnerPosition;
 }
@@ -20,43 +22,78 @@ export interface Props
 const Link = ({
   loadingSpinnerPosition,
   dangerous = false,
+  onClick,
   ...props
 }: Props) => {
-  const renderLink = () => (
-    <button
-      {...props}
-      // @ts-ignore
-      part={"link"}
-      className={cx(
-        styles.link,
-        props.disabled ? styles.disabled : dangerous ? styles.danger : null
-      )}
-    >
-      {props.children}
-    </button>
+  const [confirmationActive, setConfirmationActive] = useState<boolean>();
+
+  const dangerousOnClick = (event: Event) => {
+    event.preventDefault();
+    setConfirmationActive(true);
+  };
+
+  const onCancel = (event: Event) => {
+    event.preventDefault();
+    setConfirmationActive(false);
+  };
+
+  const onConfirmation = useCallback(
+    (event: Event) => {
+      event.preventDefault();
+      setConfirmationActive(false);
+      onClick(event);
+    },
+    [onClick]
+  );
+
+  const renderLink = useCallback(
+    () => (
+      <Fragment>
+        {confirmationActive ? (
+          <Fragment>
+            <Link onClick={onConfirmation}>✓ yes</Link>&nbsp;
+            <Link onClick={onCancel}>✗ no</Link>
+            &nbsp;
+          </Fragment>
+        ) : null}
+        <button
+          {...props}
+          onClick={dangerous ? dangerousOnClick : onClick}
+          disabled={confirmationActive || props.disabled || props.isLoading}
+          // @ts-ignore
+          part={"link"}
+          className={cx(styles.link, dangerous ? styles.danger : null)}
+        >
+          {props.children}
+        </button>
+      </Fragment>
+    ),
+    [confirmationActive, dangerous, onClick, onConfirmation, props]
   );
 
   return (
     <Fragment>
-      {loadingSpinnerPosition ? (
-        <span
-          className={cx(
-            styles.linkWrapper,
-            loadingSpinnerPosition === "right" ? styles.reverse : null
-          )}
-          hidden={props.hidden}
-        >
-          <LoadingSpinner
-            isLoading={props.isLoading}
-            isSuccess={props.isSuccess}
-            secondary={props.secondary}
-            fadeOut
-          />
-          {renderLink()}
-        </span>
-      ) : (
-        <Fragment>{renderLink()}</Fragment>
-      )}
+      <span
+        className={cx(
+          styles.linkWrapper,
+          loadingSpinnerPosition === "right" ? styles.reverse : null
+        )}
+        hidden={props.hidden}
+      >
+        {loadingSpinnerPosition && (props.isLoading || props.isSuccess) ? (
+          <Fragment>
+            <LoadingSpinner
+              isLoading={props.isLoading}
+              isSuccess={props.isSuccess}
+              secondary={props.secondary}
+              fadeOut
+            />
+            {renderLink()}
+          </Fragment>
+        ) : (
+          <Fragment>{renderLink()}</Fragment>
+        )}
+      </span>
     </Fragment>
   );
 };

--- a/frontend/elements/src/components/link/styles.sass
+++ b/frontend/elements/src/components/link/styles.sass
@@ -10,24 +10,25 @@
   background: none!important
   border: none
   padding: 0!important
+  transition: all .1s
 
   &:hover
     text-decoration: variables.$link-text-decoration-hover
 
-  &.disabled
-    color: variables.$color
+  &:disabled
+    color: variables.$color!important
     pointer-events: none
     cursor: default
 
   &.danger
-    color: variables.$error-color!important
+    color: variables.$error-color
 
 .linkWrapper
   display: inline-flex
   flex-direction: row
   justify-content: space-between
   align-items: center
-  height: 20px
+  height: 1.2rem
 
   &.reverse
     flex-direction: row-reverse


### PR DESCRIPTION
# Description

"Dangerous" links within `<hanko-profile>` now require an extra confirmation step. E.g. when deleting a passkey or email.

# Implementation

- Click a dangerous / red link (e.g. to delete an email or a passkey) and two links ("yes / no") will appear next to the link.
- When clicking "no" it returns to the original state.
- When leaving the link area with the mouse cursor for more than one second it should also return tho the original state.
- When the action has been confirmed by clicking "yes", the action will be executed.