### PR TITLE
fix: don't override error before return

### DIFF
--- a/backend/handler/webauthn.go
+++ b/backend/handler/webauthn.go
@@ -200,9 +200,9 @@ func (h *WebauthnHandler) FinishRegistration(c echo.Context) error {
 				errorMessage = fmt.Sprintf("%s: %s: %s", errorMessage, err.Details, err.DevInfo)
 				errorStatus = http.StatusUnprocessableEntity
 			}
-			err = h.auditLogger.CreateWithConnection(tx, c, models.AuditLogWebAuthnRegistrationFinalFailed, user, errors.New(errorMessage))
-			if err != nil {
-				return fmt.Errorf(CreateAuditLogFailureMessage, err)
+			aErr := h.auditLogger.CreateWithConnection(tx, c, models.AuditLogWebAuthnRegistrationFinalFailed, user, errors.New(errorMessage))
+			if aErr != nil {
+				return fmt.Errorf(CreateAuditLogFailureMessage, aErr)
 			}
 
 			return echo.NewHTTPError(errorStatus, errorMessage).SetInternal(err)


### PR DESCRIPTION
# Description

When registering a webauthn credential fails the internal error is overridden and therefore not returned.

# Implementation

The error is overridden by an auditLogger error, now the auditLog error is now assigned to a new variable instead.

# Tests

Create a webauthn config where `origins` is not set correct (e.g. "https://example.com") and try to register a new webauthn credential. Before the fix the error on the logs on show `code=400, message=failed to validate attestation`. With the fix it should include the internal error `code=400, message=failed to validate attestation, internal=Error validating origin`
