### PR TITLE
fix: public router adhere to LogHealthAndMetrics option

### DIFF
--- a/backend/handler/public_router.go
+++ b/backend/handler/public_router.go
@@ -18,14 +18,17 @@ import (
 
 func NewPublicRouter(cfg *config.Config, persister persistence.Persister, prometheus echo.MiddlewareFunc) *echo.Echo {
 	e := echo.New()
-
 	e.Renderer = template.NewTemplateRenderer()
-
 	e.HideBanner = true
+	g := e.Group("")
 
 	e.HTTPErrorHandler = dto.NewHTTPErrorHandler(dto.HTTPErrorHandlerConfig{Debug: false, Logger: e.Logger})
 	e.Use(middleware.RequestID())
-	e.Use(hankoMiddleware.GetLoggerMiddleware())
+	if cfg.Log.LogHealthAndMetrics {
+		e.Use(hankoMiddleware.GetLoggerMiddleware())
+	} else {
+		g.Use(hankoMiddleware.GetLoggerMiddleware())
+	}
 
 	exposeHeader := []string{
 		httplimit.HeaderRetryAfter,
@@ -75,7 +78,7 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister, promet
 	if cfg.Password.Enabled {
 		passwordHandler := NewPasswordHandler(persister, sessionManager, cfg, auditLogger)
 
-		password := e.Group("/password")
+		password := g.Group("/password")
 		password.PUT("", passwordHandler.Set, sessionMiddleware)
 		password.POST("/login", passwordHandler.Login)
 	}
@@ -84,17 +87,17 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister, promet
 	statusHandler := NewStatusHandler(persister)
 
 	e.GET("/", statusHandler.Status)
-	e.GET("/me", userHandler.Me, sessionMiddleware)
+	g.GET("/me", userHandler.Me, sessionMiddleware)
 
-	user := e.Group("/users")
+	user := g.Group("/users")
 	user.POST("", userHandler.Create)
 	user.GET("/:id", userHandler.Get, sessionMiddleware)
 
-	e.POST("/user", userHandler.GetUserIdByEmail)
-	e.POST("/logout", userHandler.Logout, sessionMiddleware)
+	g.POST("/user", userHandler.GetUserIdByEmail)
+	g.POST("/logout", userHandler.Logout, sessionMiddleware)
 
 	if cfg.Account.AllowDeletion {
-		e.DELETE("/user", userHandler.Delete, sessionMiddleware)
+		g.DELETE("/user", userHandler.Delete, sessionMiddleware)
 	}
 
 	healthHandler := NewHealthHandler()
@@ -115,7 +118,7 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister, promet
 	if err != nil {
 		panic(fmt.Errorf("failed to create well-known handler: %w", err))
 	}
-	wellKnown := e.Group("/.well-known")
+	wellKnown := g.Group("/.well-known")
 	wellKnown.GET("/jwks.json", wellKnownHandler.GetPublicKeys)
 	wellKnown.GET("/config", wellKnownHandler.GetConfig)
 
@@ -124,7 +127,7 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister, promet
 		panic(fmt.Errorf("failed to create public email handler: %w", err))
 	}
 
-	webauthn := e.Group("/webauthn")
+	webauthn := g.Group("/webauthn")
 	webauthnRegistration := webauthn.Group("/registration", sessionMiddleware)
 	webauthnRegistration.POST("/initialize", webauthnHandler.BeginRegistration)
 	webauthnRegistration.POST("/finalize", webauthnHandler.FinishRegistration)
@@ -138,25 +141,25 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister, promet
 	webauthnCredentials.PATCH("/:id", webauthnHandler.UpdateCredential)
 	webauthnCredentials.DELETE("/:id", webauthnHandler.DeleteCredential)
 
-	passcode := e.Group("/passcode")
+	passcode := g.Group("/passcode")
 	passcodeLogin := passcode.Group("/login")
 	passcodeLogin.POST("/initialize", passcodeHandler.Init)
 	passcodeLogin.POST("/finalize", passcodeHandler.Finish)
 
-	email := e.Group("/emails", sessionMiddleware)
+	email := g.Group("/emails", sessionMiddleware)
 	email.GET("", emailHandler.List)
 	email.POST("", emailHandler.Create)
 	email.DELETE("/:id", emailHandler.Delete)
 	email.POST("/:id/set_primary", emailHandler.SetPrimaryEmail)
 
 	thirdPartyHandler := NewThirdPartyHandler(cfg, persister, sessionManager, auditLogger)
-	thirdparty := e.Group("thirdparty")
+	thirdparty := g.Group("thirdparty")
 	thirdparty.GET("/auth", thirdPartyHandler.Auth)
 	thirdparty.GET("/callback", thirdPartyHandler.Callback)
 	thirdparty.POST("/callback", thirdPartyHandler.CallbackPost)
 
 	tokenHandler := NewTokenHandler(cfg, persister, sessionManager, auditLogger)
-	e.POST("/token", tokenHandler.Validate)
+	g.POST("/token", tokenHandler.Validate)
 
 	return e
 }


### PR DESCRIPTION
# Description

In contrast to the admin routes, the public router does not disable logging on the health endpoints.
This means that if using the public endpoints for health checking, logs will be spammed with health check requests.

With this pull request the "LogHealthAndMetrics" configuration option is now correctly observed also for the public router.

# Implementation

Used the admin router implementation and implemented the same solution for the public router.
