### PR TITLE
feat: adds the possibility to set context values to the flow

### DIFF
--- a/backend/flowpilot/builder.go
+++ b/backend/flowpilot/builder.go
@@ -207,6 +207,7 @@ func (fb *defaultFlowBuilder) Build() (Flow, error) {
 		ttl:              fb.ttl,
 		debug:            fb.debug,
 		defaultFlowBase:  dfb,
+		contextValues:    make(contextValues),
 	}
 
 	if err := fb.scanFlowStates(flow); err != nil {

--- a/backend/flowpilot/context.go
+++ b/backend/flowpilot/context.go
@@ -11,6 +11,8 @@ import (
 
 // flowContext represents the basic context for a flow.
 type flowContext interface {
+	// Get returns the context value with the given name.
+	Get(string) interface{}
 	// GetFlowID returns the unique ID of the current defaultFlow.
 	GetFlowID() uuid.UUID
 	// GetPath returns the current path within the flow.
@@ -113,7 +115,7 @@ func createAndInitializeFlow(db FlowDB, flow defaultFlow) (FlowResult, error) {
 
 	// Create a new flow model with the provided parameters.
 	flowCreation := flowCreationParam{currentState: flow.initialStateName, expiresAt: expiresAt}
-	flowModel, err := dbw.CreateFlowWithParam(flowCreation)
+	flowModel, err := dbw.createFlowWithParam(flowCreation)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create flow: %w", err)
 	}

--- a/backend/flowpilot/context_action_exec.go
+++ b/backend/flowpilot/context_action_exec.go
@@ -30,7 +30,7 @@ func (aec *defaultActionExecutionContext) saveNextState(executionResult executio
 	}
 
 	// Update the flow model in the database.
-	if _, err := aec.dbw.UpdateFlowWithParam(flowUpdate); err != nil {
+	if _, err := aec.dbw.updateFlowWithParam(flowUpdate); err != nil {
 		return fmt.Errorf("failed to store updated flow: %w", err)
 	}
 
@@ -48,7 +48,7 @@ func (aec *defaultActionExecutionContext) saveNextState(executionResult executio
 	}
 
 	// Create a new Transition in the database.
-	if _, err := aec.dbw.CreateTransitionWithParam(transitionCreation); err != nil {
+	if _, err := aec.dbw.createTransitionWithParam(transitionCreation); err != nil {
 		return fmt.Errorf("failed to store a new transition: %w", err)
 	}
 

--- a/backend/flowpilot/context_flow.go
+++ b/backend/flowpilot/context_flow.go
@@ -10,7 +10,7 @@ type defaultFlowContext struct {
 	payload   Payload       // JSONManager for payload data.
 	stash     Stash         // JSONManager for stash data.
 	flow      defaultFlow   // The associated defaultFlow instance.
-	dbw       FlowDBWrapper // Wrapped FlowDB instance with additional functionality.
+	dbw       flowDBWrapper // Wrapped FlowDB instance with additional functionality.
 	flowModel FlowModel     // The current FlowModel.
 }
 
@@ -70,6 +70,11 @@ func (fc *defaultFlowContext) StateExists(stateName StateName) bool {
 	}
 
 	return false
+}
+
+// Get returns the context value with the given name.
+func (fc *defaultFlowContext) Get(name string) interface{} {
+	return fc.flow.contextValues[name]
 }
 
 // FetchActionInput fetches input data for a specific action.

--- a/backend/flowpilot/db.go
+++ b/backend/flowpilot/db.go
@@ -42,22 +42,22 @@ type FlowDB interface {
 	FindLastTransitionWithAction(flowID uuid.UUID, method ActionName) (*TransitionModel, error)
 }
 
-// FlowDBWrapper is an extended FlowDB interface that includes additional methods.
-type FlowDBWrapper interface {
+// flowDBWrapper is an extended FlowDB interface that includes additional methods.
+type flowDBWrapper interface {
 	FlowDB
-	CreateFlowWithParam(p flowCreationParam) (*FlowModel, error)
-	UpdateFlowWithParam(p flowUpdateParam) (*FlowModel, error)
-	CreateTransitionWithParam(p transitionCreationParam) (*TransitionModel, error)
+	createFlowWithParam(p flowCreationParam) (*FlowModel, error)
+	updateFlowWithParam(p flowUpdateParam) (*FlowModel, error)
+	createTransitionWithParam(p transitionCreationParam) (*TransitionModel, error)
 }
 
-// DefaultFlowDBWrapper wraps a FlowDB instance to provide additional functionality.
-type DefaultFlowDBWrapper struct {
+// defaultFlowDBWrapper wraps a FlowDB instance to provide additional functionality.
+type defaultFlowDBWrapper struct {
 	FlowDB
 }
 
-// wrapDB wraps a FlowDB instance to provide FlowDBWrapper functionality.
-func wrapDB(db FlowDB) FlowDBWrapper {
-	return &DefaultFlowDBWrapper{FlowDB: db}
+// wrapDB wraps a FlowDB instance to provide flowDBWrapper functionality.
+func wrapDB(db FlowDB) flowDBWrapper {
+	return &defaultFlowDBWrapper{FlowDB: db}
 }
 
 // flowCreationParam holds parameters for creating a new defaultFlow.
@@ -67,7 +67,7 @@ type flowCreationParam struct {
 }
 
 // CreateFlowWithParam creates a new defaultFlow with the given parameters.
-func (w *DefaultFlowDBWrapper) CreateFlowWithParam(p flowCreationParam) (*FlowModel, error) {
+func (w *defaultFlowDBWrapper) createFlowWithParam(p flowCreationParam) (*FlowModel, error) {
 	// Generate a new UUID for the defaultFlow.
 	flowID, err := uuid.NewV4()
 	if err != nil {
@@ -105,7 +105,7 @@ type flowUpdateParam struct {
 }
 
 // UpdateFlowWithParam updates the specified defaultFlow with the given parameters.
-func (w *DefaultFlowDBWrapper) UpdateFlowWithParam(p flowUpdateParam) (*FlowModel, error) {
+func (w *defaultFlowDBWrapper) updateFlowWithParam(p flowUpdateParam) (*FlowModel, error) {
 	// Prepare the updated FlowModel.
 	fm := FlowModel{
 		ID:           p.flowID,
@@ -137,7 +137,7 @@ type transitionCreationParam struct {
 }
 
 // CreateTransitionWithParam creates a new Transition with the given parameters.
-func (w *DefaultFlowDBWrapper) CreateTransitionWithParam(p transitionCreationParam) (*TransitionModel, error) {
+func (w *defaultFlowDBWrapper) createTransitionWithParam(p transitionCreationParam) (*TransitionModel, error) {
 	// Generate a new UUID for the Transition.
 	transitionID, err := uuid.NewV4()
 	if err != nil {

--- a/backend/flowpilot/flow.go
+++ b/backend/flowpilot/flow.go
@@ -126,12 +126,18 @@ type flowBase interface {
 
 // Flow represents a flow.
 type Flow interface {
+	// Execute executes the flow using the provided FlowDB and options.
+	// It returns the result of the flow execution and an error if any.
 	Execute(db FlowDB, opts ...func(*flowExecutionOptions)) (FlowResult, error)
+	// ResultFromError converts an error into a FlowResult.
 	ResultFromError(err error) FlowResult
-
+	// Set sets a value with the given key in the flow context.
+	Set(string, interface{})
+	// setDefaults sets the default values for the flow.
 	setDefaults()
+	// getState retrieves the details of a specific state in the flow.
 	getState(stateName StateName) (*stateDetail, error)
-
+	// Embed the flowBase interface.
 	flowBase
 }
 
@@ -139,6 +145,8 @@ type Flow interface {
 type SubFlow interface {
 	flowBase
 }
+
+type contextValues map[string]interface{}
 
 type defaultFlowBase struct {
 	flow        stateActions // StateName to Actions mapping.
@@ -155,8 +163,13 @@ type defaultFlow struct {
 	errorStateName   StateName     // State representing errors.
 	ttl              time.Duration // Time-to-live for the flow.
 	debug            bool          // Enables debug mode.
+	contextValues    contextValues // Values to be used within the flow context.
 
 	defaultFlowBase
+}
+
+func (f *defaultFlow) Set(name string, value interface{}) {
+	f.contextValues[name] = value
 }
 
 // getActionsForState returns state details for the specified state.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

- you can now set a value to the flow, e.g. `bar := &Bar{}; Flow.Set("foo", bar)` and get the value within a flow action like `bar := c.Get("foo").(*Bar)`
- refactoring: the db wrapper interface and related structs and methods are now private.