### PR TITLE
feat(flow-api): share email verification hook

### DIFF
--- a/backend/flow_api/flow/login/flow.go
+++ b/backend/flow_api/flow/login/flow.go
@@ -51,6 +51,7 @@ var Flow = flowpilot.NewFlow("/login").
 	State(shared.StateError).
 	SubFlows(capabilities.SubFlow, passkey_onboarding.SubFlow, passcode.SubFlow).
 	InitialState(capabilities.StatePreflight, StateLoginInit).
+	AfterState(passcode.StatePasscodeConfirmation, shared.EmailPersistVerifiedStatus{}).
 	ErrorState(shared.StateError).
 	TTL(10 * time.Minute).
 	MustBuild()

--- a/backend/flow_api/flow/profile/flow.go
+++ b/backend/flow_api/flow/profile/flow.go
@@ -47,7 +47,7 @@ var Flow = flowpilot.NewFlow("/profile").
 	).
 	State(StateProfileWebauthnCredentialVerification, WebauthnVerifyAttestationResponse{}).
 	AfterState(StateProfileWebauthnCredentialVerification, WebauthnCredentialSave{}).
-	AfterState(passcode.StatePasscodeConfirmation, EmailSetVerified{}).
+	AfterState(passcode.StatePasscodeConfirmation, shared.EmailPersistVerifiedStatus{}).
 	State(StateProfileAccountDeleted).
 	ErrorState(shared.StateError).
 	SubFlows(capabilities.SubFlow, passcode.SubFlow).


### PR DESCRIPTION
# Description

The hook for persisting the email verification status (after passcode confirmation) is currently only available  in the profile flow but the login flow also needs it, e.g. if email verification was activated retroactively and users logging in with previously unverified email addresses should also have said email's verification status persisted as verified after passcode confirmation.

# Implementation

- Rename the hook to make it more obvious that it is responsible for persisting the verification status for an email after verification.
- Move it to the shared package and apply to both profile and login flow.
- Add a noop case if the email address already exists and is also already verfified.