### PR TITLE
Flowpilot subflow updates and fixes

### DIFF
--- a/backend/flow_api_test/flow.go
+++ b/backend/flow_api_test/flow.go
@@ -7,19 +7,16 @@ import (
 
 var ThirdSubFlow = flowpilot.NewSubFlow().
 	State(StateThirdSubFlowInit, EndSubFlow{}, Back{}).
-	FixedStates(StateThirdSubFlowInit).
 	MustBuild()
 
 var SecondSubFlow = flowpilot.NewSubFlow().
 	State(StateSecondSubFlowInit, ContinueToFinal{}, Back{}).
 	State(StateSecondSubFlowFinal, EndSubFlow{}, Back{}).
-	FixedStates(StateSecondSubFlowInit).
 	MustBuild()
 
 var FirstSubFlow = flowpilot.NewSubFlow().
 	State(StateFirstSubFlowInit, StartSecondSubFlow{}, Back{}).
 	SubFlows(SecondSubFlow).
-	FixedStates(StateFirstSubFlowInit).
 	MustBuild()
 
 var Flow = flowpilot.NewFlow("/flow_api_login").
@@ -35,8 +32,6 @@ var Flow = flowpilot.NewFlow("/flow_api_login").
 	State(StatePasswordCreation, SubmitNewPassword{}).
 	State(StateConfirmPasskeyCreation, GetWAAssertion{}, SkipPasskeyCreation{}).
 	State(StateCreatePasskey, VerifyWAAssertion{}).
-	State(StateError).
-	State(StateSuccess).
 	FixedStates(StateSignInOrSignUp, StateError, StateSuccess).
 	SubFlows(FirstSubFlow, ThirdSubFlow).
 	TTL(time.Minute * 10).

--- a/backend/flowpilot/context.go
+++ b/backend/flowpilot/context.go
@@ -26,7 +26,7 @@ type flowContext interface {
 	// CurrentStateEquals returns true, when one of the given states matches the current state.
 	CurrentStateEquals(states ...StateName) bool
 	// GetPreviousState returns the previous state of the flow.
-	GetPreviousState() *StateName
+	GetPreviousState() (*StateName, error)
 	// GetErrorState returns the designated error state of the flow.
 	GetErrorState() StateName
 	// GetEndState returns the final state of the flow.

--- a/backend/flowpilot/context_action_exec.go
+++ b/backend/flowpilot/context_action_exec.go
@@ -67,7 +67,7 @@ func (aec *defaultActionExecutionContext) continueFlow(nextState StateName, flow
 	}
 
 	stateExists := detail.flow.stateExists(nextState)
-	subFlowEntryStateAllowed := detail.subFlows.isEntryStateAllowed(nextState)
+	subFlowEntryStateAllowed := detail.subFlows.stateExists(nextState)
 
 	// Check if the specified nextState is valid.
 	if !(stateExists ||
@@ -168,7 +168,7 @@ func (aec *defaultActionExecutionContext) ContinueToPreviousState() error {
 	}
 
 	if unscheduledState != nil {
-		err = aec.stash.addScheduledStates(*nextState)
+		err = aec.stash.addScheduledStates(*unscheduledState)
 		if err != nil {
 			return fmt.Errorf("failed add scheduled states: %w", err)
 		}
@@ -198,7 +198,7 @@ func (aec *defaultActionExecutionContext) StartSubFlow(entryState StateName, nex
 	}
 
 	// the specified entry state must be an entry state to a sub-flow of the current flow
-	if entryStateAllowed := detail.subFlows.isEntryStateAllowed(entryState); !entryStateAllowed {
+	if entryStateAllowed := detail.subFlows.stateExists(entryState); !entryStateAllowed {
 		return fmt.Errorf("the specified entry state '%s' is not associated with a sub-flow of the current flow", entryState)
 	}
 
@@ -207,18 +207,18 @@ func (aec *defaultActionExecutionContext) StartSubFlow(entryState StateName, nex
 	// validate the specified nextStates and append valid state to the list of scheduledStates
 	for index, nextState := range nextStates {
 		stateExists := detail.flow.stateExists(nextState)
-		subFlowEntryStateAllowed := detail.subFlows.isEntryStateAllowed(nextState)
+		subFlowEntryStateAllowed := detail.subFlows.stateExists(nextState)
 
 		// validate the current next state
 		if index == len(nextStates)-1 {
 			// the last state must be a member of the current flow or a sub-flow entry state
 			if !stateExists && !subFlowEntryStateAllowed {
-				return fmt.Errorf("the last next state '%s' specified is not a sub-flow entry state or another state associated with the current flow", nextState)
+				return fmt.Errorf("the last next state '%s' specified is not a sub-flow state or another state associated with the current flow", nextState)
 			}
 		} else {
 			// every other state must be a sub-flow entry state
 			if !subFlowEntryStateAllowed {
-				return fmt.Errorf("the specified next state '%s' is not a sub-flow entry state of the current flow", nextState)
+				return fmt.Errorf("the specified next state '%s' is not a sub-flow state of the current flow", nextState)
 			}
 		}
 

--- a/backend/flowpilot/context_action_exec.go
+++ b/backend/flowpilot/context_action_exec.go
@@ -216,7 +216,7 @@ func (aec *defaultActionExecutionContext) StartSubFlow(entryState StateName, nex
 				return fmt.Errorf("the last next state '%s' specified is not a sub-flow state or another state associated with the current flow", nextState)
 			}
 		} else {
-			// every other state must be a sub-flow entry state
+			// every other state must be a sub-flow state
 			if !subFlowEntryStateAllowed {
 				return fmt.Errorf("the specified next state '%s' is not a sub-flow state of the current flow", nextState)
 			}

--- a/backend/flowpilot/context_action_exec.go
+++ b/backend/flowpilot/context_action_exec.go
@@ -211,7 +211,7 @@ func (aec *defaultActionExecutionContext) StartSubFlow(entryState StateName, nex
 
 		// validate the current next state
 		if index == len(nextStates)-1 {
-			// the last state must be a member of the current flow or a sub-flow entry state
+			// the last state must be a member of the current flow or a sub-flow
 			if !stateExists && !subFlowEntryStateAllowed {
 				return fmt.Errorf("the last next state '%s' specified is not a sub-flow state or another state associated with the current flow", nextState)
 			}

--- a/backend/flowpilot/context_flow.go
+++ b/backend/flowpilot/context_flow.go
@@ -46,14 +46,9 @@ func (fc *defaultFlowContext) CurrentStateEquals(stateNames ...StateName) bool {
 }
 
 // GetPreviousState returns a pointer to the previous state of the flow.
-func (fc *defaultFlowContext) GetPreviousState() *StateName {
-	state, _, _, _ := fc.stash.getLastStateFromHistory()
-
-	if state == nil {
-		state = &fc.flow.initialState
-	}
-
-	return state
+func (fc *defaultFlowContext) GetPreviousState() (*StateName, error) {
+	state, _, _, err := fc.stash.getLastStateFromHistory()
+	return state, err
 }
 
 // GetErrorState returns the designated error state of the flow.


### PR DESCRIPTION
# Description

- Sub-flows can now be started with any sub-flow state and they don't have initial states anymore in consequence
- Fixes an an issue with the `ContinueToPreviousState()` function
- Flow validation now happens when building the flow
- Refactoring 
