### PR TITLE
`isready` subcommand to check if a service is ready to serve requests

### DIFF
--- a/backend/cmd/isready/isready.go
+++ b/backend/cmd/isready/isready.go
@@ -14,9 +14,10 @@ func NewIsReadyCommand(config *config.Config) *cobra.Command {
 		Args: cobra.OnlyValidArgs,
 		ValidArgs: []string{"admin", "public"},
 		Short: "Health check a service",
-		Long: `Checks if the specified service is healthy. Possible values are "admin" and "public".`,
+		Long: `Checks if the specified service is healthy. Possible values are "admin" and "public".
+Uses the "/health/ready" endpoint to check if the service is ready to serve requests.
+		`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// check that there is only one argument
 			if len(args) != 1 {
 				fmt.Println("Please specify a service to check")
 				os.Exit(1)

--- a/backend/cmd/isready/isready.go
+++ b/backend/cmd/isready/isready.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/teamhanko/hanko/backend/config"
 	"log"
+	"net"
 	"net/http"
 )
 
@@ -29,18 +30,22 @@ Uses the "/health/ready" endpoint to check if the service is ready to serve requ
 			if service == "public" {
 				address = config.Server.Public.Address
 			}
-			if address[0] == ':' {
-				address = "localhost" + address
+			host, port, err := net.SplitHostPort(address)
+			if err != nil {
+				log.Fatalf("Could not parse address %s", address)
 			}
-			address = "http://" + address
-			res, err := http.Get(address + "/health/ready")
+			if host == "" {
+				host = "localhost"
+			}
+			requestUrl := fmt.Sprintf("http://%s:%s/health/ready", host, port)
+			res, err := http.Get(requestUrl)
 			if err != nil {
 				log.Fatalf("Service %s is not ready", service)
 			} else {
 				if res.StatusCode != 200 {
 					log.Fatalf("Service %s is not ready", service)
 				} else {
-					fmt.Printf("Service %s is ready", service)
+					log.Println(fmt.Sprintf("Service %s is ready", service))
 				}
 			}
 		},

--- a/backend/cmd/isready/isready.go
+++ b/backend/cmd/isready/isready.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/teamhanko/hanko/backend/config"
+	"log"
 	"net/http"
-	"os"
 )
 
 func NewIsReadyCommand(config *config.Config) *cobra.Command {
@@ -19,8 +19,7 @@ Uses the "/health/ready" endpoint to check if the service is ready to serve requ
 		`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
-				fmt.Println("Please specify a service to check")
-				os.Exit(1)
+				log.Fatalf("Please specify a service to check")
 			}
 			service := args[0]
 			address := ""
@@ -36,12 +35,10 @@ Uses the "/health/ready" endpoint to check if the service is ready to serve requ
 			address = "http://" + address
 			res, err := http.Get(address + "/health/ready")
 			if err != nil {
-				fmt.Printf("Service %s is not ready", service)
-				os.Exit(1)
+				log.Fatalf("Service %s is not ready", service)
 			} else {
 				if res.StatusCode != 200 {
-					fmt.Printf("Service %s is not ready", service)
-					os.Exit(1)
+					log.Fatalf("Service %s is not ready", service)
 				} else {
 					fmt.Printf("Service %s is ready", service)
 				}

--- a/backend/cmd/isready/isready.go
+++ b/backend/cmd/isready/isready.go
@@ -13,8 +13,13 @@ func NewIsReadyCommand() *cobra.Command {
 		Short: "Health check a service",
 		Long: `Checks if the specified service is healthy. Possible values are "admin" and "public".`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// log the args
-			fmt.Println(args)
+			// check that there is only one argument
+			if len(args) != 1 {
+				fmt.Println("Please specify a service to check")
+				return
+			}
+			service := args[0]
+			fmt.Printf("Service %s is ready", service)
 		},
 	}
 }

--- a/backend/cmd/isready/isready.go
+++ b/backend/cmd/isready/isready.go
@@ -3,9 +3,12 @@ package isready
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/teamhanko/hanko/backend/config"
+	"net/http"
+	"os"
 )
 
-func NewIsReadyCommand() *cobra.Command {
+func NewIsReadyCommand(config *config.Config) *cobra.Command {
 	return &cobra.Command{
 		Use:   "isready",
 		Args: cobra.OnlyValidArgs,
@@ -16,15 +19,37 @@ func NewIsReadyCommand() *cobra.Command {
 			// check that there is only one argument
 			if len(args) != 1 {
 				fmt.Println("Please specify a service to check")
-				return
+				os.Exit(1)
 			}
 			service := args[0]
-			fmt.Printf("Service %s is ready", service)
+			address := ""
+			if service == "admin" {
+				address = config.Server.Admin.Address
+			}
+			if service == "public" {
+				address = config.Server.Public.Address
+			}
+			if address[0] == ':' {
+				address = "0.0.0.0" + address
+			}
+			address = "http://" + address
+			res, err := http.Get(address + "/health/ready")
+			if err != nil {
+				fmt.Printf("Service %s is not ready", service)
+				os.Exit(1)
+			} else {
+				if res.StatusCode != 200 {
+					fmt.Printf("Service %s is not ready", service)
+					os.Exit(1)
+				} else {
+					fmt.Printf("Service %s is ready", service)
+				}
+			}
 		},
 	}
 }
 
-func RegisterCommands(parent *cobra.Command) {
-	cmd := NewIsReadyCommand()
+func RegisterCommands(parent *cobra.Command, config *config.Config) {
+	cmd := NewIsReadyCommand(config)
 	parent.AddCommand(cmd)
 }

--- a/backend/cmd/isready/isready.go
+++ b/backend/cmd/isready/isready.go
@@ -30,7 +30,7 @@ Uses the "/health/ready" endpoint to check if the service is ready to serve requ
 				address = config.Server.Public.Address
 			}
 			if address[0] == ':' {
-				address = "0.0.0.0" + address
+				address = "localhost" + address
 			}
 			address = "http://" + address
 			res, err := http.Get(address + "/health/ready")

--- a/backend/cmd/isready/isready.go
+++ b/backend/cmd/isready/isready.go
@@ -1,0 +1,25 @@
+package isready
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+func NewIsReadyCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "isready",
+		Args: cobra.OnlyValidArgs,
+		ValidArgs: []string{"admin", "public"},
+		Short: "Health check a service",
+		Long: `Checks if the specified service is healthy. Possible values are "admin" and "public".`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// log the args
+			fmt.Println(args)
+		},
+	}
+}
+
+func RegisterCommands(parent *cobra.Command) {
+	cmd := NewIsReadyCommand()
+	parent.AddCommand(cmd)
+}

--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/teamhanko/hanko/backend/cmd/isready"
 	"github.com/teamhanko/hanko/backend/cmd/jwk"
 	"github.com/teamhanko/hanko/backend/cmd/jwt"
 	"github.com/teamhanko/hanko/backend/cmd/migrate"
@@ -27,6 +28,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file")
 	migrate.RegisterCommands(cmd, &cfg)
 	serve.RegisterCommands(cmd, &cfg)
+	isready.RegisterCommands(cmd)
 	jwk.RegisterCommands(cmd)
 	jwt.RegisterCommands(cmd, &cfg)
 	version.RegisterCommands(cmd)

--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -28,7 +28,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file")
 	migrate.RegisterCommands(cmd, &cfg)
 	serve.RegisterCommands(cmd, &cfg)
-	isready.RegisterCommands(cmd)
+	isready.RegisterCommands(cmd, &cfg)
 	jwk.RegisterCommands(cmd)
 	jwt.RegisterCommands(cmd, &cfg)
 	version.RegisterCommands(cmd)


### PR DESCRIPTION
# Description

This PR introduces the `isready` subcommand for the Hanko CLI.
<!-- Brief description of WHAT you’re doing and WHY. -->

<!-- If applicable, add references to fixed/related issues (e.g. add "Fixes #<issue>"/"Relates to#<issue>".  -->

Fixes #697.

# Implementation

The command takes in the service to check (`public` or `admin`) and makes an HTTP request to the corresponding health endpoint. 

# Tests

Tested manually.

![image](https://user-images.githubusercontent.com/60938164/227909478-40fc867d-dcfa-4fb3-92d0-c87386b3c650.png)
