### PR TITLE
ci: introduce stale issue workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

<!-- Brief description of WHAT you’re doing and WHY. -->
Introducing the stale issue workflow

<!-- If applicable, add references to fixed/related issues (e.g. add "Fixes #<issue>"/"Relates to#<issue>".  -->
Closes: #927 
# Implementation
The stale issue workflow details:
- Follow this guide: https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues
- The issue will be automatically marked as stale if it has been open for 30 days with no activity.
- Then after 14 days since being marked as stale it will be automatically closed
- The workflow will run every day at 1:30 UTC
- The workflow also supports manual trigger event if needed (`workflow_dispatch:`)
<!-- Brief description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need
to refactor something? What tradeoffs did you take? Are there any caveats/downsides to your solution? Are there things
in here which you’d particularly like people to pay close attention to? -->

# Tests
<!-- Describe how to verify your changes. Provide instructions for the purpose of reproducibility. List any relevant
details for your test configuration. -->
This was test at my personal repo, please check the result. It look like:
- https://github.com/tungbq/tungshop/issues/21
- https://github.com/tungbq/tungshop/issues/3
![image](https://github.com/teamhanko/hanko/assets/85242618/b40792e1-233b-4e99-8dbf-e24a353e8ce5)

# Todos
N/A