### PR TITLE
feat(passcode): include passcode in email subject

### DIFF
--- a/backend/mail/locales/passcode.en.yaml
+++ b/backend/mail/locales/passcode.en.yaml
@@ -6,4 +6,4 @@ ttl_text:
   other: "The passcode is valid for {{ .TTL }} minutes."
 email_subject_login:
   description: ""
-  other: "Login to {{ .ServiceName }}"
+  other: "Use passcode {{ .Code }} to sign in to {{ .ServiceName }}"

--- a/backend/mail/render_test.go
+++ b/backend/mail/render_test.go
@@ -73,3 +73,36 @@ func TestRenderer_Render(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderer_Translate(t *testing.T) {
+	renderer, err := NewRenderer()
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, renderer)
+
+	tests := []struct {
+		Name      string
+		MessageID string
+		Lang      string
+		Data      map[string]interface{}
+		Expected  string
+	}{
+		{
+			Name:      "Translate email_subject_login",
+			MessageID: "email_subject_login",
+			Lang:      "en",
+			Data: map[string]interface{}{
+				"ServiceName": "Test Service",
+				"Code":        "123456",
+			},
+			Expected: "Use passcode 123456 to sign in to Test Service",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			result := renderer.Translate(test.Lang, test.MessageID, test.Data)
+			assert.Equal(t, test.Expected, result)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Include the actual passcode in the email's subject.

Closes #744 

# Implementation

Change the `email_subject_login` locale template.
