### PR TITLE
Backfill unit tests for Email Handler Create

### DIFF
--- a/backend/handler/email_test.go
+++ b/backend/handler/email_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/gofrs/uuid"
@@ -79,6 +80,135 @@ func (s *emailSuite) TestEmailHandler_List() {
 				var emails []*dto.EmailResponse
 				s.NoError(json.Unmarshal(rec.Body.Bytes(), &emails))
 				s.Equal(currentTest.expectedCount, len(emails))
+			}
+		})
+	}
+}
+
+func (s *emailSuite) TestEmailHandler_Create() {
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
+	}
+
+	err := s.LoadFixtures("../test/fixtures/email")
+	s.Require().NoError(err)
+
+	tests := []struct {
+		name                 string
+		email                string
+		userId               uuid.UUID
+		maxNumberOfAddresses int
+		requiresVerification bool
+		expectedStatusCode   int
+		upsertsRecords       bool
+		expectedEmailUserId  uuid.UUID
+	}{
+		{
+			name:                 "should reject the request when the user has already reached the maximum number of email addresses",
+			email:                "rejection1@example.com",
+			userId:               uuid.FromStringOrNil("b5dd5267-b462-48be-b70d-bcd6f1bbe7a5"),
+			maxNumberOfAddresses: 0,
+			requiresVerification: false,
+			expectedStatusCode:   409,
+			upsertsRecords:       false,
+		},
+		{
+			name:                 "should error if email address is already in use",
+			email:                "john.doe@example.com",
+			userId:               uuid.FromStringOrNil("d41df4b7-c055-45e6-9faf-61aa92a4032e"),
+			requiresVerification: false,
+			maxNumberOfAddresses: 100,
+			expectedStatusCode:   400,
+			upsertsRecords:       false,
+			expectedEmailUserId:  uuid.FromStringOrNil("b5dd5267-b462-48be-b70d-bcd6f1bbe7a5"),
+		},
+		{
+			name:                 "should assign the email address to the user if not yet assigned and does not require verification",
+			email:                "john.doe+6@example.com",
+			userId:               uuid.FromStringOrNil("d41df4b7-c055-45e6-9faf-61aa92a4032e"),
+			requiresVerification: false,
+			maxNumberOfAddresses: 100,
+			expectedStatusCode:   200,
+			upsertsRecords:       true,
+			expectedEmailUserId:  uuid.FromStringOrNil("d41df4b7-c055-45e6-9faf-61aa92a4032e"),
+		},
+		{
+			name:                 "should not assign the email address to the user if not yet assigned and requires verification",
+			email:                "john.doe+7@example.com",
+			userId:               uuid.FromStringOrNil("d41df4b7-c055-45e6-9faf-61aa92a4032e"),
+			requiresVerification: true,
+			maxNumberOfAddresses: 100,
+			expectedStatusCode:   200,
+			upsertsRecords:       false,
+			expectedEmailUserId:  uuid.Nil,
+		},
+		{
+			name:                 "should create email record with nil user ID if verification required",
+			email:                "test.email.verification@example.com",
+			userId:               uuid.FromStringOrNil("d41df4b7-c055-45e6-9faf-61aa92a4032e"),
+			requiresVerification: true,
+			maxNumberOfAddresses: 100,
+			expectedStatusCode:   200,
+			upsertsRecords:       true,
+			expectedEmailUserId:  uuid.Nil,
+		},
+		{
+			name:                 "should create email record with user ID if verification not required",
+			email:                "test.email.noverification@example.com",
+			userId:               uuid.FromStringOrNil("d41df4b7-c055-45e6-9faf-61aa92a4032e"),
+			requiresVerification: false,
+			maxNumberOfAddresses: 100,
+			expectedStatusCode:   200,
+			upsertsRecords:       true,
+			expectedEmailUserId:  uuid.FromStringOrNil("d41df4b7-c055-45e6-9faf-61aa92a4032e"),
+		},
+	}
+
+	for _, currentTest := range tests {
+		s.Run(currentTest.name, func() {
+			cfg := test.DefaultConfig
+			cfg.Emails.RequireVerification = currentTest.requiresVerification
+			cfg.Emails.MaxNumOfAddresses = currentTest.maxNumberOfAddresses
+			e := NewPublicRouter(&cfg, s.Storage, nil)
+			jwkManager, err := jwk.NewDefaultManager(cfg.Secrets.Keys, s.Storage.GetJwkPersister())
+			s.Require().NoError(err)
+			sessionManager, err := session.NewManager(jwkManager, cfg)
+			s.Require().NoError(err)
+
+			token, err := sessionManager.GenerateJWT(currentTest.userId)
+			s.Require().NoError(err)
+			cookie, err := sessionManager.GenerateCookie(token)
+			s.Require().NoError(err)
+
+			body := dto.EmailCreateRequest{
+				Address: currentTest.email,
+			}
+			bodyJson, err := json.Marshal(body)
+			s.Require().NoError(err)
+
+			req := httptest.NewRequest(http.MethodPost, "/emails", bytes.NewReader(bodyJson))
+			req.Header.Set("Content-Type", "application/json")
+			req.AddCookie(cookie)
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			s.Equal(currentTest.expectedStatusCode, rec.Code)
+
+			email, err := s.Storage.GetEmailPersister().FindByAddress(currentTest.email)
+			s.Require().NoError(err)
+
+			if currentTest.upsertsRecords {
+				s.NotNil(email)
+			}
+
+			if email != nil {
+				if currentTest.expectedEmailUserId != uuid.Nil {
+					s.Equal(currentTest.expectedEmailUserId, *email.UserID)
+					return
+				}
+
+				s.Nil(email.UserID)
 			}
 		})
 	}

--- a/backend/test/fixtures/email/emails.yaml
+++ b/backend/test/fixtures/email/emails.yaml
@@ -34,3 +34,13 @@
   verified: true
   created_at: 2020-12-31 23:59:59
   updated_at: 2020-12-31 23:59:59
+- id: 5458fbb3-a58b-45df-ab06-937a3e1a140e
+  address: john.doe+6@example.com
+  verified: false
+  created_at: 2020-12-31 23:59:59
+  updated_at: 2020-12-31 23:59:59
+- id: 7c4473b8-ddcc-480b-b01f-df89e99f74c9
+  address: john.doe+7@example.com
+  verified: false
+  created_at: 2020-12-31 23:59:59
+  updated_at: 2020-12-31 23:59:59


### PR DESCRIPTION
# Description

While working on #1030 I noticed there weren't any unit tests for the email handler's create method. While I work through some blockers I'm facing working on this issue, I wanted to make a separate PR to add in tests.

# Implementation

Following examples of other tests, I've setup my tests to run as a list of scenarios.