### PR TITLE
fix: fix concurrency issue

### DIFF
--- a/backend/flow_api/flow/login/flow.go
+++ b/backend/flow_api/flow/login/flow.go
@@ -53,5 +53,4 @@ var Flow = flowpilot.NewFlow("/login").
 	InitialState(capabilities.StatePreflight, StateLoginInit).
 	AfterState(passcode.StatePasscodeConfirmation, shared.EmailPersistVerifiedStatus{}).
 	ErrorState(shared.StateError).
-	TTL(10 * time.Minute).
-	MustBuild()
+	TTL(10 * time.Minute)

--- a/backend/flow_api/flow/profile/flow.go
+++ b/backend/flow_api/flow/profile/flow.go
@@ -52,5 +52,4 @@ var Flow = flowpilot.NewFlow("/profile").
 	ErrorState(shared.StateError).
 	SubFlows(capabilities.SubFlow, passcode.SubFlow).
 	TTL(10 * time.Minute).
-	Debug(true).
-	MustBuild()
+	Debug(true)

--- a/backend/flow_api/flow/registration/flow.go
+++ b/backend/flow_api/flow/registration/flow.go
@@ -30,5 +30,4 @@ var Flow = flowpilot.NewFlow("/registration").
 	InitialState(capabilities.StatePreflight, StateRegistrationInit).
 	ErrorState(shared.StateError).
 	TTL(10 * time.Minute).
-	Debug(true).
-	MustBuild()
+	Debug(true)

--- a/backend/flow_api/handler.go
+++ b/backend/flow_api/handler.go
@@ -27,15 +27,15 @@ type FlowPilotHandler struct {
 }
 
 func (h *FlowPilotHandler) RegistrationFlowHandler(c echo.Context) error {
-	return h.executeFlow(c, registration.Flow)
+	return h.executeFlow(c, registration.Flow.MustBuild())
 }
 
 func (h *FlowPilotHandler) LoginFlowHandler(c echo.Context) error {
-	return h.executeFlow(c, login.Flow)
+	return h.executeFlow(c, login.Flow.MustBuild())
 }
 
 func (h *FlowPilotHandler) ProfileFlowHandler(c echo.Context) error {
-	return h.executeFlow(c, profile.Flow)
+	return h.executeFlow(c, profile.Flow.MustBuild())
 }
 
 func (h *FlowPilotHandler) executeFlow(c echo.Context, flow flowpilot.Flow) error {

--- a/backend/flowpilot/builder.go
+++ b/backend/flowpilot/builder.go
@@ -90,7 +90,11 @@ func (fb *defaultFlowBuilderBase) addStateIfNotExists(stateNames ...StateName) {
 
 // scanFlowStates iterates through each state in the provided flow and associates relevant information, also it checks
 // for uniqueness of state names.
-func (fb *defaultFlowBuilder) scanFlowStates(flow flowBase) error {
+func (fb *defaultFlowBuilder) scanFlowStates(flow flowBase, isRootFlow bool) error {
+	// Check if states were already scanned, if so, don't scan again
+	if len(fb.stateDetails) > 0 && isRootFlow {
+		return nil
+	}
 	// Iterate through states in the flow.
 	for stateName, actions := range flow.getFlow() {
 		// Check if state name is already in use.
@@ -127,7 +131,7 @@ func (fb *defaultFlowBuilder) scanFlowStates(flow flowBase) error {
 
 	// Recursively scan sub-flows.
 	for _, sf := range flow.getSubFlows() {
-		if err := fb.scanFlowStates(sf); err != nil {
+		if err := fb.scanFlowStates(sf, false); err != nil {
 			return err
 		}
 	}
@@ -252,7 +256,7 @@ func (fb *defaultFlowBuilder) Build() (Flow, error) {
 		contextValues:         make(contextValues),
 	}
 
-	if err := fb.scanFlowStates(flow); err != nil {
+	if err := fb.scanFlowStates(flow, true); err != nil {
 		return nil, fmt.Errorf("failed to scan flow states: %w", err)
 	}
 


### PR DESCRIPTION
# Description

With current implementation of the flow builder and how it is used, each request shared the same flow instance, this leads to a concurrency issue, because the flow instance holds the database transaction and http context of a request. And when all incoming request share the same flow instance, the transaction and http context get overridden and also we get a `concurrency write` error on the contextValue variable in the flow.

# Implementation

Create a new instance of a flow for each incoming request. The `scanFlowStates` function from the `defaultFlowBuilder` is changed, that this only runs once.

# Tests

Call an endpoint e.g. `/registration` automated (concurrent) many times (at least one action should be used e.g. `register_client_capabilities`). Check that no errors occur.
