### PR TITLE
chore: remove sonatype lift config

### DIFF
--- a/.lift/ignoreFiles
+++ b/.lift/ignoreFiles
@@ -1,3 +1,0 @@
-**/test/**
-**/*.min.js
-examples/**


### PR DESCRIPTION
# Description

Sonatype Lift has reached EOL in August 2023 and is no longer available for use. This removes the remaining CI configuration.

