### PR TITLE
chore: individual input fields for 'identifier', 'email' and 'username'

### DIFF
--- a/backend/flow_api/flow/shared/errors.go
+++ b/backend/flow_api/flow/shared/errors.go
@@ -18,4 +18,5 @@ var (
 var (
 	ErrorEmailAlreadyExists    = flowpilot.NewInputError("email_already_exists", "The email address already exists.")
 	ErrorUsernameAlreadyExists = flowpilot.NewInputError("username_already_exists", "The username already exists.")
+	ErrorUnknownUsername       = flowpilot.NewInputError("unknown_username_error", "The username is unknown.")
 )


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

- Enables the UI to differentiate between the login identifier options, both email and username, or exclusively emails or usernames.
- Additionally, introduces a new error type for handling unknown usernames, enabling the UI to respond accordingly.

# Implementation

Previously, there was one input field named 'identifier', but in the UI, the placeholder in the input field should indicate whether the user can enter an email, a username, or both. Therefore, individual fields are now available. The introduced private method `analyzeIdentifierInputs()` checks the user input and determines, from the individual fields, the information of the input field expected based on the backend configuration.
