### PR TITLE
Fix/1067/email server parallel

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,15 @@ jobs:
         go generate ./...
         go build -v ./...
 
+    - name: Start test Mailslurper container
+      working-directory: .
+      run: docker-compose -f ./backend/test/docker-compose.test.yaml up --build -d
+
     - name: Test
       working-directory: ./backend
       run: go test -v ./...
+
+    - name: Stop containers
+      if: always()
+      working-directory: .
+      run: docker-compose -f ./backend/test/docker-compose.test.yaml down

--- a/backend/handler/passcode_test.go
+++ b/backend/handler/passcode_test.go
@@ -38,7 +38,7 @@ func (s *passcodeSuite) TestPasscodeHandler_Init() {
 	cfg := func() *config.Config {
 		cfg := &test.DefaultConfig
 		cfg.Passcode.Smtp.Host = "localhost"
-		cfg.Passcode.Smtp.Port = fmt.Sprintf("%d", s.EmailServer.ServicePort)
+		cfg.Passcode.Smtp.Port = fmt.Sprintf("%d", s.EmailServer.SmtpPort)
 		return cfg
 	}
 

--- a/backend/handler/passcode_test.go
+++ b/backend/handler/passcode_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/suite"
 	"github.com/teamhanko/hanko/backend/config"
@@ -12,7 +13,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"testing"
 	"time"
 )
@@ -35,7 +35,14 @@ func (s *passcodeSuite) TestPasscodeHandler_Init() {
 	err := s.LoadFixtures("../test/fixtures/passcode")
 	s.Require().NoError(err)
 
-	e := NewPublicRouter(&test.DefaultConfig, s.Storage, nil)
+	cfg := func() *config.Config {
+		cfg := &test.DefaultConfig
+		cfg.Passcode.Smtp.Host = "localhost"
+		cfg.Passcode.Smtp.Port = fmt.Sprintf("%d", s.EmailServer.ServicePort)
+		return cfg
+	}
+
+	e := NewPublicRouter(cfg(), s.Storage, nil)
 
 	emailId := "51b7c175-ceb6-45ba-aae6-0092221c1b84"
 	unknownEmailId := "83618f24-2db8-4ea2-b370-ac8335f782d8"
@@ -91,9 +98,11 @@ func (s *passcodeSuite) TestPasscodeHandler_Init() {
 			e.ServeHTTP(rec, req)
 
 			if s.Equal(currentTest.expectedStatusCode, rec.Code) && currentTest.expectedStatusCode >= 200 && currentTest.expectedStatusCode <= 299 {
-				messages := s.EmailServer.Messages()
+				emails, err := s.EmailServer.GetEmails()
+				s.Require().NoError(err)
+				messages := emails.MailItems
 
-				emailAddress := s.GetToEmailAddress(messages[len(messages)-1].MsgRequest())
+				emailAddress := messages[len(messages)-1].ToAddresses[0]
 				s.Equal(currentTest.expectedEmailAddress, emailAddress)
 			}
 		})
@@ -243,18 +252,4 @@ func (s *passcodeSuite) TestPasscodeHandler_Finish() {
 			_ = s.Storage.GetPasscodePersister().Delete(currentTest.passcode)
 		})
 	}
-}
-
-func (s *passcodeSuite) GetToEmailAddress(data string) string {
-	to := regexp.MustCompile("To: (.*)\r")
-	matchTo := to.FindStringSubmatch(data)
-
-	return matchTo[1]
-}
-
-func (s *passcodeSuite) GetPasscode(data string) string {
-	passcode := regexp.MustCompile("Subject: Use passcode ([0-9]{1,6}) to sign in to Test")
-	matchPasscode := passcode.FindStringSubmatch(data)
-
-	return matchPasscode[1]
 }

--- a/backend/test/config/mailslurper.json
+++ b/backend/test/config/mailslurper.json
@@ -1,0 +1,18 @@
+{
+  "wwwAddress": "0.0.0.0",
+  "wwwPort": 9080,
+  "serviceAddress": "0.0.0.0",
+  "servicePort": 9085,
+  "smtpAddress": "0.0.0.0",
+  "smtpPort": 3500,
+  "dbEngine": "SQLite",
+  "dbHost": "",
+  "dbPort": 0,
+  "dbDatabase": "./mailslurper.db",
+  "dbUserName": "",
+  "dbPassword": "",
+  "maxWorkers": 1000,
+  "autoStartBrowser": false,
+  "keyFile": "",
+  "certFile": ""
+}

--- a/backend/test/docker-compose.test.yaml
+++ b/backend/test/docker-compose.test.yaml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  mailslurper:
+    image: "marcopas/docker-mailslurper"
+    ports:
+      - "9080:9080"
+      - "9085:9085"
+      - "3500:3500"
+    volumes:
+      - ./config/mailslurper.json:/opt/mailslurper/config.json

