### PR TITLE
Added the Hanko Cloud video tutorial to the Docs

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -12,7 +12,7 @@ Hanko is a lightweight, open source user authentication solution that takes you 
 
 Start a project with [Hanko Cloud](https://cloud.hanko.io):
 
-<iframe width="90%" height="450" src="https://www.youtube.com/embed/qFDws5s10jc?si=ukKJoj2Ln5y6T8eP" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="100%" height="450" src="https://www.youtube.com/embed/dSeYqEhqZc0?si=anD8PLuU7khVRfDw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 Or learn how to [host Hanko](https://github.com/teamhanko/hanko) yourself.
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -3,19 +3,30 @@ sidebar_position: 1
 slug: /
 title: Introduction
 ---
+
 # :wave: Welcome to Hanko Docs
+
 Hanko is a lightweight, open source user authentication solution that takes you on the journey beyond passwords. For better security, increased conversion rates, and happier users.
 
 ## Get started with Hanko
-[Start a project](https://cloud.hanko.io) with Hanko Cloud or learn how to [host Hanko](https://github.com/teamhanko/hanko) yourself.
+
+Start a project with [Hanko Cloud](https://cloud.hanko.io):
+
+<iframe width="90%" height="450" src="https://www.youtube.com/embed/qFDws5s10jc?si=ukKJoj2Ln5y6T8eP" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+Or learn how to [host Hanko](https://github.com/teamhanko/hanko) yourself.
 
 ## Integrate Hanko
+
 To integrate Hanko into your project, we are providing [guides](/guides/frontend) for popular frontend frameworks.
 
 ## Give feedback
+
 We'd love to hear your thoughts about Hanko, especially if you encounter any problems. Please do not hesitate to reach out. You can find us on
+
 - [Hanko Community Slack](https://www.hanko.io/community)
 - [Twitter](https://twitter.com/hanko_io)
 
 ## Contribute
+
 Contributions to the Hanko project are appreciated. For more complex topics, we encourage you to talk to us first to avoid misunderstandings. We're actively working on Hanko and may have already started implementing certain features.


### PR DESCRIPTION

# Description

Added the video tutorial on how to set up a project on the Hanko Cloud in the "Introduction" page of the Docs


