### PR TITLE
fix: reload the profile after passkey creation

### DIFF
--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -145,7 +145,7 @@ const AppProvider = ({
         hanko.onUserDeleted(init);
         break;
       case "profile":
-        hanko.onSessionCreated(init);
+        hanko.onAuthFlowCompleted(init);
         break;
     }
   }, [componentName, hanko, init]);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

The passkey list in the profile remained empty after account creation (incl. passkey onboarding), when embedding hanko-auth and hanko-profile on the same page. 

# Implementation

- Changed the profile to initialize when the "onAuthFlowCompleted" has been received (instead of "onSessionCreated").

# Additional context

fixes #1138