### PR TITLE
fix: hanko-elements uses wrong frontend-sdk version

### DIFF
--- a/frontend/elements/package.json
+++ b/frontend/elements/package.json
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "@denysvuika/preact-translate": "^0.4.1",
-    "@teamhanko/hanko-frontend-sdk": "^0.8.0",
+    "@teamhanko/hanko-frontend-sdk": "^0.8.1",
     "@teamhanko/preact-custom-element": "^4.2.2",
     "classnames": "^2.3.2",
     "preact": "^10.13.1"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
       "license": "MIT",
       "dependencies": {
         "@denysvuika/preact-translate": "^0.4.1",
-        "@teamhanko/hanko-frontend-sdk": "^0.8.0",
+        "@teamhanko/hanko-frontend-sdk": "^0.8.1",
         "@teamhanko/preact-custom-element": "^4.2.2",
         "classnames": "^2.3.2",
         "preact": "^10.13.1"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

- Updates the `frontend-sdk` dependency version  to 0.8.1.

# Additional context

Fixes #936 
