### PR TITLE
[FEAT] disable email delivery

### DIFF
--- a/backend/docs/Config.md
+++ b/backend/docs/Config.md
@@ -300,6 +300,18 @@ webauthn:
     origins:
       - "android:apk-key-hash:nLSu7wVTbnMOxLgC52f2faTnv..."
       - "https://login.example.com"
+## email_delivery ##
+#
+# Settings needed for email delivery.
+#
+email_delivery:
+  ## enabled ##
+  #
+  # Enable or disable email delivery by hanko. Disable if you want to send the emails yourself. To send emails yourself you must subscribe to the `email.create` webhook event.
+  #
+  # Default: true
+  #
+  enabled: true
 ## audit_log ##
 #
 # Configures audit logging
@@ -972,4 +984,10 @@ webhooks:
         # Email - Triggers on: change of primary email
         #
         - user.update.email.primary
+        ##
+        #
+        # Triggers on: an email was sent or should be sent
+        #
+        - email.create
+
 ```

--- a/backend/dto/webhook/email.go
+++ b/backend/dto/webhook/email.go
@@ -1,0 +1,26 @@
+package webhook
+
+type EmailCreate struct {
+	Subject          string    `json:"subject"`        // subject
+	BodyPlain        string    `json:"body_plain"`     // used for string templates
+	Body             string    `json:"body,omitempty"` // used for html templates
+	ToEmailAddress   string    `json:"to_email_address"`
+	DeliveredByHanko bool      `json:"delivered_by_hanko"`
+	AcceptLanguage   string    `json:"accept_language"` // accept_language header from http request
+	Type             EmailType `json:"type"`            // type of the email, currently only "passcode", but other could be added later
+
+	Data interface{} `json:"data"`
+}
+
+type PasscodeData struct {
+	ServiceName string `json:"service_name"`
+	OtpCode     string `json:"otp_code"`
+	TTL         int    `json:"ttl"`
+	ValidUntil  int64  `json:"valid_until"` // UnixTimestamp
+}
+
+type EmailType string
+
+var (
+	EmailTypePasscode EmailType = "passcode"
+)

--- a/backend/handler/email.go
+++ b/backend/handler/email.go
@@ -144,7 +144,7 @@ func (h *EmailHandler) Create(c echo.Context) error {
 			var evt events.Event
 
 			if len(user.Emails) >= 1 {
-				evt = events.EmailCreate
+				evt = events.UserEmailCreate
 			} else {
 				evt = events.UserCreate
 			}
@@ -212,7 +212,7 @@ func (h *EmailHandler) SetPrimaryEmail(c echo.Context) error {
 			return fmt.Errorf("failed to create audit log: %w", err)
 		}
 
-		utils.NotifyUserChange(c, tx, h.persister, events.EmailPrimary, userId)
+		utils.NotifyUserChange(c, tx, h.persister, events.UserEmailPrimary, userId)
 
 		return c.NoContent(http.StatusNoContent)
 	})
@@ -256,7 +256,7 @@ func (h *EmailHandler) Delete(c echo.Context) error {
 			return fmt.Errorf("failed to create audit log: %w", err)
 		}
 
-		utils.NotifyUserChange(c, tx, h.persister, events.EmailDelete, userId)
+		utils.NotifyUserChange(c, tx, h.persister, events.UserEmailDelete, userId)
 
 		return c.NoContent(http.StatusNoContent)
 	})

--- a/backend/handler/email_admin.go
+++ b/backend/handler/email_admin.go
@@ -150,7 +150,7 @@ func (h *emailAdminHandler) Create(ctx echo.Context) error {
 			err = h.persister.GetPrimaryEmailPersisterWithConnection(tx).Create(*primaryEmail)
 		}
 
-		utils.NotifyUserChange(ctx, tx, h.persister, events.EmailCreate, userId)
+		utils.NotifyUserChange(ctx, tx, h.persister, events.UserEmailCreate, userId)
 
 		return ctx.JSON(http.StatusCreated, admin.FromEmailModel(email))
 	})
@@ -229,7 +229,7 @@ func (h *emailAdminHandler) Delete(ctx echo.Context) error {
 			return fmt.Errorf("failed to delete email from db: %w", err)
 		}
 
-		utils.NotifyUserChange(ctx, tx, h.persister, events.EmailDelete, userId)
+		utils.NotifyUserChange(ctx, tx, h.persister, events.UserEmailDelete, userId)
 
 		return ctx.NoContent(http.StatusNoContent)
 	})
@@ -275,7 +275,7 @@ func (h *emailAdminHandler) SetPrimaryEmail(ctx echo.Context) error {
 			return err
 		}
 
-		utils.NotifyUserChange(ctx, tx, h.persister, events.EmailPrimary, userId)
+		utils.NotifyUserChange(ctx, tx, h.persister, events.UserEmailPrimary, userId)
 
 		return ctx.NoContent(http.StatusNoContent)
 	})

--- a/backend/handler/public_router.go
+++ b/backend/handler/public_router.go
@@ -143,9 +143,9 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister, promet
 	webauthnCredentials.DELETE("/:id", webauthnHandler.DeleteCredential)
 
 	passcode := g.Group("/passcode")
-	passcodeLogin := passcode.Group("/login")
+	passcodeLogin := passcode.Group("/login", webhookMiddlware)
 	passcodeLogin.POST("/initialize", passcodeHandler.Init)
-	passcodeLogin.POST("/finalize", passcodeHandler.Finish, webhookMiddlware)
+	passcodeLogin.POST("/finalize", passcodeHandler.Finish)
 
 	email := g.Group("/emails", sessionMiddleware, webhookMiddlware)
 	email.GET("", emailHandler.List)

--- a/backend/json_schema/hanko.config.json
+++ b/backend/json_schema/hanko.config.json
@@ -133,6 +133,9 @@
         "smtp": {
           "$ref": "#/$defs/SMTP"
         },
+        "email_delivery": {
+          "$ref": "#/$defs/EmailDelivery"
+        },
         "passcode": {
           "$ref": "#/$defs/Passcode"
         },
@@ -301,6 +304,19 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "EmailDelivery": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ]
     },
     "Emails": {
       "properties": {

--- a/backend/rate_limiter/rate_limiter.go
+++ b/backend/rate_limiter/rate_limiter.go
@@ -53,7 +53,6 @@ func Limit(store limiter.Store, userId uuid.UUID, c echo.Context) error {
 	}
 
 	resetTime := int(math.Floor(time.Unix(0, int64(reset)).UTC().Sub(time.Now().UTC()).Seconds()))
-	log.Println(resetTime)
 
 	// Set headers (we do this regardless of whether the request is permitted).
 	c.Response().Header().Set(httplimit.HeaderRateLimitLimit, strconv.FormatUint(limit, 10))

--- a/backend/thirdparty/linking.go
+++ b/backend/thirdparty/linking.go
@@ -128,7 +128,7 @@ func signIn(tx *pop.Connection, cfg *config.Config, p persistence.Persister, use
 			}
 
 			identity.EmailID = email.ID
-			webhookEvent = events.EmailCreate
+			webhookEvent = events.UserEmailCreate
 		}
 	}
 

--- a/backend/webhooks/events/events.go
+++ b/backend/webhooks/events/events.go
@@ -5,14 +5,16 @@ import "github.com/teamhanko/hanko/backend/persistence/models"
 type Event string
 
 const (
-	User         Event = "user"
-	UserCreate   Event = "user.create"
-	UserUpdate   Event = "user.update"
-	UserDelete   Event = "user.delete"
-	Email        Event = "user.update.email"
-	EmailCreate  Event = "user.update.email.create"
-	EmailPrimary Event = "user.update.email.primary"
-	EmailDelete  Event = "user.update.email.delete"
+	User             Event = "user"
+	UserCreate       Event = "user.create"
+	UserUpdate       Event = "user.update"
+	UserDelete       Event = "user.delete"
+	UserEmail        Event = "user.update.email"
+	UserEmailCreate  Event = "user.update.email.create"
+	UserEmailPrimary Event = "user.update.email.primary"
+	UserEmailDelete  Event = "user.update.email.delete"
+
+	EmailCreate Event = "email.create"
 )
 
 func StringIsValidEvent(value string) bool {
@@ -23,7 +25,7 @@ func StringIsValidEvent(value string) bool {
 func IsValidEvent(evt Event) bool {
 	var isValid bool
 	switch evt {
-	case User, UserCreate, UserUpdate, UserDelete, Email, EmailCreate, EmailPrimary, EmailDelete:
+	case User, UserCreate, UserUpdate, UserDelete, UserEmail, UserEmailCreate, UserEmailPrimary, UserEmailDelete, EmailCreate:
 		isValid = true
 	default:
 		isValid = false

--- a/backend/webhooks/webhook_test.go
+++ b/backend/webhooks/webhook_test.go
@@ -17,7 +17,7 @@ func TestBaseWebhook_HasEvent(t *testing.T) {
 		Events:   events.Events{events.UserUpdate},
 	}
 
-	require.True(t, baseHook.HasEvent(events.EmailCreate))
+	require.True(t, baseHook.HasEvent(events.UserEmailCreate))
 }
 
 func TestWebhooks_HasEvent_WithMultipleEvents(t *testing.T) {
@@ -37,7 +37,7 @@ func TestWebhooks_HasSubEvent_WithMultipleEvents(t *testing.T) {
 		Events:   events.Events{events.UserCreate, events.UserUpdate},
 	}
 
-	require.True(t, baseHook.HasEvent(events.EmailCreate))
+	require.True(t, baseHook.HasEvent(events.UserEmailCreate))
 }
 
 func TestBaseWebhook_HasSubEvent(t *testing.T) {


### PR DESCRIPTION
# Description

Add a config option to disable email delivery by hanko. Currently there is no way to style the emails hanko is sending, with this option a user can send and style the emails himself. 
If email delivery is disabled you do not need to provide smtp settings. To send an email yourself you need to add a webhook which is subscribed to the `email.create` event. 

# Implementation

A new webhook event is introduced (`email.create`). This will always be triggered when a email was sent or when it should be sent, depending if email delivery is enabled or disabled. This webhook event contains all data that is necessary to send your own email (e.g. subject, body, passcode, ttl, toAddress). This webhook event also contains a flag which indicates if the email was sent by hanko or not.

# Tests

To test this create a new webhook with the `email.create` event. Then enable the email delivery (is by default) and check if the email is still send and that the webhook gets called and the `delivered_by_hanko` flag is set to `true`. Then disable the email delivery and check that the email is not sent that the webhook gets called and that the `delivered_by_hanko` flag is set to `false`.
