### PR TITLE
feat: add option to disable passkeys

### DIFF
--- a/frontend/elements/README.md
+++ b/frontend/elements/README.md
@@ -41,8 +41,9 @@ Use as a module:
 import { register } from "@teamhanko/hanko-elements";
 
 const { hanko } = await register("https://hanko.yourdomain.com", {
-  shadow: true,       // Set to false if you don't want the web component to be attached to the shadow DOM.
-  injectStyles: true  // Set to false if you don't want to inject any default styles.
+  shadow: true,         // Set to false if you don't want the web component to be attached to the shadow DOM.
+  injectStyles: true,   // Set to false if you don't want to inject any default styles.
+  enablePasskeys: true, // Set to false if you don't want passkeys to be enabled.
 });
 ```
 
@@ -53,8 +54,9 @@ With a script tag via CDN:
   import { register } from "https://cdn.jsdelivr.net/npm/@teamhanko/hanko-elements/dist/elements.js";
 
   const { hanko } = await register("https://hanko.yourdomain.com", {
-    shadow: true,       // Set to false if you don't want the web component to be attached to the shadow DOM.
-    injectStyles: true  // Set to false if you don't want to inject any default styles.
+    shadow: true,         // Set to false if you don't want the web component to be attached to the shadow DOM.
+    injectStyles: true,   // Set to false if you don't want to inject any default styles.
+    enablePasskeys: true, // Set to false if you don't want passkeys to be enabled.
   });
 </script>
 ```

--- a/frontend/elements/src/Elements.tsx
+++ b/frontend/elements/src/Elements.tsx
@@ -30,31 +30,10 @@ declare global {
   }
 }
 
