### PR TITLE
🐞 fix(frontend-sdk): fix export types

### DIFF
--- a/frontend/frontend-sdk/package.json
+++ b/frontend/frontend-sdk/package.json
@@ -8,12 +8,15 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.d.ts",
   "type": "module",
   "source": "src/index.ts",
+  "types": "dist/index.d.ts",
   "exports": {
-    "require": "./dist/sdk.cjs",
-    "default": "./dist/sdk.modern.js"
+    ".": {
+      "require": "./dist/sdk.cjs",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/sdk.modern.js"
+    }
   },
   "main": "./dist/sdk.cjs",
   "module": "./dist/sdk.module.js",


### PR DESCRIPTION
# Description
Issue
```
Could not find a declaration file for module '@teamhanko/hanko-frontend-sdk'. 'd:/Git/sbte-refactor/node_modules/@teamhanko/hanko-frontend-sdk/dist/sdk.modern.js' implicitly has an 'any' type.
  There are types at 'd:/Git/sbte-refactor/node_modules/@teamhanko/hanko-frontend-sdk/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@teamhanko/hanko-frontend-sdk' library may need to update its package.json or typings.ts(7016)
```
Screenshot
![image](https://github.com/teamhanko/hanko/assets/86785660/571ff200-12eb-4c6b-8f25-3798773748f5)

closes #1072
closes #1069 


# Implementation

Types has to be exported in `package.json`. 



# Tests

![image](https://github.com/teamhanko/hanko/assets/86785660/b4da21ac-b5dc-4e5b-8040-04279df46c05)



# Additional context

Also #1069 fails to build elements in turbo repo. 
https://github.com/microsoft/TypeScript/issues/52363