### PR TITLE
fix(flow-api): persist webauthn credential in onboarding

### DIFF
--- a/backend/flow_api/flow/login/flow.go
+++ b/backend/flow_api/flow/login/flow.go
@@ -50,6 +50,7 @@ var Flow = flowpilot.NewFlow("/login").
 	State(shared.StateSuccess).
 	State(shared.StateError).
 	SubFlows(capabilities.SubFlow, passkey_onboarding.SubFlow, passcode.SubFlow).
+	AfterState(passkey_onboarding.StateOnboardingVerifyPasskeyAttestation, shared.WebauthnCredentialSave{}).
 	InitialState(capabilities.StatePreflight, StateLoginInit).
 	AfterState(passcode.StatePasscodeConfirmation, shared.EmailPersistVerifiedStatus{}).
 	ErrorState(shared.StateError).

--- a/backend/flow_api/flow/passkey_onboarding/action_webauthn_verify_attestation_response.go
+++ b/backend/flow_api/flow/passkey_onboarding/action_webauthn_verify_attestation_response.go
@@ -68,9 +68,9 @@ func (a WebauthnVerifyAttestationResponse) Execute(c flowpilot.ExecutionContext)
 		return fmt.Errorf("failed to verify attestation response: %w", err)
 	}
 
-	err = c.Stash().Set("passkey_credential", credential)
+	err = c.Stash().Set("webauthn_credential", credential)
 	if err != nil {
-		return fmt.Errorf("failed to set passkey_credential to the stash: %w", err)
+		return fmt.Errorf("failed to set webauthn_credential to the stash: %w", err)
 	}
 
 	return c.EndSubFlow()

--- a/backend/flow_api/flow/profile/action_webauthn_verify_attestation_response.go
+++ b/backend/flow_api/flow/profile/action_webauthn_verify_attestation_response.go
@@ -80,6 +80,14 @@ func (a WebauthnVerifyAttestationResponse) Execute(c flowpilot.ExecutionContext)
 		return fmt.Errorf("failed to set webauthn_credential to the stash: %w", err)
 	}
 
+	// Set user_id explicitly because persisting the credential is now part of a shared hook which has
+	// to work in multiple flows, e.g. the login flow, which does not work with the session_user in the
+	// context like the profile does
+	err = c.Stash().Set("user_id", userModel.ID.String())
+	if err != nil {
+		return fmt.Errorf("failed to set user_id to the stash: %w", err)
+	}
+
 	return c.ContinueFlow(StateProfileInit)
 }
 

--- a/backend/flow_api/flow/profile/flow.go
+++ b/backend/flow_api/flow/profile/flow.go
@@ -48,7 +48,7 @@ var Flow = flowpilot.NewFlow("/profile").
 		WebauthnCredentialDelete{},
 	).
 	State(StateProfileWebauthnCredentialVerification, WebauthnVerifyAttestationResponse{}).
-	AfterState(StateProfileWebauthnCredentialVerification, WebauthnCredentialSave{}).
+	AfterState(StateProfileWebauthnCredentialVerification, shared.WebauthnCredentialSave{}).
 	AfterState(passcode.StatePasscodeConfirmation, shared.EmailPersistVerifiedStatus{}).
 	State(StateProfileAccountDeleted).
 	ErrorState(shared.StateError).

--- a/backend/flow_api/flow/registration/hook_create_user.go
+++ b/backend/flow_api/flow/registration/hook_create_user.go
@@ -31,19 +31,20 @@ func (h CreateUser) Execute(c flowpilot.HookExecutionContext) error {
 	}
 
 	var credentialModel *models.WebauthnCredential
