### PR TITLE
fix(frontend-sdk): Export types

### DIFF
--- a/frontend/frontend-sdk/package.json
+++ b/frontend/frontend-sdk/package.json
@@ -8,11 +8,11 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.d.ts",
   "type": "module",
   "source": "src/index.ts",
   "exports": {
     "require": "./dist/sdk.cjs",
+    "types": "./dist/index.d.ts",
     "default": "./dist/sdk.modern.js"
   },
   "main": "./dist/sdk.cjs",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

Currently, the frontend-sdk does not export types properly, Which gives the following error: 

```
Could not find a declaration file for module '@teamhanko/hanko-frontend-sdk'. '/Users/gaurish/projects/documenzo/node_modules/@teamhanko/hanko-frontend-sdk/dist/sdk.modern.js' implicitly has an 'any' type.
  There are types at '/Users/gaurish/projects/documenzo/node_modules/@teamhanko/hanko-frontend-sdk/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@teamhanko/hanko-frontend-sdk' library may need to update its package.json or typings.ts(7016)
```

Which can be fixed by adding a dot path in types field.

# Implementation

types has to be in the exports along with the implementation for server-side

# Tests

N/A

# Todos

n/a

# Additional context
![image](https://github.com/teamhanko/hanko/assets/78847111/0d5b46bd-2d26-4b5e-9457-d3615fee5ed6)
![image](https://github.com/teamhanko/hanko/assets/78847111/5c9ded67-4fb5-41cc-90e6-e2c9336733b9)
