### PR TITLE
fix(hanko-elements): translations shown when lang attribute is missing

### DIFF
--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -211,7 +211,6 @@ const AppProvider = ({
     >
       <TranslateProvider
         translations={translations}
-        lang={lang?.toString()}
         fallbackLang={fallbackLanguage}
         root={translationsLocation}
       >


### PR DESCRIPTION
# Description

- Fixes the default translation is not used, when the "lang" attribute is not provided