### PR TITLE
Add configuration to disable user registration

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -140,6 +140,10 @@ func DefaultConfig() *Config {
 				Interval: 1 * time.Minute,
 			},
 		},
+		Account: Account{
+			AllowDeletion: false,
+			AllowSignup:   true,
+		},
 	}
 }
 
@@ -626,4 +630,5 @@ type LoggerConfig struct {
 type Account struct {
 	// Allow Deletion indicates if a user can perform self-service deletion
 	AllowDeletion bool `yaml:"allow_deletion" json:"allow_deletion,omitempty" koanf:"allow_deletion" jsonschema:"default=false"`
+	AllowSignup   bool `yaml:"allow_signup" json:"allow_signup,omitempty" koanf:"allow_signup" jsonschema:"default=true"`
 }

--- a/backend/config/config_test.go
+++ b/backend/config/config_test.go
@@ -15,6 +15,12 @@ func TestDefaultConfigNotEnoughForValidation(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigAccountParameters(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Equal(t, cfg.Account.AllowDeletion, false)
+	assert.Equal(t, cfg.Account.AllowSignup, true)
+}
+
 func TestParseValidConfig(t *testing.T) {
 	configPath := "./config.yaml"
 	cfg, err := Load(&configPath)

--- a/backend/docs/Config.md
+++ b/backend/docs/Config.md
@@ -579,4 +579,11 @@ account:
   # Default: false
   #
   allow_deletion: false
+  ## allow_signup
+  #
+  # Users are able to sign up new accounts.
+  #
+  # Default: true
+  #
+  allow_signup: true
 ```

--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -38,6 +38,10 @@ type UserCreateBody struct {
 }
 
 func (h *UserHandler) Create(c echo.Context) error {
+	if !h.cfg.Account.AllowSignup {
+		return echo.NewHTTPError(http.StatusForbidden).SetInternal(errors.New("account signup is disabled"))
+	}
+
 	var body UserCreateBody
 	if err := (&echo.DefaultBinder{}).BindBody(c, &body); err != nil {
 		return dto.ToHttpError(err)

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -220,6 +220,27 @@ func (s *userSuite) TestUserHandler_Create_EmailMissing() {
 	s.Equal(http.StatusBadRequest, rec.Code)
 }
 
+func (s *userSuite) TestUserHandler_Create_AccountCreationDisabled() {
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
+	}
+	testConfig := test.DefaultConfig
+	testConfig.Account.AllowSignup = false
+	e := NewPublicRouter(&testConfig, s.Storage, nil)
+
+	body := UserCreateBody{Email: "jane.doe@example.com"}
+	bodyJson, err := json.Marshal(body)
+	s.NoError(err)
+
+	req := httptest.NewRequest(http.MethodPost, "/users", bytes.NewReader(bodyJson))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusForbidden, rec.Code)
+}
+
 func (s *userSuite) TestUserHandler_Get() {
 	if testing.Short() {
 		s.T().Skip("skipping test in short mode.")

--- a/backend/json_schema/hanko.config.json
+++ b/backend/json_schema/hanko.config.json
@@ -9,6 +9,11 @@
           "type": "boolean",
           "description": "Allow Deletion indicates if a user can perform self-service deletion",
           "default": false
+        },
+        "allow_signup": {
+          "type": "boolean",
+          "description": "Allow Signup indicates if a user can sign up with service",
+          "default": true
         }
       },
       "additionalProperties": false,

--- a/backend/test/config.go
+++ b/backend/test/config.go
@@ -36,4 +36,8 @@ var DefaultConfig = config.Config{
 	Service: config.Service{
 		Name: "Test",
 	},
+	Account: config.Account{
+		AllowSignup:   true,
+		AllowDeletion: false,
+	},
 }

--- a/deploy/docker-compose/config-disable-signup.yaml
+++ b/deploy/docker-compose/config-disable-signup.yaml
@@ -1,0 +1,31 @@
+database:
+  user: hanko
+  password: hanko
+  host: postgresd
+  port: 5432
+  dialect: postgres
+passcode:
+  email:
+    from_address: no-reply@hanko.io
+  smtp:
+    host: "mailslurper"
+    port: "2500"
+secrets:
+  keys:
+    - abcedfghijklmnopqrstuvwxyz
+service:
+  name: Hanko Authentication Service
+webauthn:
+  relying_party:
+    origins:
+      - "http://localhost:8888"
+session:
+  cookie:
+    secure: false # is needed for safari, because safari does not store secure cookies on localhost
+server:
+  public:
+    cors:
+      allow_origins:
+        - "http://localhost:8888"
+account:
+  allow_signup: false

--- a/docs/static/jsdoc/hanko-frontend-sdk/AccountConfig.html
+++ b/docs/static/jsdoc/hanko-frontend-sdk/AccountConfig.html
@@ -125,6 +125,7 @@
 <tr class="deep-level-0">
     
         <td class="name"><code>allow_deletion</code></td>
+        <td class="name"><code>allow_signup</code></td>
     
 
     <td class="type">

--- a/docs/static/spec/public.yaml
+++ b/docs/static/spec/public.yaml
@@ -819,6 +819,7 @@ paths:
   /users:
     post:
       summary: 'Create a user'
+      description: Used to create a new user. To disable this endpoint, `config.account.allow_signup` must be set to false.
       operationId: createUser
       tags:
         - User Management
@@ -842,6 +843,8 @@ paths:
                 $ref: '#/components/schemas/CreateUserResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '409':
           $ref: '#/components/responses/Conflict'
         '500':
@@ -1096,6 +1099,9 @@ components:
           properties:
             allow_deletion:
               description: Indicates the user account can be deleted by the current user.
+              type: boolean
+            allow_signup:
+              description: Indicates users are able to create new accounts.
               type: boolean
     CookieSession:
       type: string

--- a/frontend/elements/src/i18n/de.ts
+++ b/frontend/elements/src/i18n/de.ts
@@ -4,6 +4,7 @@ export const de: Translation = {
   headlines: {
     error: "Ein Fehler ist aufgetreten",
     loginEmail: "Anmelden / Registrieren",
+    loginEmailNoSignup: "Anmelden",
     loginFinished: "Login erfolgreich",
     loginPasscode: "Passcode eingeben",
     loginPassword: "Passwort eingeben",
@@ -24,6 +25,7 @@ export const de: Translation = {
     createdAt: "Erstellt am",
     connectedAccounts: "Verbundene Konten",
     deleteAccount: "Konto löschen",
+    accountNotFound: "Konto nicht gefunden"
   },
   texts: {
     enterPasscode:
@@ -57,6 +59,8 @@ export const de: Translation = {
       "Löschen Sie diesen Passkey aus Ihrem Konto. Beachten Sie, dass der Passkey noch auf Ihren Geräten vorhanden ist und auch dort gelöscht werden muss.",
     deleteAccount:
       "Sind Sie sicher, dass Sie Ihr Konto löschen wollen? Alle Daten werden sofort gelöscht und können nicht wiederhergestellt werden.",
+    noAccountExists:
+      'Es existiert kein Konto für "{emailAddress}".',
   },
   labels: {
     or: "oder",

--- a/frontend/elements/src/i18n/en.ts
+++ b/frontend/elements/src/i18n/en.ts
@@ -4,6 +4,7 @@ export const en: Translation = {
   headlines: {
     error: "An error has occurred",
     loginEmail: "Sign in or sign up",
+    loginEmailNoSignup: "Sign in",
     loginFinished: "Login successful",
     loginPasscode: "Enter passcode",
     loginPassword: "Enter password",
@@ -24,6 +25,7 @@ export const en: Translation = {
     createdAt: "Created at",
     connectedAccounts: "Connected accounts",
     deleteAccount: "Delete account",
+    accountNotFound: "Account not found",
   },
   texts: {
     enterPasscode: 'Enter the passcode that was sent to "{emailAddress}".',
@@ -55,6 +57,8 @@ export const en: Translation = {
       "Delete this passkey from your account. Note that the passkey will still exist on your devices and needs to be deleted there as well.",
     deleteAccount:
       "Are you sure you want to delete this account? All data will be deleted immediately and cannot be recovered.",
+    noAccountExists:
+      'No account exists for "{emailAddress}".',
   },
   labels: {
     or: "or",

--- a/frontend/elements/src/i18n/fr.ts
+++ b/frontend/elements/src/i18n/fr.ts
@@ -4,6 +4,7 @@ export const fr: Translation = {
   headlines: {
     error: "Une erreur s'est produite",
     loginEmail: "Se connecter ou s'inscrire",
+    loginEmailNoSignup: "Se connecter",
     loginFinished: "Connexion réussie",
     loginPasscode: "Entrez le code d'accès",
     loginPassword: "Entrez le mot de passe",
@@ -24,6 +25,7 @@ export const fr: Translation = {
     createdAt: "Créé le",
     connectedAccounts: "Comptes connectés",
     deleteAccount: "Supprimer le compte",
+    accountNotFound: "Compte non trouvé",
   },
   texts: {
     enterPasscode:
@@ -57,6 +59,8 @@ export const fr: Translation = {
       "Supprimez cette clé d'identification de votre compte. Notez que la clé d'identification continuera d'exister sur vos appareils et devra également y être supprimée.",
     deleteAccount:
       "Êtes-vous sûr de vouloir supprimer ce compte ? Toutes les données seront supprimées immédiatement et ne pourront pas être récupérées.",
+    noAccountExists:
+      'Aucun compte n\'existe pour "{emailAddress}".',
   },
   labels: {
     or: "ou",

--- a/frontend/elements/src/i18n/translations.ts
+++ b/frontend/elements/src/i18n/translations.ts
@@ -7,7 +7,9 @@ export interface Translations {
 export interface Translation {
   headlines: {
     error: string;
+    accountNotFound: string;
     loginEmail: string;
+    loginEmailNoSignup: string;
     loginFinished: string;
     loginPasscode: string;
     loginPassword: string;
@@ -33,6 +35,7 @@ export interface Translation {
     enterPasscode: string;
     setupPasskey: string;
     createAccount: string;
+    noAccountExists: string;
     passwordFormatHint: string;
     manageEmails: string;
     changePassword: string;

--- a/frontend/elements/src/pages/AccountNotFoundPage.tsx
+++ b/frontend/elements/src/pages/AccountNotFoundPage.tsx
@@ -1,0 +1,45 @@
+import { Fragment } from "preact";
+import { useContext } from "preact/compat";
+
+import { TranslateContext } from "@denysvuika/preact-translate";
+
+import Content from "../components/wrapper/Content";
+import Footer from "../components/wrapper/Footer";
+import ErrorMessage from "../components/error/ErrorMessage";
+import Paragraph from "../components/paragraph/Paragraph";
+import Headline1 from "../components/headline/Headline1";
+import Link from "../components/link/Link";
+
+interface Props {
+  emailAddress: string;
+  onBack: () => void;
+}
+
+const AccountNotFoundPage = ({
+  emailAddress,
+  onBack,
+}: Props) => {
+  const { t } = useContext(TranslateContext);
+
+  const onBackClick = (event: Event) => {
+    event.preventDefault();
+    onBack();
+  };
+
+  return (
+    <Fragment>
+      <Content>
+        <Headline1>{t("headlines.accountNotFound")}</Headline1>
+        <Paragraph>{t("texts.noAccountExists", { emailAddress })}</Paragraph>
+      </Content>
+      <Footer>
+        <span hidden />
+        <Link onClick={onBackClick}>
+          {t("labels.back")}
+        </Link>
+      </Footer>
+    </Fragment>
+  );
+};
+
+export default AccountNotFoundPage;

--- a/frontend/elements/src/pages/LoginEmailPage.tsx
+++ b/frontend/elements/src/pages/LoginEmailPage.tsx
@@ -37,6 +37,7 @@ import LoginPasswordPage from "./LoginPasswordPage";
 import RegisterPasskeyPage from "./RegisterPasskeyPage";
 import RegisterPasswordPage from "./RegisterPasswordPage";
 import ErrorPage from "./ErrorPage";
+import AccountNotFoundPage from "./AccountNotFoundPage";
 
 interface Props {
   emailAddress?: string;
@@ -199,6 +200,15 @@ const LoginEmailPage = (props: Props) => {
     ]
   );
 
+  const renderAccountNotFound = useCallback(
+    () => setPage(<AccountNotFoundPage emailAddress={emailAddress} onBack={onBackHandler}/>), 
+    [ 
+      emailAddress, 
+      onBackHandler, 
+      setPage
+    ]
+  );
+
   const loginWithEmailAndWebAuthn = () => {
     let _userInfo: UserInfo;
     let _webauthnFinalizedResponse: WebauthnFinalized;
@@ -237,7 +247,13 @@ const LoginEmailPage = (props: Props) => {
       })
       .catch((e) => {
         if (e instanceof NotFoundError) {
-          renderRegistrationConfirm();
+          
+          if (config.account.allow_signup) {
+            renderRegistrationConfirm();
+            return;
+          }
+          
+          renderAccountNotFound();
           return;
         }
 
@@ -397,7 +413,7 @@ const LoginEmailPage = (props: Props) => {
 
   return (
     <Content>
-      <Headline1>{t("headlines.loginEmail")}</Headline1>
+      <Headline1>{config.account.allow_signup ? t("headlines.loginEmail") : t("headlines.loginEmailNoSignup")}</Headline1>
       <ErrorMessage error={error} />
       <Form onSubmit={onEmailSubmit}>
         <Input

--- a/frontend/frontend-sdk/.gitignore
+++ b/frontend/frontend-sdk/.gitignore
@@ -1,0 +1,1 @@
+coverage

--- a/frontend/frontend-sdk/src/index.ts
+++ b/frontend/frontend-sdk/src/index.ts
@@ -83,6 +83,7 @@ export type {
 import {
   HankoError,
   ConflictError,
+  ForbiddenError,
   EmailAddressAlreadyExistsError,
   InvalidPasswordError,
   InvalidPasscodeError,
@@ -103,6 +104,7 @@ import {
 export {
   HankoError,
   ConflictError,
+  ForbiddenError,
   EmailAddressAlreadyExistsError,
   InvalidPasswordError,
   InvalidPasscodeError,

--- a/frontend/frontend-sdk/src/lib/Dto.ts
+++ b/frontend/frontend-sdk/src/lib/Dto.ts
@@ -29,9 +29,11 @@ export interface EmailConfig {
  * @category SDK
  * @subcategory DTO
  * @property {boolean} allow_deletion - Indicates the current user is allowed to delete the account.
+ * @property {boolean} allow_signup - Indicates the current user is allowed to sign up.
  */
 export interface AccountConfig {
   allow_deletion: boolean;
+  allow_signup: boolean;
 }
 
 /**

--- a/frontend/frontend-sdk/src/lib/Errors.ts
+++ b/frontend/frontend-sdk/src/lib/Errors.ts
@@ -222,6 +222,21 @@ class UnauthorizedError extends HankoError {
 }
 
 /**
+ * A 'ForbiddenError' occurs when the user is not allowed to perform the requested action.
+ *
+ * @category SDK
+ * @subcategory Errors
+ * @extends {HankoError}
+ */
+class ForbiddenError extends HankoError {
+  // eslint-disable-next-line require-jsdoc
+  constructor(cause?: Error) {
+    super("Forbidden error", "forbidden", cause);
+    Object.setPrototypeOf(this, ForbiddenError.prototype);
+  }
+}
+
+/**
  * A 'UserVerificationError' occurs when the user verification requirements
  * for a WebAuthn ceremony are not met.
  *
@@ -306,6 +321,7 @@ export {
   NotFoundError,
   TooManyRequestsError,
   UnauthorizedError,
+  ForbiddenError,
   UserVerificationError,
   MaxNumOfEmailAddressesReachedError,
   EmailAddressAlreadyExistsError,

--- a/frontend/frontend-sdk/src/lib/client/UserClient.ts
+++ b/frontend/frontend-sdk/src/lib/client/UserClient.ts
@@ -4,6 +4,7 @@ import {
   NotFoundError,
   TechnicalError,
   UnauthorizedError,
+  ForbiddenError,
 } from "../Errors";
 import { Client } from "./Client";
 
@@ -55,6 +56,8 @@ class UserClient extends Client {
 
     if (response.status === 409) {
       throw new ConflictError();
+    } if (response.status === 403) {
+      throw new ForbiddenError();
     } else if (!response.ok) {
       throw new TechnicalError();
     }

--- a/frontend/frontend-sdk/tests/lib/client/UserClient.spec.ts
+++ b/frontend/frontend-sdk/tests/lib/client/UserClient.spec.ts
@@ -2,6 +2,7 @@ import {
   ConflictError,
   NotFoundError,
   TechnicalError,
+  ForbiddenError,
   UserClient,
 } from "../../../src";
 import { Response } from "../../../src/lib/client/HttpClient";
@@ -177,6 +178,15 @@ describe("UserClient.create()", () => {
 
     const user = userClient.create(email);
     await expect(user).rejects.toThrow(ConflictError);
+  });
+
+  it("should throw error when signup is disabled", async () => {
+    const response = new Response(new XMLHttpRequest());
+    response.status = 403;
+    jest.spyOn(userClient.client, "post").mockResolvedValue(response);
+
+    const user = userClient.create(email);
+    await expect(user).rejects.toThrow(ForbiddenError);
   });
 
   it("should throw error if API response is not ok (no 2xx, no 4xx)", async () => {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

Work to address #911, add configuration to disable user signup functionality. By default, users will be able to signup. If `account.allow_signup` is set to `false` within the configuration, it will not allow users to register from the frontend or by calling the user create API.

# Implementation

Added a new bool value to the configuration in the backend called `AllowSignup` that will be `true` by default.

On the backend, I added a check in the user create endpoint to check whether this config value is set to false. If so, it will return a 403 Forbidden response.

On the frontend, added a new page for when an account does not exist. This page does not include a button to register, it will only allow users to navigate back to the login screen. Users will only be redirected to this new screen if the config disallows user signups.

# Tests

Added a test in the backend to verify that account creation is forbidden if `account.allow_signup` is disabled in the configuration. On the frontend side, I ran the application locally to verify new site behavior of signup is disabled. I could create an e2e test to test site navigation in an automated fashion, please let me know if I have authorization to update the GitHub action.

# Todos

N/A

# Additional context

N/A
