### PR TITLE
ci(docs): deploy only on backend tag or workflow dispatch

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -2,8 +2,8 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches:
-      - main
+    tags: [ 'backend/v*.*.*' ]
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
# Description

Docs should only be published on backend release tags or via manual deploy (workflow dispatch)
