### PR TITLE
fix: improve passcode email text

### DIFF
--- a/backend/mail/locales/passcode.en.yaml
+++ b/backend/mail/locales/passcode.en.yaml
@@ -1,9 +1,9 @@
 login_text:
   description: "The sign in content of the text email."
-  other: "Enter the following passcode on your login screen:"
+  other: "Enter the following passcode to verify your identity:"
 ttl_text:
   description: "The length how long the passcode is valid."
   other: "The passcode is valid for {{ .TTL }} minutes."
 email_subject_login:
   description: ""
-  other: "Use passcode {{ .Code }} to sign in to {{ .ServiceName }}"
+  other: "{{ .Code }} is your passcode for {{ .ServiceName }}"


### PR DESCRIPTION
Passcodes are not only used for logins, but also for email verification. This PR aims to generalize the wording to reflect that.