### PR TITLE
fix: reset states after account deletion failes

### DIFF
--- a/frontend/elements/src/pages/DeleteAccountPage.tsx
+++ b/frontend/elements/src/pages/DeleteAccountPage.tsx
@@ -34,10 +34,11 @@ const DeleteAccountPage = ({ onBack }: Props) => {
     hanko.user
       .delete()
       .then(() => {
-        setIsLoading(false);
+        setError(null);
         setIsSuccess(true);
         return;
       })
+      .finally(() => setIsLoading(false))
       .catch(setError);
   };
 


### PR DESCRIPTION
# Description

* Fixes a bug on the `DeleteAccountPage` where the UI elements remain in the loading state after the deletion request returned an error.
