### PR TITLE
feat: add path prefixes for routers

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -240,8 +240,9 @@ func (c *Cookie) GetName() string {
 type ServerSettings struct {
 	// The Address to listen on in the form of host:port
 	// See net.Dial for details of the address format.
-	Address string `yaml:"address" json:"address,omitempty" koanf:"address"`
-	Cors    Cors   `yaml:"cors" json:"cors,omitempty" koanf:"cors"`
+	Address    string `yaml:"address" json:"address,omitempty" koanf:"address"`
+	PathPrefix string `yaml:"path_prefix" json:"path_prefix,omitempty" koanf:"path_prefix" split_words:"true"`
+	Cors       Cors   `yaml:"cors" json:"cors,omitempty" koanf:"cors"`
 }
 
 type Cors struct {

--- a/backend/handler/admin_router.go
+++ b/backend/handler/admin_router.go
@@ -15,7 +15,11 @@ func NewAdminRouter(cfg *config.Config, persister persistence.Persister, prometh
 	e := echo.New()
 	e.Renderer = template.NewTemplateRenderer()
 	e.HideBanner = true
+
 	g := e.Group("")
+	if len(cfg.Server.Admin.PathPrefix) > 0 {
+		g = e.Group(cfg.Server.Admin.PathPrefix)
+	}
 
 	e.HTTPErrorHandler = dto.NewHTTPErrorHandler(dto.HTTPErrorHandlerConfig{Debug: false, Logger: e.Logger})
 	e.Use(middleware.RequestID())


### PR DESCRIPTION
# Description

Implements path prefixes for both public and admin routers so hanko can be hosted also on a subpath.
E.g. AWS Application Load Balancers do not offer the option to rewrite the path - so hosting Hanko would always require an additional system (e.g. nginx) if hosted on a subpath on a shared domain.

With these small changes it's possible to host hanko on a subpath.


# Tests

Please let me know if there is a proper way to test this (that makes sense).
