### PR TITLE
added API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The remainder of the repository consists of:
 2. Head over to the [backend](/backend/README.md) to learn how to get it up and running for your own project. Use [Hanko Cloud](https://cloud.hanko.io) for a hosted backend.
 3. Then, integrate [hanko-elements](/frontend/elements/README.md) – we provide [example applications](frontend/examples/README.md) and [guides](https://docs.hanko.io/guides/frontend) for your favourite frontend framework in the official documentation
 
-If you want to use the Hanko backend API but prefer to build your own UI, you can still make use of the [hanko-frontend-sdk](/frontend/frontend-sdk/README.md). It forms the basis of our web components and the client it provides handles communication with the Hanko backend API and saves you the time of rolling your own.
+If you want to use the Hanko backend API but prefer to build your own UI, you can still make use of the [hanko-frontend-sdk](/frontend/frontend-sdk/README.md). It forms the basis of our web components and the client it provides handles communication with the [Hanko backend API](https://docs.hanko.io/api-reference/introduction) and saves you the time of rolling your own.
 
 # Contact us
 Schedule a Hanko demo. Learn how Hanko will speed up your registration and login flows with passkeys.


### PR DESCRIPTION

# Description

<!-- Brief description of WHAT you’re doing and WHY. -->
I provided a direct link to the hanko API, even though the link to the official documentation is already mentioned. I added the direct API reference link so that users can conveniently access the APIs in other languages directly from the provided link. This makes it easier for users and can save them some time as well. 

<img width="816" alt="image" src="https://github.com/teamhanko/hanko/assets/67964054/68037c70-5c09-48b6-8761-5960df520bab">

