### PR TITLE
ci: enable dependabot version updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,10 @@ updates:
     # Always increase the version requirement
     # to match the new version.
     versioning-strategy: increase
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`.
+    # (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Description

On inspection of a failed workflow run I noticed deprecation warnings regarding the version of some of the actions used in the workflow, e.g.:

<img width="1394" alt="Screenshot 2024-02-02 at 17 58 50" src="https://github.com/teamhanko/hanko/assets/67686424/4fe11184-f0bd-4fd7-8790-b6f8614794ee">

As long as workflow runs are successful there is barely any reason for further inspection of the runs so there is a high chance these warnings go unnoticed. We should let dependabot watch and update versions if necessary.

# Implementation

I edited the dependabot configuration according to the [GitHub docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions).

# Todos

This updates only the dependabot configuration. I deliberately did not update the workflows/actions. My expectation is that dependabot will provide PRs to do this. 
