### PR TITLE
fix(deploy): set correct webauthn settings in k8s x-domain config

### DIFF
--- a/deploy/k8s/overlays/thirdparty-x-domain/config.yaml
+++ b/deploy/k8s/overlays/thirdparty-x-domain/config.yaml
@@ -26,7 +26,9 @@ server:
         - 'https://app.domain-app.grocery'
 webauthn:
   relying_party:
-    origin: "https://app.domain-app.grocery"
+    id: "app.domain-app.grocery"
+    origins:
+      - "https://app.domain-app.grocery"
 third_party:
   error_redirect_url: https://app.domain-app.grocery
   allowed_redirect_urls:


### PR DESCRIPTION
# Description

- Set correct `webauthn.relying_party.id` value
- Use `origins` instead of deprecated `origin`