### PR TITLE
fix(quickstart): redirect to login after account deletion

### DIFF
--- a/quickstart/public/html/secured.html
+++ b/quickstart/public/html/secured.html
@@ -42,6 +42,8 @@
 
     const { hanko } = await register("{{.HankoUrl}}", { shadow: false });
 
+    hanko.onUserDeleted(() => window.location.href = "/" );
+
     document.getElementById("logout-link")
         .addEventListener("click", (event) => {
             event.preventDefault();


### PR DESCRIPTION
# Description

Redirect to login after account deletion

Closes #741 
