### PR TITLE
feat(elements): inherit the justify-content property when using shadow…

### DIFF
--- a/frontend/elements/src/components/form/Button.tsx
+++ b/frontend/elements/src/components/form/Button.tsx
@@ -71,6 +71,7 @@ const Button = ({
         isSuccess={isSuccess}
         secondary={true}
         hasIcon={!!icon}
+        maxWidth
       >
         {icon ? (
           <Icon

--- a/frontend/elements/src/components/form/styles.sass
+++ b/frontend/elements/src/components/form/styles.sass
@@ -35,6 +35,7 @@
   transition: 0.1s ease-out
   flex-grow: 1
   flex-shrink: 1
+  display: inline-flex
 
   &:disabled
     cursor: default
@@ -43,6 +44,7 @@
     color: variables.$brand-contrast-color
     background: variables.$brand-color
     border-color: variables.$brand-color
+    justify-content: center
 
   &.primary:hover
     color: variables.$brand-contrast-color
@@ -63,6 +65,7 @@
     color: variables.$color
     background: variables.$background-color
     border-color: variables.$color
+    justify-content: left
 
   &.secondary:hover
     color: variables.$color

--- a/frontend/elements/src/components/icons/LoadingSpinner.tsx
+++ b/frontend/elements/src/components/icons/LoadingSpinner.tsx
@@ -1,6 +1,7 @@
 import { ComponentChildren, Fragment } from "preact";
 import styles from "./styles.sass";
 import Icon from "./Icon";
+import cx from "classnames";
 
 export type Props = {
   children?: ComponentChildren;
@@ -9,6 +10,7 @@ export type Props = {
   fadeOut?: boolean;
   secondary?: boolean;
   hasIcon?: boolean;
+  maxWidth?: boolean;
 };
 
 const LoadingSpinner = ({
@@ -18,15 +20,16 @@ const LoadingSpinner = ({
   fadeOut,
   secondary,
   hasIcon,
+  maxWidth,
 }: Props) => {
   return (
     <Fragment>
       {isLoading ? (
-        <div className={styles.loadingSpinnerWrapper}>
+        <div className={cx(styles.loadingSpinnerWrapper, styles.centerContent, maxWidth && styles.maxWidth)}>
           <Icon name={"spinner"} secondary={secondary} />
         </div>
       ) : isSuccess ? (
-        <div className={styles.loadingSpinnerWrapper}>
+        <div className={cx(styles.loadingSpinnerWrapper, styles.centerContent,  maxWidth && styles.maxWidth)}>
           <Icon name={"checkmark"} secondary={secondary} fadeOut={fadeOut} />
         </div>
       ) : (

--- a/frontend/elements/src/components/icons/styles.sass
+++ b/frontend/elements/src/components/icons/styles.sass
@@ -41,7 +41,6 @@
 
 .loadingSpinnerWrapperIcon
   @extend .loadingSpinnerWrapper
-  justify-content: flex-start
   width: 100%
   column-gap: 10px
   margin-left: 10px
@@ -51,6 +50,13 @@
   align-items: center
   height: 100%
   margin: 0 5px
+  justify-content: inherit
+
+  &.centerContent
+    justify-content: center
+
+  &.maxWidth
+    width: 100%
 
   .loadingSpinner
     @extend .icon


### PR DESCRIPTION
# Description

The `justify-content` property for buttons is now inherited, so you can use e.g. `hanko-auth::part(secondary-button) { justify-content: center; }` to center the contents of the secondary button.
