### PR TITLE
fix(flow-api): restore restore schema generation logic

### DIFF
--- a/backend/flowpilot/context.go
+++ b/backend/flowpilot/context.go
@@ -64,6 +64,8 @@ type actionExecutionContext interface {
 	ValidateInputData() bool
 	// CopyInputValuesToStash copies specified inputs to the stash.
 	CopyInputValuesToStash(inputNames ...string) error
+
+	SuspendAction()
 }
 
 // actionExecutionContinuationContext represents the context within an action continuation.

--- a/backend/flowpilot/context_action_exec.go
+++ b/backend/flowpilot/context_action_exec.go
@@ -7,11 +7,11 @@ import (
 
 // defaultActionExecutionContext is the default implementation of the actionExecutionContext interface.
 type defaultActionExecutionContext struct {
-	actionName      ActionName       // Name of the action being executed.
-	input           ExecutionSchema  // JSONManager for accessing input data.
-	executionResult *executionResult // Result of the action execution.
-	links           []Link           // TODO:
-
+	actionName         ActionName       // Name of the action being executed.
+	input              ExecutionSchema  // JSONManager for accessing input data.
+	executionResult    *executionResult // Result of the action execution.
+	links              []Link           // TODO:
+	isSuspended        bool
 	defaultFlowContext // Embedding the defaultFlowContext for common context fields.
 }
 
@@ -97,8 +97,9 @@ func (aec *defaultActionExecutionContext) closeExecutionContext(nextStateName St
 	}
 
 	actionResult := actionExecutionResult{
-		actionName: aec.actionName,
-		schema:     aec.input,
+		actionName:  aec.actionName,
+		schema:      aec.input,
+		isSuspended: aec.isSuspended,
 	}
 
 	result := executionResult{
@@ -325,4 +326,8 @@ func (aec *defaultActionExecutionContext) AddLink(links ...Link) {
 
 func (aec *defaultActionExecutionContext) Set(key string, value interface{}) {
 	aec.flow.Set(key, value)
+}
+
+func (aec *defaultActionExecutionContext) SuspendAction() {
+	aec.isSuspended = true
 }

--- a/backend/flowpilot/response.go
+++ b/backend/flowpilot/response.go
@@ -105,8 +105,9 @@ func (r DefaultFlowResult) Status() int {
 
 // actionExecutionResult holds the result of a method execution.
 type actionExecutionResult struct {
-	actionName ActionName
-	schema     ExecutionSchema
+	actionName  ActionName
+	schema      ExecutionSchema
+	isSuspended bool
 }
 
 // executionResult holds the result of an action execution.
@@ -175,9 +176,14 @@ func (er *executionResult) generateActions(fc defaultFlowContext) PublicActions 
 
 			// Create action HREF based on the current flow context and method name.
 			href := er.createHref(fc, actionName)
+			schema := er.getExecutionSchema(actionName)
 
-			schema := er.createSchema(fc, action)
 			if schema == nil {
+				// Create schema if not available.
+				if schema = er.createSchema(fc, action); schema == nil {
+					continue
+				}
+			} else if er.isSuspended {
 				continue
 			}
 


### PR DESCRIPTION
# Description

Skipping schema generation for the next state actions if the schema already existed was previously removed (see https://github.com/teamhanko/hanko/pull/1300/commits/e895860ec3ba079812df3d1944e5ffb315ca55f9#diff-a8fa1b7ced878250bc6af9ba29ce25b9e0f80c8f0c20f10e891b2234d1324c6b) . This results in errors added to inputs during execution not being part of the response because a new schema without error information was generated. This change reverts this.

# Implementation

If any action changes data such that it leads to a state of data where the same action should be suspended for the next execution (esp. in case of the profile where successful actions result in the same state as the previous one and where the same action might be part of the available actions) then the action can/should now check the new state of data for suspension during execution and then set a flag on the context/execution result accordingly (capabilites to do so are introduced with these changes). Schema generation is then skipped if there already is a schema and if the suspension flag is set to true.

For some actions affected by the above scenario, suspension logic would be duplicated across initialization and execution. In those cases I refactored to an extracted private method. 