### PR TITLE
feat(jwt): add email claim to session JWT

### DIFF
--- a/backend/dto/email.go
+++ b/backend/dto/email.go
@@ -39,3 +39,17 @@ func FromEmailModel(email *models.Email) *EmailResponse {
 
 	return emailResponse
 }
+
+type EmailJwt struct {
+	Address    string `json:"address"`
+	IsPrimary  bool   `json:"is_primary"`
+	IsVerified bool   `json:"is_verified"`
+}
+
+func JwtFromEmailModel(email *models.Email) *EmailJwt {
+	return &EmailJwt{
+		Address:    email.Address,
+		IsPrimary:  email.IsPrimary(),
+		IsVerified: email.Verified,
+	}
+}

--- a/backend/handler/email_test.go
+++ b/backend/handler/email_test.go
@@ -64,7 +64,7 @@ func (s *emailSuite) TestEmailHandler_List() {
 
 	for _, currentTest := range tests {
 		s.Run(currentTest.name, func() {
-			token, err := sessionManager.GenerateJWT(currentTest.userId)
+			token, err := sessionManager.GenerateJWT(currentTest.userId, nil)
 			s.Require().NoError(err)
 			cookie, err := sessionManager.GenerateCookie(token)
 			s.Require().NoError(err)
@@ -177,7 +177,7 @@ func (s *emailSuite) TestEmailHandler_Create() {
 			sessionManager, err := session.NewManager(jwkManager, cfg)
 			s.Require().NoError(err)
 
-			token, err := sessionManager.GenerateJWT(currentTest.userId)
+			token, err := sessionManager.GenerateJWT(currentTest.userId, nil)
 			s.Require().NoError(err)
 			cookie, err := sessionManager.GenerateCookie(token)
 			s.Require().NoError(err)
@@ -244,7 +244,7 @@ func (s *emailSuite) TestEmailHandler_SetPrimaryEmail() {
 	newPrimaryEmailId := uuid.FromStringOrNil("8bb4c8a7-a3e6-48bb-b54f-20e3b485ab33")
 	userId := uuid.FromStringOrNil("b5dd5267-b462-48be-b70d-bcd6f1bbe7a5")
 
-	token, err := sessionManager.GenerateJWT(userId)
+	token, err := sessionManager.GenerateJWT(userId, nil)
 	s.NoError(err)
 	cookie, err := sessionManager.GenerateCookie(token)
 	s.NoError(err)
@@ -285,7 +285,7 @@ func (s *emailSuite) TestEmailHandler_Delete() {
 	sessionManager, err := session.NewManager(jwkManager, test.DefaultConfig)
 	s.Require().NoError(err)
 
-	token, err := sessionManager.GenerateJWT(userId)
+	token, err := sessionManager.GenerateJWT(userId, nil)
 	s.NoError(err)
 	cookie, err := sessionManager.GenerateCookie(token)
 	s.NoError(err)

--- a/backend/handler/passcode.go
+++ b/backend/handler/passcode.go
@@ -361,7 +361,12 @@ func (h *PasscodeHandler) Finish(c echo.Context) error {
 			}
 		}
 
-		token, err := h.sessionManager.GenerateJWT(passcode.UserId)
+		var emailJwt *dto.EmailJwt
+		if e := user.Emails.GetPrimary(); e != nil {
+			emailJwt = dto.JwtFromEmailModel(e)
+		}
+
+		token, err := h.sessionManager.GenerateJWT(passcode.UserId, emailJwt)
 		if err != nil {
 			return fmt.Errorf("failed to generate jwt: %w", err)
 		}

--- a/backend/handler/passcode_test.go
+++ b/backend/handler/passcode_test.go
@@ -298,13 +298,13 @@ func (s *passcodeSuite) TestPasscodeHandler_Finish() {
 				req := httptest.NewRequest(http.MethodPost, "/passcode/login/finalize", bytes.NewReader(bodyJson))
 				req.Header.Set("Content-Type", "application/json")
 				if currentTest.sendSessionTokenInAuthHeader {
-					sessionToken, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(currentTest.userId))
+					sessionToken, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(currentTest.userId), nil)
 					s.Require().NoError(err)
 					req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", sessionToken))
 				}
 
 				if currentTest.sendSessionTokenInCookie {
-					sessionToken, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(currentTest.userId))
+					sessionToken, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(currentTest.userId), nil)
 					s.Require().NoError(err)
 
 					sessionCookie, err := sessionManager.GenerateCookie(sessionToken)

--- a/backend/handler/password.go
+++ b/backend/handler/password.go
@@ -218,7 +218,12 @@ func (h *PasswordHandler) Login(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized).SetInternal(err)
 	}
 
-	token, err := h.sessionManager.GenerateJWT(pw.UserId)
+	var emailJwt *dto.EmailJwt
+	if e := user.Emails.GetPrimary(); e != nil {
+		emailJwt = dto.JwtFromEmailModel(e)
+	}
+
+	token, err := h.sessionManager.GenerateJWT(pw.UserId, emailJwt)
 	if err != nil {
 		return fmt.Errorf("failed to generate jwt: %w", err)
 	}

--- a/backend/handler/password_test.go
+++ b/backend/handler/password_test.go
@@ -91,7 +91,7 @@ func (s *passwordSuite) TestPasswordHandler_Set_Create() {
 			s.Require().NoError(err)
 
 			sessionManager := s.GetDefaultSessionManager()
-			token, err := sessionManager.GenerateJWT(currentTest.userId)
+			token, err := sessionManager.GenerateJWT(currentTest.userId, nil)
 			s.Require().NoError(err)
 			cookie, err := sessionManager.GenerateCookie(token)
 			s.Require().NoError(err)
@@ -227,17 +227,17 @@ func TestMaxPasswordLength(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			hash, err := bcrypt.GenerateFromPassword([]byte(test.creationPassword), 12)
-			if test.wantErr {
+	for _, passwordTest := range tests {
+		t.Run(passwordTest.name, func(t *testing.T) {
+			hash, err := bcrypt.GenerateFromPassword([]byte(passwordTest.creationPassword), 12)
+			if passwordTest.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
 
-			err = bcrypt.CompareHashAndPassword(hash, []byte(test.loginPassword))
-			if test.wantErr {
+			err = bcrypt.CompareHashAndPassword(hash, []byte(passwordTest.loginPassword))
+			if passwordTest.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)

--- a/backend/handler/token.go
+++ b/backend/handler/token.go
@@ -82,7 +82,17 @@ func (h TokenHandler) Validate(c echo.Context) error {
 			return fmt.Errorf("failed to delete token from db: %w", terr)
 		}
 
-		jwtToken, err := h.sessionManager.GenerateJWT(token.UserID)
+		emails, err := h.persister.GetEmailPersister().FindByUserId(token.UserID)
+		if err != nil {
+			return fmt.Errorf("failed to get emails from db: %w", err)
+		}
+
+		var emailJwt *dto.EmailJwt
+		if e := emails.GetPrimary(); e != nil {
+			emailJwt = dto.JwtFromEmailModel(e)
+		}
+
+		jwtToken, err := h.sessionManager.GenerateJWT(token.UserID, emailJwt)
 		if err != nil {
 			return fmt.Errorf("failed to generate jwt: %w", err)
 		}

--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -104,7 +104,13 @@ func (h *UserHandler) Create(c echo.Context) error {
 				return fmt.Errorf("failed to store primary email: %w", err)
 			}
 
-			token, err := h.sessionManager.GenerateJWT(newUser.ID)
+			var emailJwt *dto.EmailJwt
+			if e := newUser.Emails.GetPrimary(); e != nil {
+				emailJwt = dto.JwtFromEmailModel(e)
+			}
+
+			token, err := h.sessionManager.GenerateJWT(newUser.ID, emailJwt)
+
 			if err != nil {
 				return fmt.Errorf("failed to generate jwt: %w", err)
 			}

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -261,7 +261,7 @@ func (s *userSuite) TestUserHandler_Get() {
 	if err != nil {
 		panic(fmt.Errorf("failed to create session generator: %w", err))
 	}
-	token, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(userId))
+	token, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(userId), nil)
 	s.Require().NoError(err)
 	cookie, err := sessionManager.GenerateCookie(token)
 	s.Require().NoError(err)
@@ -301,7 +301,7 @@ func (s *userSuite) TestUserHandler_GetUserWithWebAuthnCredential() {
 	if err != nil {
 		panic(fmt.Errorf("failed to create session generator: %w", err))
 	}
-	token, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(userId))
+	token, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(userId), nil)
 	s.Require().NoError(err)
 	cookie, err := sessionManager.GenerateCookie(token)
 	s.Require().NoError(err)
@@ -338,7 +338,7 @@ func (s *userSuite) TestUserHandler_Get_InvalidUserId() {
 	if err != nil {
 		panic(fmt.Errorf("failed to create session generator: %w", err))
 	}
-	token, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(userId))
+	token, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(userId), nil)
 	s.Require().NoError(err)
 	cookie, err := sessionManager.GenerateCookie(token)
 	s.Require().NoError(err)
@@ -475,7 +475,7 @@ func (s *userSuite) TestUserHandler_Me() {
 	if err != nil {
 		panic(fmt.Errorf("failed to create session generator: %w", err))
 	}
-	token, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(userId))
+	token, err := sessionManager.GenerateJWT(uuid.FromStringOrNil(userId), nil)
 	s.Require().NoError(err)
 	cookie, err := sessionManager.GenerateCookie(token)
 	s.Require().NoError(err)
@@ -512,7 +512,7 @@ func (s *userSuite) TestUserHandler_Logout() {
 	if err != nil {
 		panic(fmt.Errorf("failed to create session generator: %w", err))
 	}
-	token, err := sessionManager.GenerateJWT(userId)
+	token, err := sessionManager.GenerateJWT(userId, nil)
 	s.Require().NoError(err)
 	cookie, err := sessionManager.GenerateCookie(token)
 	s.Require().NoError(err)
@@ -553,7 +553,7 @@ func (s *userSuite) TestUserHandler_Delete() {
 	if err != nil {
 		panic(fmt.Errorf("failed to create session generator: %w", err))
 	}
-	token, err := sessionManager.GenerateJWT(userId)
+	token, err := sessionManager.GenerateJWT(userId, nil)
 	s.Require().NoError(err)
 	cookie, err := sessionManager.GenerateCookie(token)
 	s.Require().NoError(err)


### PR DESCRIPTION
# Description

This PR adds an email claim to the session JWT when the user has a primary email address. The claim contains the following fields:

* primary email address of the user
* Flag if the email address is a primary address
* Flag if the email address is verified

This PR also cleans up some unused stuff and refactors some error messages.

Closes: #1388