### PR TITLE
feat(flow-api): suspend oauth action when no provider enabled

### DIFF
--- a/backend/flow_api/flow/shared/action_thirdparty_oauth.go
+++ b/backend/flow_api/flow/shared/action_thirdparty_oauth.go
@@ -25,11 +25,17 @@ func (a ThirdPartyOAuth) GetDescription() string {
 func (a ThirdPartyOAuth) Initialize(c flowpilot.InitializationContext) {
 	deps := a.GetDeps(c)
 
+	enabledProviders := deps.Cfg.ThirdParty.Providers.GetEnabled()
+	if len(enabledProviders) == 0 {
+		c.SuspendAction()
+		return
+	}
+
 	providerInput := flowpilot.StringInput("provider").
 		Hidden(true).
 		Required(true)
 
-	for _, provider := range deps.Cfg.ThirdParty.Providers.GetEnabled() {
+	for _, provider := range enabledProviders {
 		providerInput.AllowedValue(strings.ToLower(provider.DisplayName), provider.DisplayName)
 	}
 


### PR DESCRIPTION
# Description

The shared `thirdparty_oauth` action is currently offered as a viable action even if no providers are enabled.

# Implementation

- Suspend the action during initialization of the action if no providers are enabled.