### PR TITLE
chore(dockerfile): update Node.js version for compatibility in Next.j…

### DIFF
--- a/frontend/examples/nextjs/Dockerfile
+++ b/frontend/examples/nextjs/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM node:16-alpine
+FROM node:18.17-alpine
 
 # set working directory
 WORKDIR /app


### PR DESCRIPTION
# Description

I encountered an error while attempting to run the Next.js quick start. The error message is as follows:

```
/app/node_modules/next/dist/server/web/spec-extension/request.js:28
class NextRequest extends Request {
                          ^

ReferenceError: Request is not defined
    at Object.<anonymous> (/app/node_modules/next/dist/server/web/spec-extension/request.js:28:27)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1252:10)
    at Module.load (node:internal/modules/cjs/loader:1076:32)
    at Function.Module._load (node:internal/modules/cjs/loader:911:12)
    at Module.require (node:internal/modules/cjs/loader:1100:19)
    at Module.mod.require (/app/node_modules/next/dist/server/require-hook.js:64:28)
    at require (node:internal/modules/cjs/helpers:119:18)
    at Object.<anonymous> (/app/node_modules/next/dist/server/web/spec-extension/adapters/next-request.js:37:18)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
```
I investigated the issue and found that the error is related to a missing import for the Request class. To resolve this, I checked the Next.js documentation [here](https://nextjs.org/docs/getting-started/installation) and identified that the minimum Node.js version required is 18.17.
