### PR TITLE
fix: make passcode email optional in backend config schema

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -332,7 +332,7 @@ func (e *Email) Validate() error {
 }
 
 type Passcode struct {
-	Email Email `yaml:"email" json:"email" koanf:"email"`
+	Email Email `yaml:"email" json:"email,omitempty" koanf:"email"`
 	Smtp  SMTP  `yaml:"smtp" json:"smtp" koanf:"smtp"`
 	TTL   int   `yaml:"ttl" json:"ttl,omitempty" koanf:"ttl" jsonschema:"default=300"`
 }

--- a/backend/json_schema/hanko.config.json
+++ b/backend/json_schema/hanko.config.json
@@ -268,7 +268,6 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "email",
         "smtp"
       ]
     },


### PR DESCRIPTION
# Description

Make `passcode.email` optional in json schema because we provide default values in the `DefaultConfig` 
