### PR TITLE
docs(social): fix apple guide typo, sign-in-with button wording

### DIFF
--- a/docs/docs/guides/social/apple.mdx
+++ b/docs/docs/guides/social/apple.mdx
@@ -272,7 +272,7 @@ a custom UI using the [`@teamhanko/hanko-frontend-sdk`](https://www.npmjs.com/pa
 
 Depending on what framework your frontend uses, integrate the `<hanko-auth>` web component from the `hanko-elements`
 package according to one of our [frontend guides](/guides/frontend). If everything was successful, the component should
-now render a button to log in with `GitHub` on the login view.
+now render a button for signing in with `Apple` on the login view.
 
 :::info
 

--- a/docs/docs/guides/social/github.mdx
+++ b/docs/docs/guides/social/github.mdx
@@ -178,7 +178,7 @@ a custom UI using the [`@teamhanko/hanko-frontend-sdk`](https://www.npmjs.com/pa
 
 Depending on what framework your frontend uses, integrate the `<hanko-auth>` web component from the `hanko-elements`
 package according to one of our [frontend guides](/guides/frontend). If everything was successful, the component should
-now render a button to log in with `GitHub` on the login view.
+now render a button for signing in with `GitHub` on the login view.
 
 :::info
 

--- a/docs/docs/guides/social/google.mdx
+++ b/docs/docs/guides/social/google.mdx
@@ -198,7 +198,7 @@ a custom UI using the [`@teamhanko/hanko-frontend-sdk`](https://www.npmjs.com/pa
 
 Depending on what framework your frontend uses, integrate the `<hanko-auth>` web component from the `hanko-elements`
 package according to one of our [frontend guides](/guides/frontend). If everything was successful, the component should
-now render a button to log in with `Google` on the login view.
+now render a button for signing in with `Google` on the login view.
 
 :::info
 


### PR DESCRIPTION
# Description

In social guides, when using web components: 

-  Fix typo in SIWA guide for button description(`GitHub` c/p remnant)
-  Adjust wording describing button description