--- a/backend/test/mailslurper_interceptor.go
+++ b/backend/test/mailslurper_interceptor.go
@@ -12,6 +12,7 @@ import (
 
 type MailslurperConfiguration struct {
 	ServicePort int `json:"servicePort" required:"true"`
+	SmtpPort    int `json:"smtpPort" required:"true"`
 }
 
 func NewMailslurperInterceptor() (*mailslurperInterceptor, error) {
@@ -28,13 +29,13 @@ func NewMailslurperInterceptor() (*mailslurperInterceptor, error) {
 	}
 	return &mailslurperInterceptor{
 		ServiceBaseUrl: fmt.Sprintf("http://localhost:%d", config.ServicePort),
-		ServicePort:    config.ServicePort,
+		SmtpPort:       config.SmtpPort,
 	}, nil
 }
 
 type mailslurperInterceptor struct {
 	ServiceBaseUrl string
-	ServicePort    int
+	SmtpPort       int
 }
 
 type GetEmailResponse struct {
@@ -66,8 +67,4 @@ func (m *mailslurperInterceptor) GetEmails() (*GetEmailResponse, error) {
 		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 	return &result, nil
-}
-
-func (m *mailslurperInterceptor) GetEmailPort() int {
-	return m.ServicePort
 }

--- a/backend/test/mailslurper_interceptor.go
+++ b/backend/test/mailslurper_interceptor.go
@@ -1,0 +1,73 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"runtime"
+)
+
+type MailslurperConfiguration struct {
+	ServicePort int `json:"servicePort" required:"true"`
+}
+
+func NewMailslurperInterceptor() (*mailslurperInterceptor, error) {
+	_, b, _, _ := runtime.Caller(0)
+	testRoot := path.Dir(b)
+	jsonFile, err := os.Open(path.Join(testRoot, "config", "mailslurper.json"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open mailslurper config: %w", err)
+	}
+	defer jsonFile.Close()
+	var config MailslurperConfiguration
+	if err := json.NewDecoder(jsonFile).Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to decode mailslurper config: %w", err)
+	}
+	return &mailslurperInterceptor{
+		ServiceBaseUrl: fmt.Sprintf("http://localhost:%d", config.ServicePort),
+		ServicePort:    config.ServicePort,
+	}, nil
+}
+
+type mailslurperInterceptor struct {
+	ServiceBaseUrl string
+	ServicePort    int
+}
+
+type GetEmailResponse struct {
+	MailItems []GetEmailResponseMailItem `json:"mailItems"`
+}
+
+type GetEmailResponseMailItem struct {
+	Id          string   `json:"id"`
+	DateSent    string   `json:"dateSent"`
+	FromAddress string   `json:"fromAddress"`
+	ToAddresses []string `json:"toAddresses"`
+	Subject     string   `json:"subject"`
+	Body        string   `json:"body"`
+	ContentType string   `json:"contentType"`
+}
+
+func (m *mailslurperInterceptor) GetEmails() (*GetEmailResponse, error) {
+	response, err := http.Get(fmt.Sprintf("%s/mail", m.ServiceBaseUrl))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get emails from mailslurper: %w", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	var result GetEmailResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+	return &result, nil
+}
+
+func (m *mailslurperInterceptor) GetEmailPort() int {
+	return m.ServicePort
+}

--- a/backend/test/suite.go
+++ b/backend/test/suite.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/pop/v6/logging"
 	"github.com/gofrs/uuid"
-	smtpmock "github.com/mocktools/go-smtp-mock/v2"
 	"github.com/stretchr/testify/suite"
 	"github.com/teamhanko/hanko/backend/config"
 	"github.com/teamhanko/hanko/backend/persistence"
@@ -17,7 +16,7 @@ type Suite struct {
 	suite.Suite
 	Storage         persistence.Storage
 	DB              *TestDB
-	EmailServer     *smtpmock.Server
+	EmailServer     *mailslurperInterceptor
 	Name            string // used for database docker container name, so that tests can run in parallel
 	WithEmailServer bool
 }
@@ -45,13 +44,8 @@ func (s *Suite) SetupSuite() {
 	s.Require().NoError(err)
 
 	if s.WithEmailServer {
-		server := smtpmock.New(smtpmock.ConfigurationAttr{
-			PortNumber: 2500,
-		})
-
-		err = server.Start()
+		s.EmailServer, err = NewMailslurperInterceptor()
 		s.Require().NoError(err)
-		s.EmailServer = server
 	}
 
 	s.Storage = storage
@@ -75,9 +69,6 @@ func (s *Suite) TearDownTest() {
 func (s *Suite) TearDownSuite() {
 	if s.DB != nil {
 		s.NoError(PurgeDB(s.DB))
-	}
-	if s.EmailServer != nil {
-		s.NoError(s.EmailServer.Stop())
 	}
 }
 


### PR DESCRIPTION
# Description

This pull request resolves an issue described in PR #1067 , which will help resolve issue blocking #1030. The crux of the issue is that the current EmailServer solution is run per test suite. If multiple tests rely on an email server, it will attempt to create multiple instances of a mock SMTP server and will fail the test suite if these tests overlap. There isn't a clean way to get around this issue, even forcing tests to run non-parallel does not help, nor does ignoring errors where an existing server is already running. 

To get around this issue, I propose that we start up a separate Mailslurper Docker container that our tests will use. Mailslurper offers a good API we can use to fetch sent emails, so it helps us write assertions around emails. The downside is that this Docker instance will need to be spun up before tests are ran, so there's overhead in it. But it's the only solution I see possible for now. If alternative solutions are possible, I'd be curious to learn what they are.

In order for this test Mailslurper instance to not interfere with existing Mailslurper instances already running, the test Mailslurper container will run on different ports. i.e. 9080 / 9085 vs 8080 / 8085.

# Implementation

- Create a docker compose script in the `backend/test` directory that feeds in a configuration file defined in `backend/test/config`. This will override default web / API / SMTP ports to 9080 / 9085 / 3500, respectively. Then, I created a class that can reach out to the Mailslurper API to fetch emails sent. Using this, I've re-written the `passcode` tests to use this new class to assert on emails sent.

- Modified the go.yml PR workflow to spin up a Mailslurper Docker container before running tests, and then spin this container down after tests run.
