### PR TITLE
Seed existing user for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Start containers
         working-directory: ./deploy/docker-compose
-        run: docker compose -f "quickstart.yaml" up -d --build
+        run: docker compose -f "quickstart.e2e.yaml" up -d --build
 
       - name: Install dependencies
         working-directory: ./e2e
@@ -28,7 +28,7 @@ jobs:
       - name: Stop containers
         if: always()
         working-directory: ./deploy/docker-compose
-        run: docker compose -f "quickstart.yaml" down
+        run: docker compose -f "quickstart.e2e.yaml" down
   passwords:
     runs-on: ubuntu-22.04
     steps:
@@ -37,7 +37,7 @@ jobs:
 
       - name: Start containers
         working-directory: ./deploy/docker-compose
-        run: docker compose -f "quickstart.yaml" up -d --build
+        run: docker compose -f "quickstart.e2e.yaml" up -d --build
         env:
           PASSWORD_ENABLED: true
 
@@ -54,7 +54,7 @@ jobs:
       - name: Stop containers
         if: always()
         working-directory: ./deploy/docker-compose
-        run: docker compose -f "quickstart.yaml" down
+        run: docker compose -f "quickstart.e2e.yaml" down
   nosignup:
     runs-on: ubuntu-22.04
     steps:
@@ -67,7 +67,7 @@ jobs:
 
       - name: Start containers
         working-directory: ./deploy/docker-compose
-        run: docker compose -f "quickstart.yaml" up -d --build
+        run: docker compose -f "quickstart.e2e.yaml" up -d --build
 
       - name: Install dependencies
         working-directory: ./e2e
@@ -82,4 +82,4 @@ jobs:
       - name: Stop containers
         if: always()
         working-directory: ./deploy/docker-compose
-        run: docker compose -f "quickstart.yaml" down
+        run: docker compose -f "quickstart.e2e.yaml" down