-	if c.Stash().Get("passkey_credential").Exists() {
-		passkeyCredentialStr := c.Stash().Get("passkey_credential").String()
+	if c.Stash().Get("webauthn_credential").Exists() {
+		webauthnCredentialStr := c.Stash().Get("webauthn_credential").String()
 
-		var passkeyCredential webauthnLib.Credential
-		err = json.Unmarshal([]byte(passkeyCredentialStr), &passkeyCredential)
+		var webauthnCredential webauthnLib.Credential
+		err = json.Unmarshal([]byte(webauthnCredentialStr), &webauthnCredential)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal stashed passkey_credential: %w", err)
+			return fmt.Errorf("failed to unmarshal stashed webauthn_credential: %w", err)
 		}
 
+		// TODO: Who/what sets this? Do we need this?
 		passkeyBackupEligible := c.Stash().Get("passkey_backup_eligible").Bool()
 		passkeyBackupState := c.Stash().Get("passkey_backup_state").Bool()
 
-		credentialModel = intern.WebauthnCredentialToModel(&passkeyCredential, userId, passkeyBackupEligible, passkeyBackupState, deps.AuthenticatorMetadata)
+		credentialModel = intern.WebauthnCredentialToModel(&webauthnCredential, userId, passkeyBackupEligible, passkeyBackupState, deps.AuthenticatorMetadata)
 	}
 
 	err = h.createUser(

--- a/backend/flow_api/flow/shared/hook_persist_webauthn_credential.go
+++ b/backend/flow_api/flow/shared/hook_persist_webauthn_credential.go
@@ -1,26 +1,29 @@
-package profile
+package shared
 
 import (
 	"encoding/json"
 	"errors"
 	"fmt"
 	webauthnLib "github.com/go-webauthn/webauthn/webauthn"
+	"github.com/gofrs/uuid"
 	"github.com/teamhanko/hanko/backend/dto/intern"
-	"github.com/teamhanko/hanko/backend/flow_api/flow/shared"
 	"github.com/teamhanko/hanko/backend/flowpilot"
-	"github.com/teamhanko/hanko/backend/persistence/models"
 )
 
 type WebauthnCredentialSave struct {
-	shared.Action
+	Action
 }
 
 func (h WebauthnCredentialSave) Execute(c flowpilot.HookExecutionContext) error {
 	deps := h.GetDeps(c)
 
-	userModel, ok := c.Get("session_user").(*models.User)
-	if !ok {
+	if !c.Stash().Get("user_id").Exists() {
 		return flowpilot.ErrorOperationNotPermitted
+	}
+
+	userId, err := uuid.FromString(c.Stash().Get("user_id").String())
+	if err != nil {
+		return fmt.Errorf("failed to parse stashed user_id into a uuid: %w", err)
 	}
 
 	if !c.Stash().Get("webauthn_credential").Exists() {
@@ -30,12 +33,12 @@ func (h WebauthnCredentialSave) Execute(c flowpilot.HookExecutionContext) error 
 	webauthnCredentialJson := c.Stash().Get("webauthn_credential").String()
 
 	var webauthnCredential webauthnLib.Credential
-	err := json.Unmarshal([]byte(webauthnCredentialJson), &webauthnCredential)
+	err = json.Unmarshal([]byte(webauthnCredentialJson), &webauthnCredential)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal stashed webauthn_credential: %w", err)
 	}
 
-	credentialModel := intern.WebauthnCredentialToModel(&webauthnCredential, userModel.ID, webauthnCredential.Flags.BackupEligible, webauthnCredential.Flags.BackupState, deps.AuthenticatorMetadata)
+	credentialModel := intern.WebauthnCredentialToModel(&webauthnCredential, userId, webauthnCredential.Flags.BackupEligible, webauthnCredential.Flags.BackupState, deps.AuthenticatorMetadata)
 	err = deps.Persister.GetWebauthnCredentialPersisterWithConnection(deps.Tx).Create(*credentialModel)
 	if err != nil {
 		return fmt.Errorf("failed so save credential: %w", err)


### PR DESCRIPTION
Make the profile hook persisting a webauthn credential a shared hook.

