### PR TITLE
feat(saml): make getting providers from metadata non-panic

### DIFF
--- a/backend/ee/saml/handler.go
+++ b/backend/ee/saml/handler.go
@@ -36,12 +36,14 @@ func NewSamlHandler(cfg *config.Config, persister persistence.Persister, session
 			name := ""
 			name, err := parseProviderFromMetadataUrl(idpConfig.MetadataUrl)
 			if err != nil {
-				panic(err)
+				fmt.Printf("failed to parse provider from metadata url: %v\n", err)
+				continue
 			}
 
 			newProvider, err := provider.GetProvider(name, cfg, idpConfig, persister.GetSamlCertificatePersister())
 			if err != nil {
-				panic(err)
+				fmt.Printf("failed to initialize provider: %v\n", err)
+				continue
 			}
 
 			providers = append(providers, newProvider)


### PR DESCRIPTION
# Description

Changes the error behaviour when initialising saml providers. Instead of stoping the application now there will be a warning that the provider could not be loaded. The provider in question will be ignored on startup.

Closes: #1445 