### PR TITLE
ci: remove docs auto deploy on backend tag

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    tags: [ 'backend/v*.*.*' ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Description

The gh-pages action as it is configured seems to reset the custom domain value to docs.hanko.io in the repo's pages settings. This somehow leads to conflicts with the new docs because the static JS docs must be reachable at a teamhanko.github.io URL and not docs.hanko.io.

