### PR TITLE
feat(flow-api): improve thirdparty integration

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -180,15 +180,19 @@ func DefaultConfig() *Config {
 		ThirdParty: ThirdParty{
 			Providers: ThirdPartyProviders{
 				Google: ThirdPartyProvider{
+					DisplayName:  "Google",
 					AllowLinking: true,
 				},
 				GitHub: ThirdPartyProvider{
+					DisplayName:  "GitHub",
 					AllowLinking: true,
 				},
 				Apple: ThirdPartyProvider{
+					DisplayName:  "Apple",
 					AllowLinking: true,
 				},
 				Discord: ThirdPartyProvider{
+					DisplayName:  "Discord",
 					AllowLinking: true,
 				},
 			},
@@ -664,6 +668,7 @@ type ThirdPartyProvider struct {
 	ClientID     string `yaml:"client_id" json:"client_id" koanf:"client_id" split_words:"true"`
 	Secret       string `yaml:"secret" json:"secret" koanf:"secret"`
 	AllowLinking bool   `yaml:"allow_linking" json:"allow_linking" koanf:"allow_linking" split_words:"true"`
+	DisplayName  string `yaml:"display_name" json:"display_name" koanf:"display_name" split_words:"true"`
 }
 
 func (p *ThirdPartyProvider) Validate() error {
@@ -707,6 +712,19 @@ func (p *ThirdPartyProviders) HasEnabled() bool {
 	}
 
 	return false
+}
+
+func (p *ThirdPartyProviders) GetEnabled() []ThirdPartyProvider {
+	s := structs.New(p)
+	var enabledProviders []ThirdPartyProvider
+	for _, field := range s.Fields() {
+		provider := field.Value().(ThirdPartyProvider)
+		if provider.Enabled {
+			enabledProviders = append(enabledProviders, provider)
+		}
+	}
+
+	return enabledProviders
 }
 
 func (p *ThirdPartyProviders) Get(provider string) *ThirdPartyProvider {

--- a/backend/flow_api/flow/login/flow.go
+++ b/backend/flow_api/flow/login/flow.go
@@ -30,12 +30,16 @@ const (
 )
 
 var Flow = flowpilot.NewFlow("/login").
-	State(StateLoginInit, ContinueWithLoginIdentifier{}, WebauthnGenerateRequestOptions{}).
-	BeforeState(StateLoginInit, shared.GenerateOAuthLinks{}).
+	State(StateLoginInit,
+		ContinueWithLoginIdentifier{},
+		WebauthnGenerateRequestOptions{},
+		shared.ThirdPartyOAuth{}).
+	State(shared.StateThirdPartyOAuth, shared.ExchangeToken{}).
 	State(StateLoginMethodChooser,
 		WebauthnGenerateRequestOptions{},
 		ContinueToPasswordLogin{},
 		ContinueToPasscodeConfirmation{},
+		shared.ThirdPartyOAuth{},
 		shared.Back{},
 	).
 	State(StateLoginPasskey, WebauthnVerifyAssertionResponse{}).

--- a/backend/flow_api/flow/registration/flow.go
+++ b/backend/flow_api/flow/registration/flow.go
@@ -20,8 +20,8 @@ const (
 )
 
 var Flow = flowpilot.NewFlow("/registration").
-	State(StateRegistrationInit, RegisterLoginIdentifier{}).
-	BeforeState(StateRegistrationInit, shared.GenerateOAuthLinks{}).
+	State(StateRegistrationInit, RegisterLoginIdentifier{}, shared.ThirdPartyOAuth{}).
+	State(shared.StateThirdPartyOAuth, shared.ExchangeToken{}).
 	State(StatePasswordCreation, RegisterPassword{}).
 	BeforeState(shared.StateSuccess, CreateUser{}, shared.IssueSession{}).
 	State(shared.StateSuccess).

--- a/backend/flow_api/flow/registration/hook_create_user.go
+++ b/backend/flow_api/flow/registration/hook_create_user.go
@@ -17,6 +17,12 @@ type CreateUser struct {
 }
 
 func (h CreateUser) Execute(c flowpilot.HookExecutionContext) error {
+	// Set by shared thirdparty_oauth action because the third party callback endpoint already
+	// creates the user.
+	if c.Stash().Get("skip_user_creation").Bool() {
+		return nil
+	}
+
 	deps := h.GetDeps(c)
 
 	userId, err := uuid.NewV4()

--- a/backend/flow_api/flow/shared/action_exchange_token.go
+++ b/backend/flow_api/flow/shared/action_exchange_token.go
@@ -1,0 +1,66 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"github.com/teamhanko/hanko/backend/flowpilot"
+	"time"
+)
+
+type ExchangeToken struct {
+	Action
+}
+
+func (a ExchangeToken) GetName() flowpilot.ActionName {
+	return ActionExchangeToken
+}
+
+func (a ExchangeToken) GetDescription() string {
+	return "Exchange a one time token."
+}
+
+func (a ExchangeToken) Initialize(c flowpilot.InitializationContext) {
+	c.AddInputs(flowpilot.StringInput("token").Hidden(true).Required(true))
+}
+
+func (a ExchangeToken) Execute(c flowpilot.ExecutionContext) error {
+	if valid := c.ValidateInputData(); !valid {
+		return c.ContinueFlowWithError(c.GetCurrentState(), flowpilot.ErrorFormDataInvalid)
+	}
+
+	deps := a.GetDeps(c)
+
+	tokenModel, terr := deps.Persister.GetTokenPersisterWithConnection(deps.Tx).GetByValue(c.Input().Get("token").String())
+	if terr != nil {
+		return fmt.Errorf("failed to fetch token from db: %w", terr)
+	}
+
+	if tokenModel == nil {
+		return errors.New("token not found")
+	}
+
+	if time.Now().UTC().After(tokenModel.ExpiresAt) {
+		return errors.New("token expired")
+	}
+
+	terr = deps.Persister.GetTokenPersisterWithConnection(deps.Tx).Delete(*tokenModel)
+	if terr != nil {
+		return fmt.Errorf("failed to delete token from db: %w", terr)
+	}
+
+	// Set because the thirdparty/callback endpoint already creates a user.
+	if err := c.Stash().Set("skip_user_creation", true); err != nil {
+		return fmt.Errorf("failed to set skip_user_creation to stash: %w", err)
+	}
+
+	// Set so the issue_session hook knows who to create the session for.
+	if err := c.Stash().Set("user_id", tokenModel.UserID.String()); err != nil {
+		return fmt.Errorf("failed to set user_id to stash: %w", err)
+	}
+
+	return c.ContinueFlow(StateSuccess)
+}
+
+func (a ExchangeToken) Finalize(c flowpilot.FinalizationContext) error {
+	return nil
+}

--- a/backend/flow_api/flow/shared/action_thirdparty_oauth.go
+++ b/backend/flow_api/flow/shared/action_thirdparty_oauth.go
@@ -1,0 +1,85 @@
+package shared
+
+import (
+	"fmt"
+	"github.com/teamhanko/hanko/backend/flowpilot"
+	"github.com/teamhanko/hanko/backend/thirdparty"
+	"github.com/teamhanko/hanko/backend/utils"
+	"golang.org/x/oauth2"
+	"net/http"
+	"strings"
+)
+
+type ThirdPartyOAuth struct {
+	Action
+}
+
+func (a ThirdPartyOAuth) GetName() flowpilot.ActionName {
+	return ActionThirdPartyOAuth
+}
+
+func (a ThirdPartyOAuth) GetDescription() string {
+	return "Sign up/sign in with a third party provider via OAuth."
+}
+
+func (a ThirdPartyOAuth) Initialize(c flowpilot.InitializationContext) {
+	deps := a.GetDeps(c)
+
+	providerInput := flowpilot.StringInput("provider").
+		Hidden(true).
+		Required(true)
+
+	for _, provider := range deps.Cfg.ThirdParty.Providers.GetEnabled() {
+		providerInput.AllowedValue(strings.ToLower(provider.DisplayName), provider.DisplayName)
+	}
+
+	c.AddInputs(flowpilot.StringInput("redirect_to").Hidden(true).Required(true), providerInput)
+}
+
+func (a ThirdPartyOAuth) Execute(c flowpilot.ExecutionContext) error {
+	deps := a.GetDeps(c)
+
+	errorRedirectTo := deps.HttpContext.Request().Header.Get("Referer")
+	if errorRedirectTo == "" {
+		errorRedirectTo = deps.Cfg.ThirdParty.ErrorRedirectURL
+	}
+
+	if valid := c.ValidateInputData(); !valid {
+		return c.ContinueFlowWithError(c.GetCurrentState(), flowpilot.ErrorFormDataInvalid)
+	}
+
+	redirectTo := c.Input().Get("redirect_to").String()
+	if ok := thirdparty.IsAllowedRedirect(deps.Cfg.ThirdParty, redirectTo); !ok {
+		return c.ContinueFlowWithError(c.GetCurrentState(), flowpilot.ErrorFormDataInvalid)
+	}
+
+	provider, err := thirdparty.GetProvider(deps.Cfg.ThirdParty, c.Input().Get("provider").String())
+	if err != nil {
+		return c.ContinueFlowWithError(c.GetCurrentState(), flowpilot.ErrorFormDataInvalid.Wrap(err))
+	}
+
+	state, err := thirdparty.GenerateState(&deps.Cfg, provider.Name(), redirectTo)
+	if err != nil {
+		return c.ContinueFlowWithError(c.GetCurrentState(), flowpilot.ErrorTechnical.Wrap(err))
+	}
+
+	authCodeUrl := provider.AuthCodeURL(string(state), oauth2.SetAuthURLParam("prompt", "consent"))
+
+	cookie := utils.GenerateStateCookie(&deps.Cfg, utils.HankoThirdpartyStateCookie, string(state), utils.CookieOptions{
+		MaxAge:   300,
+		Path:     "/",
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	deps.HttpContext.SetCookie(cookie)
+
+	if err = c.Payload().Set("redirect_url", authCodeUrl); err != nil {
+		return fmt.Errorf("failed to set redirect_url to payload: %w", err)
+	}
+
+	return c.ContinueFlow(StateThirdPartyOAuth)
+}
+
+func (a ThirdPartyOAuth) Finalize(c flowpilot.FinalizationContext) error {
+	return nil
+}

--- a/backend/flow_api/flow/shared/flow.go
+++ b/backend/flow_api/flow/shared/flow.go
@@ -13,12 +13,15 @@ import (
 )
 
 const (
-	StateSuccess flowpilot.StateName = "success"
-	StateError   flowpilot.StateName = "error"
+	StateSuccess         flowpilot.StateName = "success"
+	StateError           flowpilot.StateName = "error"
+	StateThirdPartyOAuth flowpilot.StateName = "thirdparty_oauth"
 )
 
 const (
-	ActionBack flowpilot.ActionName = "back"
+	ActionBack            flowpilot.ActionName = "back"
+	ActionExchangeToken   flowpilot.ActionName = "exchange_token"
+	ActionThirdPartyOAuth flowpilot.ActionName = "thirdparty_oauth"
 )
 
 type Dependencies struct {

--- a/backend/flow_api/static/generic_client.html
+++ b/backend/flow_api/static/generic_client.html
@@ -69,6 +69,18 @@
         get
     } from 'https://cdn.jsdelivr.net/npm/@github/webauthn-json@2.1.1/browser-ponyfill/+esm'
 
+    window.addEventListener("load", () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const hankoToken = urlParams.get('hanko_token');
+      if (hankoToken) {
+        const state = JSON.parse(localStorage.getItem("thirdparty_oauth_state"))
+        generateUI(state)
+        const form = document.getElementById('exchange_token');
+        form.getElementsByTagName("input")[0].value = hankoToken;
+        window.history.replaceState(null, null, window.location.pathname);
+      }
+    })
+
     async function webauthnCreate(payload) {
         const options = parseCreationOptionsFromJSON(payload)
         const response = await create(options)
@@ -95,12 +107,17 @@
       document.getElementsByName("assertion_response")[0].value = await webauthnGet(payload.request_options)
     }
 
+    const thirdpartyOAuthHandler = (payload) => {
+      window.location.href = payload.redirect_url;
+    }
+
     const stateHandler = {
         "login_passkey": passkeyLoginHandler,
         "passkey_login": passkeyLoginHandler,
         "passkey_registration": passkeyRegisterHandler,
         "onboarding_verify_passkey_attestation": passkeyRegisterHandler,
-        "webauthn_credential_verification": passkeyRegisterHandler
+        "webauthn_credential_verification": passkeyRegisterHandler,
+        "thirdparty_oauth": thirdpartyOAuthHandler
     }
 
     function generateUI(data) {
@@ -163,6 +180,7 @@
                 const form = document.createElement('form');
                 form.action = action.href;
                 form.method = 'POST';
+                form.id = action.action;
 
                 const actionHeadline = document.createElement('h4');
                 actionHeadline.textContent = "⚡ Action: " + action.action;
@@ -308,6 +326,12 @@
             body: JSON.stringify({input_data: body}),
         })
             .then(response => response.json())
+            .then((data) => {
+              if (data.state === 'thirdparty_oauth') {
+                localStorage.setItem('thirdparty_oauth_state', JSON.stringify(data))
+              }
+              return data
+            })
             .then(generateUI)
             .catch(console.error);
     }

--- a/backend/flowpilot/errors.go
+++ b/backend/flowpilot/errors.go
@@ -168,3 +168,7 @@ var (
 	ErrorValueTooLong  = NewInputError("value_too_long_error", "Value is too long.")
 	ErrorValueTooShort = NewInputError("value_too_short_error", "Value is too short.")
 )
+
+func ErrorValueInvalidMustBeOneOf(values interface{}) InputError {
+	return NewInputError("value_invalid_error", fmt.Sprintf("The value is invalid. Must be one of: %+v", values))
+}

--- a/backend/flowpilot/response.go
+++ b/backend/flowpilot/response.go
@@ -31,14 +31,15 @@ type PublicError struct {
 
 // PublicInput represents an input field for public exposure.
 type PublicInput struct {
-	Name        string       `json:"name"`
-	Type        InputType    `json:"type"`
-	Value       interface{}  `json:"value,omitempty"`
-	MinLength   *int         `json:"min_length,omitempty"`
-	MaxLength   *int         `json:"max_length,omitempty"`
-	Required    *bool        `json:"required,omitempty"`
-	Hidden      *bool        `json:"hidden,omitempty"`
-	PublicError *PublicError `json:"error,omitempty"`
+	Name          string        `json:"name"`
+	Type          InputType     `json:"type"`
+	Value         interface{}   `json:"value,omitempty"`
+	MinLength     *int          `json:"min_length,omitempty"`
+	MaxLength     *int          `json:"max_length,omitempty"`
+	Required      *bool         `json:"required,omitempty"`
+	Hidden        *bool         `json:"hidden,omitempty"`
+	PublicError   *PublicError  `json:"error,omitempty"`
+	AllowedValues AllowedValues `json:"allowed_values,omitempty"`
 }
 
 // PublicResponse represents the response of an action execution.


### PR DESCRIPTION
# Description

Improves the third party integration with the flow API.

# Implementation

- Add a `shared` action for initializing OAuth login.
    -  Add the possibility to set allowed values for inputs. The `allowed_values` are returned as part of the response schema for the action. In case of the OAuth login the `allowed_values` correspond to the providers enabled in the configuration.
- Add a `shared` action for doing a token exchange.

# How to test

Don't forget to configure at least one third party provider, e.g.: 

 ```yaml
third_party:
  allowed_redirect_urls:
    - http://localhost:8000/**
  error_redirect_url: http://localhost:8000/flowpilot/generic_client.html
  redirect_url: http://localhost:8000/thirdparty/callback
  providers:
    github:
      client_id:
      secret: 
      enabled: true
```