-const HankoAuth = (props: HankoAuthElementProps) => (
-  <AppProvider
-    componentName={"auth"}
-    {...props}
-    hanko={hanko}
-    injectStyles={injectStyles}
-  />
-);
-
-const HankoProfile = (props: HankoProfileElementProps) => (
-  <AppProvider
-    componentName={"profile"}
-    {...props}
-    hanko={hanko}
-    injectStyles={injectStyles}
-  />
-);
-
-const HankoEvents = (props: HankoProfileElementProps) => (
-  <AppProvider componentName={"events"} {...props} hanko={hanko} />
-);
-
 export interface RegisterOptions {
   shadow?: boolean;
   injectStyles?: boolean;
+  enablePasskeys?: boolean;
 }
 
 export interface RegisterResult {
@@ -67,8 +46,37 @@ interface InternalRegisterOptions extends RegisterOptions {
   observedAttributes: string[];
 }
 
-let hanko: Hanko;
-let injectStyles: boolean;
+interface Global {
+  hanko?: Hanko;
+  injectStyles?: boolean;
+  enablePasskeys?: boolean;
+}
+
+const global: Global = {};
+
+const HankoAuth = (props: HankoAuthElementProps) => (
+  <AppProvider
+    componentName={"auth"}
+    {...props}
+    hanko={global.hanko}
+    injectStyles={global.injectStyles}
+    enablePasskeys={global.enablePasskeys}
+  />
+);
+
+const HankoProfile = (props: HankoProfileElementProps) => (
+  <AppProvider
+    componentName={"profile"}
+    {...props}
+    hanko={global.hanko}
+    injectStyles={global.injectStyles}
+    enablePasskeys={global.enablePasskeys}
+  />
+);
+
+const HankoEvents = (props: HankoProfileElementProps) => (
+  <AppProvider componentName={"events"} {...props} hanko={global.hanko} />
+);
 
 const _register = async ({
   tagName,
@@ -87,9 +95,17 @@ export const register = async (
   api: string,
   options: RegisterOptions = {}
 ): Promise<RegisterResult> => {
-  options = { shadow: true, injectStyles: true, ...options };
-  hanko = new Hanko(api);
-  injectStyles = options.injectStyles;
+  options = {
+    shadow: true,
+    injectStyles: true,
+    enablePasskeys: true,
+    ...options,
+  };
+
+  global.hanko = new Hanko(api);
+  global.injectStyles = options.injectStyles;
+  global.enablePasskeys = options.enablePasskeys;
+
   await Promise.all([
     _register({
       ...options,
@@ -111,5 +127,5 @@ export const register = async (
     }),
   ]);
 
-  return { hanko };
+  return { hanko: global.hanko };
 };

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -39,6 +39,7 @@ interface Props {
   fallbackLang?: string;
   injectStyles?: boolean;
   experimental?: string;
+  enablePasskeys?: boolean;
   componentName: ComponentName;
   children?: ComponentChildren;
 }
@@ -65,6 +66,7 @@ interface Context extends States {
   componentName: ComponentName;
   experimentalFeatures?: ExperimentalFeatures;
   emitSuccessEvent: (userID: string) => void;
+  enablePasskeys: boolean;
 }
 
 export const AppContext = createContext<Context>(null);
@@ -76,6 +78,7 @@ const AppProvider = ({
   componentName,
   experimental = "",
   injectStyles = false,
+  enablePasskeys = true,
 }: Props) => {
   const ref = useRef<HTMLElement>(null);
 
@@ -180,6 +183,7 @@ const AppProvider = ({
         componentName,
         experimentalFeatures,
         emitSuccessEvent,
+        enablePasskeys,
         config,
         setConfig,
         userInfo,

--- a/frontend/elements/src/pages/InitPage.tsx
+++ b/frontend/elements/src/pages/InitPage.tsx
@@ -16,6 +16,7 @@ const InitPage = () => {
   const {
     hanko,
     componentName,
+    enablePasskeys,
     setConfig,
     setUser,
     setEmails,
@@ -32,10 +33,22 @@ const InitPage = () => {
       .then(() => hanko.webauthn.shouldRegister(_user))
       .then((shouldRegister) =>
         setPage(
-          shouldRegister ? <RegisterPasskeyPage /> : <LoginFinishedPage />
+          shouldRegister && enablePasskeys ? (
+            <RegisterPasskeyPage />
+          ) : (
+            <LoginFinishedPage />
+          )
         )
       );
-  }, [hanko.config, hanko.user, hanko.webauthn, setConfig, setPage, setUser]);
+  }, [
+    enablePasskeys,
+    hanko.config,
+    hanko.user,
+    hanko.webauthn,
+    setConfig,
+    setPage,
+    setUser,
+  ]);
 
   const hankoAuthInit = useCallback(() => {
     const thirdPartyError = hanko.thirdParty.getError();
@@ -128,6 +141,7 @@ const InitPage = () => {
   useEffect(() => {
     hanko.relay.dispatchInitialEvents();
   }, [hanko.relay]);
+
   return <LoadingSpinner isLoading />;
 };
 

--- a/frontend/elements/src/pages/ProfilePage.tsx
+++ b/frontend/elements/src/pages/ProfilePage.tsx
@@ -23,7 +23,7 @@ import Spacer from "../components/spacer/Spacer";
 
 const ProfilePage = () => {
   const { t } = useContext(TranslateContext);
-  const { config, webauthnCredentials, emails, setPage } =
+  const { config, webauthnCredentials, emails, setPage, enablePasskeys } =
     useContext(AppContext);
 
   const [emailError, setEmailError] = useState<HankoError>(null);
@@ -145,22 +145,28 @@ const ProfilePage = () => {
           </Paragraph>
         </Fragment>
       ) : null}
-      <Headline1>{t("headlines.profilePasskeys")}</Headline1>
-      <ErrorMessage error={passkeyError} />
-      <Paragraph>{t("texts.managePasskeys")}</Paragraph>
-      <Paragraph>
-        <ListPasskeysAccordion
-          credentials={webauthnCredentials}
-          setError={setPasskeyError}
-          checkedItemIndex={checkedItemIndexPasskeys}
-          setCheckedItemIndex={setCheckedItemIndexPasskeys}
-        />
-        <AddPasskeyDropdown
-          setError={setPasskeyError}
-          checkedItemIndex={checkedItemIndexAddPasskey}
-          setCheckedItemIndex={setCheckedItemIndexAddPasskey}
-        />
-      </Paragraph>
+      {webauthnCredentials.length > 0 || enablePasskeys ? (
+        <Fragment>
+          <Headline1>{t("headlines.profilePasskeys")}</Headline1>
+          <ErrorMessage error={passkeyError} />
+          <Paragraph>{t("texts.managePasskeys")}</Paragraph>
+          <Paragraph>
+            <ListPasskeysAccordion
+              credentials={webauthnCredentials}
+              setError={setPasskeyError}
+              checkedItemIndex={checkedItemIndexPasskeys}
+              setCheckedItemIndex={setCheckedItemIndexPasskeys}
+            />
+            {enablePasskeys ? (
+              <AddPasskeyDropdown
+                setError={setPasskeyError}
+                checkedItemIndex={checkedItemIndexAddPasskey}
+                setCheckedItemIndex={setCheckedItemIndexAddPasskey}
+              />
+            ) : null}
+          </Paragraph>
+        </Fragment>
+      ) : null}
       {config.account.allow_deletion ? (
         <Fragment>
           <Spacer />


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

* Adds an option to the `register()` function "enablePasskeys" which is `true` by default.
* The passkey button on the login page behaves like the button on the profile, so it's now disabled instead of invisible, when WebAuthn is not supported.
* Fixes a bug, where the third party login buttons are hidden, when WebAuthn is unsupported. 
