### PR TITLE
feat(elements): introduce a loading-spinner-container shadow part

### DIFF
--- a/frontend/elements/README.md
+++ b/frontend/elements/README.md
@@ -440,6 +440,7 @@ The following parts are available:
 - `divider-text` - the divider text
 - `divider-line` - the line before and after the `divider-text`
 - `form-item` - the container of a form item, e.g. an input field or a button
+- `loading-spinner-container` - a container that wraps texts or icons to be replaced by a loading spinner.
 
 #### Examples
 

--- a/frontend/elements/src/components/icons/LoadingSpinner.tsx
+++ b/frontend/elements/src/components/icons/LoadingSpinner.tsx
@@ -19,18 +19,21 @@ const LoadingSpinner = ({
   secondary,
   hasIcon,
 }: Props) => {
+  const partName = "loading-spinner-container";
+
   return (
     <Fragment>
       {isLoading ? (
-        <div className={styles.loadingSpinnerWrapper}>
+        <div className={styles.loadingSpinnerWrapper} part={partName}>
           <Icon name={"spinner"} secondary={secondary} />
         </div>
       ) : isSuccess ? (
-        <div className={styles.loadingSpinnerWrapper}>
+        <div className={styles.loadingSpinnerWrapper} part={partName}>
           <Icon name={"checkmark"} secondary={secondary} fadeOut={fadeOut} />
         </div>
       ) : (
         <div
+          part={partName}
           className={
             hasIcon
               ? styles.loadingSpinnerWrapperIcon


### PR DESCRIPTION
# Implementation

Adds a new shadow part for the loading spinner container. One use-case is to align the text shown within the container. E.g. `hanko-auth::part(loading-spinner-container) {  justify-content: center; }` would center the text which is going to be replaced by an centered loading-spinner when the element switches to a loading state. 

# Additional context

This feature has been requested by a community member (discord).
