### PR TITLE
chore: remove autofocus from the email input field

### DIFF
--- a/frontend/elements/src/pages/LoginEmailPage.tsx
+++ b/frontend/elements/src/pages/LoginEmailPage.tsx
@@ -401,7 +401,6 @@ const LoginEmailPage = (props: Props) => {
           placeholder={t("labels.email")}
           pattern={"^.*[^0-9]+$"}
           disabled={disabled}
-          autoFocus
         />
         <Button
           isLoading={isEmailLoginLoading}


### PR DESCRIPTION
# Description

Removes the autofocus from the email input field due to the following request:

> Remove autofocus on email input in hanko-auth
> 
> - sub-optimal for conditional UI experience (click required to trigger CondUI, but user not inclined to click if input already focused)
> - Autofocus may interfere with other content outside of element