### PR TITLE
Fix only return users with email

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/fatih/structs v1.1.0
 	github.com/go-playground/validator/v10 v10.12.0
+	github.com/go-sql-driver/mysql v1.7.0
 	github.com/go-testfixtures/testfixtures/v3 v3.8.1
 	github.com/go-webauthn/webauthn v0.7.1
 	github.com/gobuffalo/pop/v6 v6.1.1
@@ -56,7 +57,6 @@ require (
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-sql-driver/mysql v1.7.0 // indirect
 	github.com/go-webauthn/revoke v0.1.9 // indirect
 	github.com/gobuffalo/envy v1.10.2 // indirect
 	github.com/gobuffalo/fizz v1.14.4 // indirect

--- a/backend/handler/user_admin_test.go
+++ b/backend/handler/user_admin_test.go
@@ -2,206 +2,153 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/gofrs/uuid"
-	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
-	"github.com/teamhanko/hanko/backend/dto"
+	"github.com/stretchr/testify/suite"
 	"github.com/teamhanko/hanko/backend/persistence/models"
 	"github.com/teamhanko/hanko/backend/test"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
-	"time"
 )
 
-func TestUserHandlerAdmin_Delete(t *testing.T) {
-	userId, _ := uuid.NewV4()
-	users := []models.User{
-		{
-			ID:        userId,
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-		},
-	}
-
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodDelete, "/", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPath("/users/:id")
-	c.SetParamNames("id")
-	c.SetParamValues(userId.String())
-
-	p := test.NewPersister(users, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	handler := NewUserHandlerAdmin(p)
-
-	if assert.NoError(t, handler.Delete(c)) {
-		assert.Equal(t, http.StatusNoContent, rec.Code)
-	}
+func TestUserHandlerAdminSuite(t *testing.T) {
+	suite.Run(t, new(userAdminSuite))
 }
 
-func TestUserHandlerAdmin_Delete_InvalidUserId(t *testing.T) {
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodDelete, "/", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPath("/users/:id")
-	c.SetParamNames("id")
-	c.SetParamValues("invalidId")
-
-	p := test.NewPersister(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	handler := NewUserHandlerAdmin(p)
-
-	err := handler.Delete(c)
-	if assert.Error(t, err) {
-		httpError := dto.ToHttpError(err)
-		assert.Equal(t, http.StatusBadRequest, httpError.Code)
-	}
+type userAdminSuite struct {
+	test.Suite
 }
 
-func TestUserHandlerAdmin_Delete_UnknownUserId(t *testing.T) {
-	userId, _ := uuid.NewV4()
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodDelete, "/", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPath("/users/:id")
-	c.SetParamNames("id")
-	c.SetParamValues(userId.String())
-
-	p := test.NewPersister(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	handler := NewUserHandlerAdmin(p)
-
-	err := handler.Delete(c)
-	if assert.Error(t, err) {
-		httpError := dto.ToHttpError(err)
-		assert.Equal(t, http.StatusNotFound, httpError.Code)
+func (s *userAdminSuite) TestUserHandlerAdmin_Delete() {
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
 	}
+	err := s.LoadFixtures("../test/fixtures/user_admin")
+	s.Require().NoError(err)
+
+	e := NewAdminRouter(&test.DefaultConfig, s.Storage, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/users/%s", "38bf5a00-d7ea-40a5-a5de-48722c148925"), nil)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusNoContent, rec.Code)
+
+	count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "")
+	s.Require().NoError(err)
+	s.Equal(2, count)
 }
 
-func TestUserHandlerAdmin_List(t *testing.T) {
-	users := []models.User{
-		func() models.User {
-			userId, _ := uuid.NewV4()
-			return models.User{
-				ID:        userId,
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
-			}
-		}(),
-		func() models.User {
-			userId, _ := uuid.NewV4()
-			return models.User{
-				ID:        userId,
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
-			}
-		}(),
+func (s *userAdminSuite) TestUserHandlerAdmin_Delete_UnknownUserId() {
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
 	}
+	err := s.LoadFixtures("../test/fixtures/user_admin")
+	s.Require().NoError(err)
 
-	e := echo.New()
+	e := NewAdminRouter(&test.DefaultConfig, s.Storage, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/users/%s", "1e5dcc5c-8570-43cb-ba8b-caa88bbfc7ac"), nil)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusNotFound, rec.Code)
+
+	count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "")
+	s.Require().NoError(err)
+	s.Equal(3, count)
+}
+
+func (s *userAdminSuite) TestUserHandlerAdmin_Delete_InvalidUserId() {
+	e := NewAdminRouter(&test.DefaultConfig, s.Storage, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/users/%s", "invalidId"), nil)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusBadRequest, rec.Code)
+}
+
+func (s *userAdminSuite) TestUserHandlerAdmin_List() {
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
+	}
+	err := s.LoadFixtures("../test/fixtures/user_admin")
+	s.Require().NoError(err)
+
+	e := NewAdminRouter(&test.DefaultConfig, s.Storage, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/users", nil)
 	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
 
-	p := test.NewPersister(users, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	handler := NewUserHandlerAdmin(p)
+	e.ServeHTTP(rec, req)
 
-	if assert.NoError(t, handler.List(c)) {
-		assert.Equal(t, http.StatusOK, rec.Code)
-		var users []models.User
-		err := json.Unmarshal(rec.Body.Bytes(), &users)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(users))
-		assert.Equal(t, "2", rec.Header().Get("X-Total-Count"))
-		assert.Equal(t, "<http://example.com/users?page=1&per_page=20>; rel=\"first\"", rec.Header().Get("Link"))
+	s.Equal(http.StatusOK, rec.Code)
+	s.Equal("3", rec.Header().Get("X-Total-Count"))
+	s.Equal("<http://example.com/users?page=1&per_page=20>; rel=\"first\"", rec.Header().Get("Link"))
+}
+
+func (s *userAdminSuite) TestUserHandlerAdmin_List_Pagination() {
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
+	}
+	err := s.LoadFixtures("../test/fixtures/user_admin")
+	s.Require().NoError(err)
+
+	e := NewAdminRouter(&test.DefaultConfig, s.Storage, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/users?page=1&per_page=1", nil)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if s.Equal(http.StatusOK, rec.Code) {
+		s.Equal("3", rec.Header().Get("X-Total-Count"))
+
+		var got []models.User
+		err = json.Unmarshal(rec.Body.Bytes(), &got)
+		s.Require().NoError(err)
+
+		s.Equal(1, len(got))
+		s.Equal("<http://example.com/users?page=3&per_page=1>; rel=\"last\",<http://example.com/users?page=2&per_page=1>; rel=\"next\"", rec.Header().Get("Link"))
 	}
 }
 
-func TestUserHandlerAdmin_List_Pagination(t *testing.T) {
-	users := []models.User{
-		func() models.User {
-			userId, _ := uuid.NewV4()
-			return models.User{
-				ID:        userId,
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
-			}
-		}(),
-		func() models.User {
-			userId, _ := uuid.NewV4()
-			return models.User{
-				ID:        userId,
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
-			}
-		}(),
+func (s *userAdminSuite) TestUserHandlerAdmin_List_NoUsers() {
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
 	}
 
-	e := echo.New()
+	e := NewAdminRouter(&test.DefaultConfig, s.Storage, nil)
 
-	q := make(url.Values)
-	q.Set("per_page", "1")
-	q.Set("page", "2")
-	req := httptest.NewRequest(http.MethodGet, "/users?"+q.Encode(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
 	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
 
-	p := test.NewPersister(users, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	handler := NewUserHandlerAdmin(p)
+	e.ServeHTTP(rec, req)
 
-	if assert.NoError(t, handler.List(c)) {
-		assert.Equal(t, http.StatusOK, rec.Code)
+	if s.Equal(http.StatusOK, rec.Code) {
+		s.Equal("0", rec.Header().Get("X-Total-Count"))
+
 		var got []models.User
 		err := json.Unmarshal(rec.Body.Bytes(), &got)
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(got))
-		assert.Equal(t, "2", rec.Header().Get("X-Total-Count"))
-		assert.Equal(t, "<http://example.com/users?page=1&per_page=1>; rel=\"first\",<http://example.com/users?page=1&per_page=1>; rel=\"prev\"", rec.Header().Get("Link"))
+		s.Require().NoError(err)
+
+		s.Equal(0, len(got))
+		s.Equal("<http://example.com/users?page=1&per_page=20>; rel=\"first\"", rec.Header().Get("Link"))
 	}
 }
 
-func TestUserHandlerAdmin_List_NoUsers(t *testing.T) {
-	e := echo.New()
+func (s *userAdminSuite) TestUserHandlerAdmin_List_InvalidPaginationParam() {
+	e := NewAdminRouter(&test.DefaultConfig, s.Storage, nil)
 
-	q := make(url.Values)
-	q.Set("per_page", "1")
-	q.Set("page", "1")
-	req := httptest.NewRequest(http.MethodGet, "/users?"+q.Encode(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/users?per_page=invalid", nil)
 	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
 
-	p := test.NewPersister(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	handler := NewUserHandlerAdmin(p)
+	e.ServeHTTP(rec, req)
 
-	if assert.NoError(t, handler.List(c)) {
-		assert.Equal(t, http.StatusOK, rec.Code)
-		var got []models.User
-		err := json.Unmarshal(rec.Body.Bytes(), &got)
-		assert.NoError(t, err)
-		assert.Equal(t, 0, len(got))
-		assert.Equal(t, "0", rec.Header().Get("X-Total-Count"))
-		assert.Equal(t, "<http://example.com/users?page=1&per_page=1>; rel=\"first\"", rec.Header().Get("Link"))
-	}
-}
-
-func TestUserHandlerAdmin_List_InvalidPaginationParam(t *testing.T) {
-	e := echo.New()
-
-	q := make(url.Values)
-	q.Set("per_page", "invalidPerPageValue")
-	req := httptest.NewRequest(http.MethodGet, "/users?"+q.Encode(), nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-
-	p := test.NewPersister(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	handler := NewUserHandlerAdmin(p)
-
-	err := handler.List(c)
-	if assert.Error(t, err) {
-		httpError := dto.ToHttpError(err)
-		assert.Equal(t, http.StatusBadRequest, httpError.Code)
-	}
+	s.Equal(http.StatusBadRequest, rec.Code)
 }

--- a/backend/persistence/migrations/20220425122015_create_password_credentials.down.fizz
+++ b/backend/persistence/migrations/20220425122015_create_password_credentials.down.fizz
@@ -1,2 +1,1 @@
-drop_index("password_credentials", "password_credentials_user_id_idx")
 drop_table("password_credentials")

--- a/backend/persistence/migrations/20221027123530_change_passcodes.down.fizz
+++ b/backend/persistence/migrations/20221027123530_change_passcodes.down.fizz
@@ -1,1 +1,2 @@
+drop_foreign_key("passcodes", "passcodes_emails_id_fk", {"if_exists": false})
 drop_column("passcodes", "email_id")

--- a/backend/persistence/user_persister.go
+++ b/backend/persistence/user_persister.go
@@ -96,6 +96,7 @@ func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email stri
 		LeftJoin("emails", "emails.user_id = users.id")
 	query = p.addQueryParamsToSqlQuery(query, userId, email)
 	err := query.GroupBy("users.id").
+		Having("count(emails) > 0").
 		Order(fmt.Sprintf("users.created_at %s", sortDirection)).
 		Paginate(page, perPage).
 		All(&users)
@@ -116,6 +117,7 @@ func (p *userPersister) Count(userId uuid.UUID, email string) (int, error) {
 		LeftJoin("emails", "emails.user_id = users.id")
 	query = p.addQueryParamsToSqlQuery(query, userId, email)
 	count, err := query.GroupBy("users.id").
+		Having("count(emails) > 0").
 		Count(&models.User{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to get user count: %w", err)

--- a/backend/persistence/user_persister.go
+++ b/backend/persistence/user_persister.go
@@ -96,7 +96,7 @@ func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email stri
 		LeftJoin("emails", "emails.user_id = users.id")
 	query = p.addQueryParamsToSqlQuery(query, userId, email)
 	err := query.GroupBy("users.id").
-		Having("count(emails) > 0").
+		Having("count(emails.id) > 0").
 		Order(fmt.Sprintf("users.created_at %s", sortDirection)).
 		Paginate(page, perPage).
 		All(&users)
@@ -117,7 +117,7 @@ func (p *userPersister) Count(userId uuid.UUID, email string) (int, error) {
 		LeftJoin("emails", "emails.user_id = users.id")
 	query = p.addQueryParamsToSqlQuery(query, userId, email)
 	count, err := query.GroupBy("users.id").
-		Having("count(emails) > 0").
+		Having("count(emails.id) > 0").
 		Count(&models.User{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to get user count: %w", err)

--- a/backend/test/database.go
+++ b/backend/test/database.go
@@ -13,7 +13,7 @@ import (
 
 var database_user = "hanko"
 var database_password = "hanko"
-var database_name = "hankotest"
+var database_name = "hanko_test"
 
 type TestDB struct {
 	pool        *dockertest.Pool

--- a/backend/test/database.go
+++ b/backend/test/database.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
@@ -12,7 +13,7 @@ import (
 
 var database_user = "hanko"
 var database_password = "hanko"
-var database_name = "hanko_test"
+var database_name = "hankotest"
 
 type TestDB struct {
 	pool        *dockertest.Pool
@@ -54,13 +55,13 @@ func StartDB(name string, dialect string) (*TestDB, error) {
 	}
 
 	hostAndPort := resource.GetHostPort(getPortID(dialect))
-	databaseUrl := fmt.Sprintf("%s://%s:%s@%s/%s?sslmode=disable", dialect, database_user, database_password, hostAndPort, database_name)
+	dsn := getDsn(dialect, hostAndPort)
 
 	_ = resource.Expire(120)
 
 	pool.MaxWait = 120 * time.Second
 	if err = pool.Retry(func() error {
-		db, err := sql.Open(dialect, databaseUrl)
+		db, err := sql.Open(dialect, dsn)
 		if err != nil {
 			return err
 		}
@@ -69,15 +70,23 @@ func StartDB(name string, dialect string) (*TestDB, error) {
 		return nil, fmt.Errorf("could not connect to docker: %w", err)
 	}
 
-	db, err := sql.Open(dialect, databaseUrl)
+	db, err := sql.Open(dialect, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to database: %w", err)
+	}
+
+	dbUrl := ""
+	switch dialect {
+	case "mysql":
+		dbUrl = fmt.Sprintf("mysql://%s", dsn)
+	default:
+		dbUrl = dsn
 	}
 
 	return &TestDB{
 		pool:        pool,
 		resource:    resource,
-		DatabaseUrl: databaseUrl,
+		DatabaseUrl: dbUrl,
 		DbCon:       db,
 		Dialect:     dialect,
 	}, nil
@@ -132,6 +141,17 @@ func getPortID(dialect string) string {
 		return "5432/tcp"
 	case "mysql":
 		return "3306/tcp"
+	default:
+		return ""
+	}
+}
+
+func getDsn(dialect string, hostAndPort string) string {
+	switch dialect {
+	case "postgres":
+		return fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable", database_user, database_password, hostAndPort, database_name)
+	case "mysql":
+		return fmt.Sprintf("%s:%s@(%s)/%s?parseTime=true&multiStatements=true&readTimeout=5s&collation=utf8mb4_general_ci", database_user, database_password, hostAndPort, database_name)
 	default:
 		return ""
 	}

--- a/backend/test/fixtures/user_admin/emails.yaml
+++ b/backend/test/fixtures/user_admin/emails.yaml
@@ -1,0 +1,19 @@
+- id: 51b7c175-ceb6-45ba-aae6-0092221c1b84
+  user_id: b5dd5267-b462-48be-b70d-bcd6f1bbe7a5
+  address: john.doe@example.com
+  verified: true
+  created_at: 2020-12-31 23:59:59
+  updated_at: 2020-12-31 23:59:59
+- id: 38bf5a00-d7ea-40a5-a5de-48722c148925
+  user_id: 38bf5a00-d7ea-40a5-a5de-48722c148925
+  address: john.doe+1@example.com
+  verified: true
+  created_at: 2020-12-31 23:59:59
+  updated_at: 2020-12-31 23:59:59
+- id: e0282f3f-b211-4f0e-b777-6fabc69287c9
+  user_id: e0282f3f-b211-4f0e-b777-6fabc69287c9
+  address: john.doe+2@example.com
+  verified: true
+  created_at: 2020-12-31 23:59:59
+  updated_at: 2020-12-31 23:59:59
+

--- a/backend/test/fixtures/user_admin/users.yaml
+++ b/backend/test/fixtures/user_admin/users.yaml
@@ -1,0 +1,13 @@
+- id: b5dd5267-b462-48be-b70d-bcd6f1bbe7a5
+  created_at: 2020-12-31 23:59:59
+  updated_at: 2020-12-31 23:59:59
+- id: 38bf5a00-d7ea-40a5-a5de-48722c148925
+  created_at: 2020-12-31 23:59:59
+  updated_at: 2020-12-31 23:59:59
+- id: e0282f3f-b211-4f0e-b777-6fabc69287c9
+  created_at: 2020-12-31 23:59:59
+  updated_at: 2020-12-31 23:59:59
+- id: d41df4b7-c055-45e6-9faf-61aa92a4032e
+  created_at: 2020-12-31 23:59:59
+  updated_at: 2020-12-31 23:59:59
+

--- a/backend/test/suite.go
+++ b/backend/test/suite.go
@@ -35,11 +35,11 @@ func (s *Suite) SetupSuite() {
 	}
 	dialect := "postgres"
 	db, err := StartDB(s.Name, dialect)
-	s.NoError(err)
+	s.Require().NoError(err)
 	storage, err := persistence.New(config.Database{
 		Url: db.DatabaseUrl,
 	})
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Storage = storage
 	s.DB = db


### PR DESCRIPTION
# Description

Currently the list users admin endpoint returns all users regardless if they "really registered" (when email verification is `on` a user is first completely registered when he entered the passcode successful). These users can not do anything but they clutter the user table and the user list. So this PR excludes the users from the list users admin endpoint. 

# Implementation

Excluding the users from the list is done by just adding the `having` clause to the SQL query.

An other thing done in this PR is improving the test setup, so that the integration tests can easily run with a MYSQL database. I have done this, because I wanted to check if the SQL query would also work on MYSQL, which it does.
Also changed the user admin handler test to the new integration test style.

# Tests

1. Start the backend with email verification `on`
2. Create a user (either by creating it in the DB directly or by using `<hanko-auth>`, but do not finish the email verification)
3. call the list users admin endpoint
4. the newly created user should not be in the returned list


# Todos

- Create a housekeeping job that removes the "not usable" users from the users table.