--- a/deploy/docker-compose/quickstart.e2e.yaml
+++ b/deploy/docker-compose/quickstart.e2e.yaml
@@ -1,0 +1,90 @@
+version: '3.9'
+services:
+  hanko-migrate:
+    build: ../../backend
+    volumes:
+      - type: bind
+        source: ./config.yaml
+        target: /etc/config/config.yaml
+    command: --config /etc/config/config.yaml migrate up
+    restart: on-failure
+    depends_on:
+      postgresd:
+        condition: service_healthy
+    networks:
+      - intranet
+  e2e:
+    build:
+      dockerfile: Dockerfile
+      context: ../../e2e/seed
+    environment:
+      - POSTGRES_HOST=postgresd
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=hanko
+      - POSTGRES_DB=hanko
+      - PGPASSWORD=hanko
+    depends_on:
+      hanko-migrate:
+        condition: service_completed_successfully
+    networks:
+      - intranet
+  hanko:
+    depends_on:
+      hanko-migrate:
+        condition: service_completed_successfully
+    build: ../../backend
+    ports:
+      - '8000:8000' # public
+      - '8001:8001' # admin
+    restart: unless-stopped
+    command: serve --config /etc/config/config.yaml all
+    volumes:
+      - type: bind
+        source: ./config.yaml
+        target: /etc/config/config.yaml
+    networks:
+      - intranet
+    environment:
+      - PASSWORD_ENABLED
+  postgresd:
+    image: postgres:12-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=hanko
+      - POSTGRES_PASSWORD=hanko
+      - POSTGRES_DB=hanko
+    healthcheck:
+      test: pg_isready -U hanko -d hanko
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - intranet
+  elements:
+    build: ../../frontend
+    ports:
+      - "9500:80"
+    networks:
+      - intranet
+  quickstart:
+    build: ../../quickstart
+    ports:
+      - "8888:8080"
+    environment:
+      - HANKO_URL=http://localhost:8000
+      - HANKO_URL_INTERNAL=http://hanko:8000
+      - HANKO_ELEMENT_URL=http://localhost:9500/elements.js
+      - HANKO_FRONTEND_SDK_URL=http://localhost:9500/sdk.modern.js
+    networks:
+      - intranet
+  mailslurper:
+    image: marcopas/docker-mailslurper:latest
+    ports:
+      - '8080:8080' # web UI
+      - '8085:8085'
+    networks:
+      - intranet
+networks:
+  intranet:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -18,7 +18,7 @@ This directory contains E2E tests for the Hanko project using [Playwright](https
 
 To run the tests you need to have the following software installed:
 
-- [Node](https://nodejs.org) v. 16.5.1+/ npm
+- [Node](https://nodejs.org) v. 18.6.0+/ npm
 - [Docker](https://www.docker.com/) / Docker Compose
 
 

--- a/e2e/helper/Accounts.ts
+++ b/e2e/helper/Accounts.ts
@@ -1,0 +1,7 @@
+const Accounts = {
+    test: {
+        email: "test@example.com"
+    }
+};
+
+export default Accounts;

--- a/e2e/seed/Dockerfile
+++ b/e2e/seed/Dockerfile
@@ -1,0 +1,15 @@
+FROM postgres:12-alpine
+
+
+ARG POSTGRES_HOST
+ARG POSTGRES_PORT
+ARG POSTGRES_USER
+ARG POSTGRES_DB
+ARG PGPASSWORD
+
+COPY seed.sql ./seed.sql
+COPY init.sh ./init.sh
+
+RUN chmod +x ./init.sh
+
+CMD ./init.sh

--- a/e2e/seed/init.sh
+++ b/e2e/seed/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -d $POSTGRES_DB -a -w -f seed.sql

--- a/e2e/seed/seed.sql
+++ b/e2e/seed/seed.sql
@@ -1,0 +1,30 @@
+INSERT INTO users
+(id, created_at, updated_at)
+VALUES
+('357461f1-458a-42c8-abf3-05eabfc36ffd', current_timestamp, current_timestamp);
+
+INSERT INTO emails
+(id, user_id, address, verified, created_at, updated_at)
+VALUES
+('47c082da-b70a-4ccc-bc5f-1481b3499273', '357461f1-458a-42c8-abf3-05eabfc36ffd', 'test.verified@example.com', true, current_timestamp, current_timestamp);
+
+INSERT INTO primary_emails
+(id, email_id, user_id, created_at, updated_at)
+VALUES
+('8de035cd-3d21-415c-8844-644fe40d7d74', '47c082da-b70a-4ccc-bc5f-1481b3499273', '357461f1-458a-42c8-abf3-05eabfc36ffd', current_timestamp, current_timestamp);
+
+
+INSERT INTO users
+(id, created_at, updated_at)
+VALUES
+('92789b5f-d3ad-46bd-93e8-42afaa4e15ff', current_timestamp, current_timestamp);
+
+INSERT INTO emails
+(id, user_id, address, verified, created_at, updated_at)
+VALUES
+('772663eb-e598-4a63-88df-ceef1a329833', '92789b5f-d3ad-46bd-93e8-42afaa4e15ff', 'test.unverified@example.com', false, current_timestamp, current_timestamp);
+
+INSERT INTO primary_emails
+(id, email_id, user_id, created_at, updated_at)
+VALUES
+('36b9ad84-ff0b-4f9d-af5e-465a5766d071', '772663eb-e598-4a63-88df-ceef1a329833', '92789b5f-d3ad-46bd-93e8-42afaa4e15ff', current_timestamp, current_timestamp);

--- a/e2e/seed/seed.sql
+++ b/e2e/seed/seed.sql
@@ -6,25 +6,9 @@ VALUES
 INSERT INTO emails
 (id, user_id, address, verified, created_at, updated_at)
 VALUES
-('47c082da-b70a-4ccc-bc5f-1481b3499273', '357461f1-458a-42c8-abf3-05eabfc36ffd', 'test.verified@example.com', true, current_timestamp, current_timestamp);
+('47c082da-b70a-4ccc-bc5f-1481b3499273', '357461f1-458a-42c8-abf3-05eabfc36ffd', 'test@example.com', true, current_timestamp, current_timestamp);
 
 INSERT INTO primary_emails
 (id, email_id, user_id, created_at, updated_at)
 VALUES
 ('8de035cd-3d21-415c-8844-644fe40d7d74', '47c082da-b70a-4ccc-bc5f-1481b3499273', '357461f1-458a-42c8-abf3-05eabfc36ffd', current_timestamp, current_timestamp);
-
-
-INSERT INTO users
-(id, created_at, updated_at)
-VALUES
-('92789b5f-d3ad-46bd-93e8-42afaa4e15ff', current_timestamp, current_timestamp);
-
-INSERT INTO emails
-(id, user_id, address, verified, created_at, updated_at)
-VALUES
-('772663eb-e598-4a63-88df-ceef1a329833', '92789b5f-d3ad-46bd-93e8-42afaa4e15ff', 'test.unverified@example.com', false, current_timestamp, current_timestamp);
-
-INSERT INTO primary_emails
-(id, email_id, user_id, created_at, updated_at)
-VALUES
-('36b9ad84-ff0b-4f9d-af5e-465a5766d071', '772663eb-e598-4a63-88df-ceef1a329833', '92789b5f-d3ad-46bd-93e8-42afaa4e15ff', current_timestamp, current_timestamp);

--- a/e2e/tests/common.spec.ts
+++ b/e2e/tests/common.spec.ts
@@ -3,7 +3,6 @@ import { LoginEmail } from "../pages/LoginEmail.js";
 import type { Mails } from "../helper/MailSlurper.js";
 import Endpoints from "../helper/Endpoints.js";
 import { faker } from "@faker-js/faker";
-import Accounts from "../helper/Accounts.js";
 
 test.describe("@common", () => {
   test.describe("@nowebauthn", () => {
@@ -187,25 +186,6 @@ test.describe("@common", () => {
 
       await test.step("And no cookie should be created", async () => {
         await expect(loginPasscodePage).not.toHaveCookie();
-      });
-    });
-
-    test("Logging in with existing user will prompt for passcode", async ({
-      loginEmailPage,
-      loginPasscodePage
-    }) => {
-      const email = Accounts.test.email;
-
-      await test.step("When I visit the baseURL, the LoginEmail page should be shown", async () => {
-        await expect(loginEmailPage.headline).toBeVisible();
-      });
-
-      await test.step("And when I submit an email address", async () => {
-        await loginEmailPage.continueUsingEmail(email);
-      });
-
-      await test.step("The LoginPasscode page should be shown", async () => {
-        await expect(loginPasscodePage.headline).toBeVisible();
       });
     });
   });

--- a/e2e/tests/common.spec.ts
+++ b/e2e/tests/common.spec.ts
@@ -3,6 +3,7 @@ import { LoginEmail } from "../pages/LoginEmail.js";
 import type { Mails } from "../helper/MailSlurper.js";
 import Endpoints from "../helper/Endpoints.js";
 import { faker } from "@faker-js/faker";
+import Accounts from "../helper/Accounts.js";
 
 test.describe("@common", () => {
   test.describe("@nowebauthn", () => {
@@ -186,6 +187,25 @@ test.describe("@common", () => {
 
       await test.step("And no cookie should be created", async () => {
         await expect(loginPasscodePage).not.toHaveCookie();
+      });
+    });
+
+    test("Logging in with existing user will prompt for passcode", async ({
+      loginEmailPage,
+      loginPasscodePage
+    }) => {
+      const email = Accounts.test.email;
+
+      await test.step("When I visit the baseURL, the LoginEmail page should be shown", async () => {
+        await expect(loginEmailPage.headline).toBeVisible();
+      });
+
+      await test.step("And when I submit an email address", async () => {
+        await loginEmailPage.continueUsingEmail(email);
+      });
+
+      await test.step("The LoginPasscode page should be shown", async () => {
+        await expect(loginPasscodePage.headline).toBeVisible();
       });
     });
   });

--- a/e2e/tests/nosignup.spec.ts
+++ b/e2e/tests/nosignup.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from "../fixtures/Pages.js";
 import { faker } from "@faker-js/faker";
+import Accounts from "../helper/Accounts.js";
 
 test.describe("@nosignup", () => {
-    test("Login with account not found", async ({
+    test("Login with account that does not exist", async ({
         loginEmailNoSignupPage,
         noAccountFoundPage
     }) => {
@@ -29,6 +30,26 @@ test.describe("@nosignup", () => {
             await noAccountFoundPage.back();
             await expect(loginEmailNoSignupPage.headline).toBeVisible();
             await expect(loginEmailNoSignupPage.signInPasskeyButton).toBeVisible();
+        });
+    });
+
+    test("Login with existing account", async ({
+        loginEmailNoSignupPage,
+        loginPasscodePage
+    }) => {
+        const email = Accounts.test.email;
+
+        await test.step("When I visit the baseURL, the LoginEmailNoSignup page should be shown", async () => {
+            await expect(loginEmailNoSignupPage.headline).toBeVisible();
+            await expect(loginEmailNoSignupPage.signInPasskeyButton).toBeVisible();
+        });
+
+        await test.step("And when I submit an email that already exists", async () => {
+            await loginEmailNoSignupPage.continueUsingEmail(email);
+        });
+
+        await test.step("Login passocde page should be displayed", async () => {
+            await expect(loginPasscodePage.headline).toBeVisible();
         });
     });
 });

--- a/e2e/tests/passwordless.spec.ts
+++ b/e2e/tests/passwordless.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../fixtures/Pages.js";
 import { faker } from "@faker-js/faker";
 import Endpoints from "../helper/Endpoints.js";
+import Accounts from "../helper/Accounts.js";
 
 test.describe("@nopw", () => {
   test.beforeEach(async ({}) => {
@@ -157,6 +158,25 @@ test.describe("@nopw", () => {
 
       await test.step("And a cookie should have been set", async () => {
         await expect(securedContentPage).toHaveCookie();
+      });
+    });
+
+    test("Logging in with existing user will prompt for passcode", async ({
+      loginEmailPage,
+      loginPasscodePage
+    }) => {
+      const email = Accounts.test.email;
+
+      await test.step("When I visit the baseURL, the LoginEmail page should be shown", async () => {
+        await expect(loginEmailPage.headline).toBeVisible();
+      });
+
+      await test.step("And when I submit an email address", async () => {
+        await loginEmailPage.continueUsingEmail(email);
+      });
+
+      await test.step("The LoginPasscode page should be shown", async () => {
+        await expect(loginPasscodePage.headline).toBeVisible();
       });
     });
   });

--- a/e2e/tests/passwords.spec.ts
+++ b/e2e/tests/passwords.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../fixtures/Pages.js";
 import { faker } from "@faker-js/faker";
 import Endpoints from "../helper/Endpoints.js";
+import Accounts from "../helper/Accounts.js";
 
 test.describe("@pw", () => {
   test.beforeEach(async ({}) => {
@@ -280,6 +281,25 @@ test.describe("@pw", () => {
 
       await test.step("And a cookie should have been set", async () => {
         await expect(securedContentPage).toHaveCookie();
+      });
+    });
+
+    test("Logging in with existing user will prompt for password", async ({
+      loginEmailPage,
+      loginPasswordPage
+    }) => {
+      const email = Accounts.test.email;
+
+      await test.step("When I visit the baseURL, the LoginEmail page should be shown", async () => {
+        await expect(loginEmailPage.headline).toBeVisible();
+      });
+
+      await test.step("And when I submit an email address", async () => {
+        await loginEmailPage.continueUsingEmail(email);
+      });
+
+      await test.step("The LoginPassword page should be shown", async () => {
+        await expect(loginPasswordPage.headline).toBeVisible();
       });
     });
   });


### PR DESCRIPTION
# Description

As mentioned in #955, I noticed the end-to-end tests do not have a way to test out flows for users that already exist. This is especially important for the end-to-end test when signup is disallowed. I wanted to be able to verify the flow for existing users.

This change will seed a user so we can verify the various flows for existing users in the end-to-end tests.

# Implementation

Aside from migrations, there doesn't seem to be an existing solution to seed data into the databases. While I could've created a separate process within the hanko backend to handle seeding, since this behavior was not requested I decided to not add any functionality to the backend. Instead, I created a SQL script that will be executed by a seeder Docker container after the migrator container has added migrations. The script has constant values it will add into the database, including a user with the email `test@example.com` that will be used by the end-to-end tests.

# Tests

Added tests within the `nosignup`, `pw` and `nopw` tests to verify the flow of existing users and what the next screen they see would be after they login.

# Todos

N/A

# Additional context

N/A
