### PR TITLE
fix: fix saml login for existing users

### DIFF
--- a/backend/ee/saml/handler.go
+++ b/backend/ee/saml/handler.go
@@ -214,7 +214,7 @@ func (handler *SamlHandler) linkAccount(c echo.Context, redirectTo *url.URL, sta
 	samlError = handler.persister.Transaction(func(tx *pop.Connection) error {
 		userdata := provider.GetUserData(assertionInfo)
 
-		linkResult, samlError := thirdparty.LinkAccount(tx, handler.config, handler.persister, userdata, state.Provider)
+		linkResult, samlError := thirdparty.LinkAccount(tx, handler.config, handler.persister, userdata, state.Provider, true)
 		if samlError != nil {
 			return samlError
 		}

--- a/backend/handler/thirdparty.go
+++ b/backend/handler/thirdparty.go
@@ -143,7 +143,7 @@ func (h *ThirdPartyHandler) Callback(c echo.Context) error {
 			return thirdparty.ErrorInvalidRequest("could not retrieve user data from provider").WithCause(terr)
 		}
 
-		linkingResult, terr := thirdparty.LinkAccount(tx, h.cfg, h.persister, userData, provider.Name())
+		linkingResult, terr := thirdparty.LinkAccount(tx, h.cfg, h.persister, userData, provider.Name(), false)
 		if terr != nil {
 			return terr
 		}

--- a/backend/thirdparty/linking.go
+++ b/backend/thirdparty/linking.go
@@ -19,7 +19,7 @@ const (
 	getIdentityFailure = "could not get identity"
 )
 
-func LinkAccount(tx *pop.Connection, cfg *config.Config, p persistence.Persister, userData *UserData, providerName string) (*AccountLinkingResult, error) {
+func LinkAccount(tx *pop.Connection, cfg *config.Config, p persistence.Persister, userData *UserData, providerName string, isSaml bool) (*AccountLinkingResult, error) {
 	if cfg.Emails.RequireVerification && !userData.Metadata.EmailVerified {
 		return nil, ErrorUnverifiedProviderEmail("third party provider email must be verified")
 	}
@@ -38,15 +38,15 @@ func LinkAccount(tx *pop.Connection, cfg *config.Config, p persistence.Persister
 		if user == nil {
 			return signUp(tx, cfg, p, userData, providerName)
 		} else {
-			return link(tx, cfg, p, userData, providerName, user)
+			return link(tx, cfg, p, userData, providerName, user, isSaml)
 		}
 	} else {
 		return signIn(tx, cfg, p, userData, identity)
 	}
 }
 
-func link(tx *pop.Connection, cfg *config.Config, p persistence.Persister, userData *UserData, providerName string, user *models.User) (*AccountLinkingResult, error) {
-	if !cfg.ThirdParty.Providers.Get(providerName).AllowLinking {
+func link(tx *pop.Connection, cfg *config.Config, p persistence.Persister, userData *UserData, providerName string, user *models.User, isSaml bool) (*AccountLinkingResult, error) {
+	if !isSaml && !cfg.ThirdParty.Providers.Get(providerName).AllowLinking {
 		return nil, ErrorUserConflict("third party account linking for existing user with same email disallowed")
 	}
 


### PR DESCRIPTION
# Description

With the introduction of the `allow_linking` parameter for the thirdparty social provider the saml login is broken when an account for the email already exists.

# Implementation

Only check the `allow_linking` parameter while linking to an already existing user when it is not a saml provider.

# Tests

Configure a saml provider and try to login with an already existing user.
