### PR TITLE
feat: add cache control header when returning jwks.json

### DIFF
--- a/backend/handler/well_known.go
+++ b/backend/handler/well_known.go
@@ -25,6 +25,8 @@ func (h *WellKnownHandler) GetPublicKeys(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+
+	c.Response().Header().Add("Cache-Control", "max-age=600")
 	return c.JSON(http.StatusOK, keys)
 }
 

--- a/backend/handler/well_known_test.go
+++ b/backend/handler/well_known_test.go
@@ -30,4 +30,5 @@ func (s *wellKnownSuite) TestWellKnownHandler_GetPublicKeys() {
 	e.ServeHTTP(rec, req)
 
 	s.Equal(http.StatusOK, rec.Code)
+	s.Equal("max-age=600", rec.Header().Get("Cache-Control"))
 }


### PR DESCRIPTION
# Description

Add the `Cache-Control` header when returning the `jwks.json` to use a consistent caching strategy.

Fixes #849 

# Implementation

Only adds the `Cache-Control` header when returning the `jwks.json`.

Currently it is not changeable through the config, I don't known if we want to have that, feel free to share your opinion.

# Tests

- Start the public backend
- open `/.well-known/jwks.json`
- check that the `Cache-Control` header is set in the response.

