### PR TITLE
feat: emit event after user deletion

### DIFF
--- a/frontend/elements/README.md
+++ b/frontend/elements/README.md
@@ -70,18 +70,6 @@ A web component that handles user login and user registration.
 - `lang` Currently supported values are "en" for English and "de" for German. If the value is omitted, "en" is used.
 - `experimental` A space-seperated list of experimental features to be enabled. See [experimental features](#experimental-features).
 
-#### Events
-
-These events bubble up through the DOM tree.
-
-- `hankoAuthSuccess` - Login or registration completed successfully and a JWT has been issued. You can now take control and redirect the user to protected pages.
-
-```js
-document.addEventListener('hankoAuthSuccess', () => {
-    document.body.innerHTML = 'secured content...'
-})
-```
-
 ### &lt;hanko-profile&gt;
 
 A web component that allows to manage emails, passwords and passkeys.
@@ -96,6 +84,26 @@ A web component that allows to manage emails, passwords and passkeys.
 
 - `api` the location where the Hanko API is running.
 - `lang` Currently supported values are "en" for English and "de" for German. If the value is omitted, "en" is used.
+
+## Events
+
+These events bubble up through the DOM tree.
+
+- `hankoAuthSuccess` - Will be emitted by `<hanko-auth>` after login or registration completed successfully and a JWT has been issued. You can now take control and redirect the user to protected pages.
+
+```js
+document.addEventListener('hankoAuthSuccess', () => {
+    document.body.innerHTML = 'secured content...'
+})
+```
+
+- `hankoProfileUserDeleted` - Will be emitted by `<hanko-profile>` after the user account has been deleted.
+
+```js
+document.addEventListener('hankoProfileUserDeleted', () => {
+    document.body.innerHTML = 'see you soon...'
+})
+```
 
 ## UI Customization
 

--- a/frontend/elements/README.md
+++ b/frontend/elements/README.md
@@ -97,10 +97,10 @@ document.addEventListener('hankoAuthSuccess', () => {
 })
 ```
 
-- `hankoProfileUserDeleted` - Will be emitted by `<hanko-profile>` after the user account has been deleted.
+- `hankoUserDeleted` - Will be emitted by `<hanko-profile>` after the user account has been deleted.
 
 ```js
-document.addEventListener('hankoProfileUserDeleted', () => {
+document.addEventListener('hankoUserDeleted', () => {
     document.body.innerHTML = 'see you soon...'
 })
 ```

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -31,7 +31,7 @@ import SignalLike = JSXInternal.SignalLike;
 type ExperimentalFeature = "conditionalMediation";
 type ExperimentalFeatures = ExperimentalFeature[];
 type ComponentName = "auth" | "profile";
-type EventName = "hankoAuthSuccess" | "hankoProfileUserDeleted";
+type EventName = "hankoAuthSuccess" | "hankoUserDeleted";
 
 interface Props {
   api?: string;
@@ -128,8 +128,12 @@ const AppProvider = ({
   }, [initComponent]);
 
   useEffect(() => {
-    if (componentName !== "auth") return;
-    return listenEvent("hankoProfileUserDeleted", init);
+    switch (componentName) {
+      case "auth":
+        return listenEvent("hankoUserDeleted", init);
+      case "profile":
+        return listenEvent("hankoAuthSuccess", init);
+    }
   }, [componentName, init, listenEvent]);
 
   return (

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -128,8 +128,9 @@ const AppProvider = ({
   }, [initComponent]);
 
   useEffect(() => {
+    if (componentName !== "auth") return;
     return listenEvent("hankoProfileUserDeleted", init);
-  }, [init, listenEvent]);
+  }, [componentName, init, listenEvent]);
 
   return (
     <AppContext.Provider

--- a/frontend/elements/src/pages/DeleteAccountPage.tsx
+++ b/frontend/elements/src/pages/DeleteAccountPage.tsx
@@ -36,7 +36,7 @@ const DeleteAccountPage = ({ onBack }: Props) => {
       .then(() => {
         setIsLoading(false);
         setIsSuccess(true);
-        emitEvent("hankoProfileUserDeleted");
+        emitEvent("hankoUserDeleted");
         return;
       })
       .catch(setError);

--- a/frontend/elements/src/pages/DeleteAccountPage.tsx
+++ b/frontend/elements/src/pages/DeleteAccountPage.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 const DeleteAccountPage = ({ onBack }: Props) => {
   const { t } = useContext(TranslateContext);
-  const { hanko } = useContext(AppContext);
+  const { hanko, emitEvent } = useContext(AppContext);
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
@@ -36,6 +36,7 @@ const DeleteAccountPage = ({ onBack }: Props) => {
       .then(() => {
         setIsLoading(false);
         setIsSuccess(true);
+        emitEvent("hankoProfileUserDeleted");
         return;
       })
       .catch(setError);

--- a/frontend/elements/src/pages/LoginEmailPage.tsx
+++ b/frontend/elements/src/pages/LoginEmailPage.tsx
@@ -47,7 +47,7 @@ const LoginEmailPage = (props: Props) => {
   const {
     hanko,
     experimentalFeatures,
-    emitSuccessEvent,
+    emitEvent,
     config,
     setPage,
     setPasscode,
@@ -111,7 +111,7 @@ const LoginEmailPage = (props: Props) => {
               setPage(<RegisterPasskeyPage />);
               return;
             }
-            emitSuccessEvent();
+            emitEvent("hankoAuthSuccess");
           };
 
           if (recoverPassword) {
@@ -124,7 +124,7 @@ const LoginEmailPage = (props: Props) => {
         })
         .catch((e) => setPage(<ErrorPage initialError={e} />));
     },
-    [emitSuccessEvent, hanko.user, hanko.webauthn, setPage, setUser]
+    [emitEvent, hanko.user, hanko.webauthn, setPage, setUser]
   );
 
   const renderPasscode = useCallback(
@@ -209,7 +209,7 @@ const LoginEmailPage = (props: Props) => {
         if (webauthnLoginInitiated) {
           setIsEmailLoginLoading(false);
           setIsEmailLoginSuccess(true);
-          emitSuccessEvent();
+          emitEvent("hankoAuthSuccess");
         }
 
         return;
@@ -277,7 +277,7 @@ const LoginEmailPage = (props: Props) => {
         setError(null);
         setIsPasskeyLoginLoading(false);
         setIsPasskeyLoginSuccess(true);
-        emitSuccessEvent();
+        emitEvent("hankoAuthSuccess");
 
         return;
       })
@@ -331,7 +331,7 @@ const LoginEmailPage = (props: Props) => {
       .login(null, true)
       .then(() => {
         setError(null);
-        emitSuccessEvent();
+        emitEvent("hankoAuthSuccess");
         setIsEmailLoginSuccess(true);
 
         return;
@@ -344,7 +344,7 @@ const LoginEmailPage = (props: Props) => {
         }
         setError(e instanceof WebauthnRequestCancelledError ? null : e);
       });
-  }, [conditionalMediationEnabled, emitSuccessEvent, hanko.webauthn]);
+  }, [conditionalMediationEnabled, emitEvent, hanko.webauthn]);
 
   useEffect(() => {
     loginViaConditionalUI();

--- a/frontend/elements/src/pages/LoginFinishedPage.tsx
+++ b/frontend/elements/src/pages/LoginFinishedPage.tsx
@@ -10,13 +10,13 @@ import Form from "../components/form/Form";
 
 const LoginFinishedPage = () => {
   const { t } = useContext(TranslateContext);
-  const { emitSuccessEvent } = useContext(AppContext);
+  const { emitEvent } = useContext(AppContext);
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
 
   const onContinue = (event: Event) => {
     event.preventDefault();
     setIsSuccess(true);
-    emitSuccessEvent();
+    emitEvent("hankoAuthSuccess");
   };
 
   return (

--- a/frontend/elements/src/pages/RegisterPasskeyPage.tsx
+++ b/frontend/elements/src/pages/RegisterPasskeyPage.tsx
@@ -24,7 +24,7 @@ import ErrorPage from "./ErrorPage";
 
 const RegisterPasskeyPage = () => {
   const { t } = useContext(TranslateContext);
-  const { hanko, emitSuccessEvent, setPage } = useContext(AppContext);
+  const { hanko, emitEvent, setPage } = useContext(AppContext);
 
   const [isPasskeyLoading, setIsPasskeyLoading] = useState<boolean>(false);
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
@@ -40,7 +40,7 @@ const RegisterPasskeyPage = () => {
       .then(() => {
         setIsSuccess(true);
         setIsPasskeyLoading(false);
-        emitSuccessEvent();
+        emitEvent("hankoAuthSuccess");
 
         return;
       })
@@ -61,7 +61,7 @@ const RegisterPasskeyPage = () => {
   const onSkipClick = (event: Event) => {
     event.preventDefault();
     setSkipIsLoading(true);
-    emitSuccessEvent();
+    emitEvent("hankoAuthSuccess");
   };
 
   const disabled = useMemo(

--- a/frontend/elements/src/test.html
+++ b/frontend/elements/src/test.html
@@ -40,6 +40,11 @@
         document.getElementById("auth").hidden = true;
         document.getElementById("profile").hidden = false;
     })
+
+    document.addEventListener("hankoProfileUserDeleted", (event) => {
+        document.getElementById("auth").hidden = false;
+        document.getElementById("profile").hidden = true;
+    })
 </script>
 </body>
 </html>

--- a/frontend/elements/src/test.html
+++ b/frontend/elements/src/test.html
@@ -41,7 +41,7 @@
         document.getElementById("profile").hidden = false;
     })
 
-    document.addEventListener("hankoProfileUserDeleted", (event) => {
+    document.addEventListener("hankoUserDeleted", (event) => {
         document.getElementById("auth").hidden = false;
         document.getElementById("profile").hidden = true;
     })


### PR DESCRIPTION
# Description

After user deletion `<hanko-profile>` emits an `hankoUserDeleted` event.

# Implementation

- Refactored the `AppContext`'s `emitSuccessEvent` function to be a general `emitEvent` function.
- The profile element emits the new  `hankoUserDeleted` event.
- The `<hanko-auth>` UI will reinitialise, when it captures an `hankoUserDeleted` event. This will possibly be changed / improved after "session events" have been introduced to the `frontend-sdk`.
- The `<hanko-profile>`element will reinitialise, when it captures an `hankoAuthSuccess` event. This is also likely to be changed.
- Moved the readme's "Events"-section, to be relevant for both Hanko elements.

