### PR TITLE
fix(flowpilot): email regex match on empty or nil input value

### DIFF
--- a/backend/flowpilot/input.go
+++ b/backend/flowpilot/input.go
@@ -242,7 +242,7 @@ func (i *DefaultInput) validate(stateName StateName, inputData ReadOnlyActionInp
 		}
 	}
 
-	if i.dataType == EmailType && !isRequired && !hasEmptyOrNilValue {
+	if i.dataType == EmailType && (isRequired || (!isRequired && !hasEmptyOrNilValue)) {
 		pattern := regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
 		if matched := pattern.MatchString(*inputValue); !matched {
 			i.error = ErrorEmailInvalid


### PR DESCRIPTION
# Description

Input validation currently attempts a regex match on email input values even if the input is optional but empty or nil. The match fails and validation returns an error.

# Implementation

These changes fix it by first checking if the input is optional and whether it has an empty or nil value.


