### PR TITLE
docs: use correct docker image in readme

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -117,7 +117,7 @@ Before you can start and use the service you need to run the database migrations
 #### Docker
 
 ```shell
-docker run --mount type=bind,source=<PATH-TO-CONFIG-FILE>,target=/config/config.yaml -p 8000:8000 -it ghcr.io/teamhanko/hanko:main migrate up
+docker run --mount type=bind,source=<PATH-TO-CONFIG-FILE>,target=/config/config.yaml -p 8000:8000 -it ghcr.io/teamhanko/hanko:latest migrate up
 ```
 
 > **Note** The `<PATH-TO-CONFIG-FILE>` must be an absolute path to your config file created above.
@@ -323,7 +323,7 @@ endpoints). These can be started separately or in a single command.
 ##### Docker
 
 ```shell
-docker run --mount type=bind,source=<PATH-TO-CONFIG-FILE>,target=/config/config.yaml -p 8000:8000 -it ghcr.io/teamhanko/hanko:main serve public
+docker run --mount type=bind,source=<PATH-TO-CONFIG-FILE>,target=/config/config.yaml -p 8000:8000 -it ghcr.io/teamhanko/hanko:latest serve public
 ```
 
 > **Note** The `<PATH-TO-CONFIG-FILE>` must be an absolute path to your config file created above.


### PR DESCRIPTION
# Description

Use correct docker image in the backend readme.


