### PR TITLE
feat: add user data to payload on success

### DIFF
--- a/backend/flow_api/flow/login/flow.go
+++ b/backend/flow_api/flow/login/flow.go
@@ -52,7 +52,7 @@ var Flow = flowpilot.NewFlow("/login").
 		shared.Back{},
 	).
 	State(StateLoginPasswordRecovery, PasswordRecovery{}).
-	BeforeState(shared.StateSuccess, shared.IssueSession{}).
+	BeforeState(shared.StateSuccess, shared.IssueSession{}, shared.GetUserData{}).
 	State(shared.StateSuccess).
 	State(shared.StateError).
 	SubFlows(capabilities.SubFlow, passkey_onboarding.SubFlow, passcode.SubFlow).

--- a/backend/flow_api/flow/registration/flow.go
+++ b/backend/flow_api/flow/registration/flow.go
@@ -23,7 +23,7 @@ var Flow = flowpilot.NewFlow("/registration").
 	State(StateRegistrationInit, RegisterLoginIdentifier{}, shared.ThirdPartyOAuth{}).
 	State(shared.StateThirdPartyOAuth, shared.ExchangeToken{}).
 	State(StatePasswordCreation, RegisterPassword{}, shared.Back{}).
-	BeforeState(shared.StateSuccess, CreateUser{}, shared.IssueSession{}).
+	BeforeState(shared.StateSuccess, CreateUser{}, shared.IssueSession{}, shared.GetUserData{}).
 	State(shared.StateSuccess).
 	State(shared.StateError).
 	SubFlows(capabilities.SubFlow, passkey_onboarding.SubFlow, passcode.SubFlow).

--- a/backend/flow_api/flow/shared/hook_get_user_data.go
+++ b/backend/flow_api/flow/shared/hook_get_user_data.go
@@ -21,7 +21,7 @@ func (h GetUserData) Execute(c flowpilot.HookExecutionContext) error {
 
 	userModel, err := deps.Persister.GetUserPersisterWithConnection(deps.Tx).Get(userId)
 	if err != nil {
-		return fmt.Errorf("failed to get user fro db: %w", err)
+		return fmt.Errorf("failed to get user from db: %w", err)
 	}
 
 	err = c.Payload().Set("user", dto.ProfileDataFromUserModel(userModel))

--- a/backend/flow_api/flow/shared/hook_get_user_data.go
+++ b/backend/flow_api/flow/shared/hook_get_user_data.go
@@ -1,0 +1,33 @@
+package shared
+
+import (
+	"fmt"
+	"github.com/gofrs/uuid"
+	"github.com/teamhanko/hanko/backend/dto"
+	"github.com/teamhanko/hanko/backend/flowpilot"
+)
+
+type GetUserData struct {
+	Action
+}
+
+func (h GetUserData) Execute(c flowpilot.HookExecutionContext) error {
+	deps := h.GetDeps(c)
+
+	userId, err := uuid.FromString(c.Stash().Get("user_id").String())
+	if err != nil {
+		return fmt.Errorf("failed to parse stashed user_id into a uuid: %w", err)
+	}
+
+	userModel, err := deps.Persister.GetUserPersisterWithConnection(deps.Tx).Get(userId)
+	if err != nil {
+		return fmt.Errorf("failed to get user fro db: %w", err)
+	}
+
+	err = c.Payload().Set("user", dto.ProfileDataFromUserModel(userModel))
+	if err != nil {
+		return fmt.Errorf("failed to set user payload: %w", err)
+	}
+
+	return nil
+}

--- a/frontend/frontend-sdk/src/lib/flow-api/types/payload.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/types/payload.ts
@@ -54,3 +54,7 @@ export interface User {
 export interface ProfilePayload {
   readonly user: User;
 }
+
+export interface SuccessPayload {
+  readonly user: User;
+}

--- a/frontend/frontend-sdk/src/lib/flow-api/types/state-handling.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/types/state-handling.ts
@@ -20,6 +20,7 @@ import {
   OnboardingVerifyPasskeyAttestationPayload,
   PasscodeConfirmationPayload,
   ProfilePayload,
+  SuccessPayload,
 } from "./payload";
 
 export type StateName =
@@ -71,7 +72,7 @@ export interface Payloads {
   readonly onboarding_verify_passkey_attestation: OnboardingVerifyPasskeyAttestationPayload;
   readonly registration_init: null;
   readonly password_creation: null;
-  readonly success: null;
+  readonly success: SuccessPayload;
   readonly error: null;
 }
 


### PR DESCRIPTION
# Description
After a successful registration or login, the payload of the success state now includes the user object. This is needed to modify the JavaScript event "hanko-session-created" to include this data.

# Implementation
- A new hook has been implemented to gather data from the database and add the user model to the payload.
- The type interfaces of the JS SDK have been modified accordingly