### PR TITLE
Update package.json

### DIFF
--- a/frontend/elements/package.json
+++ b/frontend/elements/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@teamhanko/hanko-elements",
   "version": "0.11.0",
+  "type": "module",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes issue in Node 22 of Hanko not being a valid module

# Description

In Node 22 the following error is generated when installing Hanko Elements:

```
(node:30657) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
```

You can try this out by:

- using Node 22 (e.g `brew install node@22`)
- using SvelteKit (e.g `npm create svelte@latest mytest`)
- installing Hanko (`npm install --save @teamhanko/hanko-elements`)
- running the dev server (`npm run dev`)

This is caused by the fact that HankoElements is not declared as an ESM module correctly. As Node.js is migrating away from CommonJS, this is a rather known bug in many packages. To fix this issue, you have two options:

- declare the module type
- use `.mjs` which will instruct Node.js to import files using ESM

The later however [isn't really supported by browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#browser_compatibility).

# Tests

Updating the `package.json` of an installed Hanko Elements with the proposed box "just works" and unbreaks builds.

# Additional context

I attached a [vite_build.log](https://github.com/user-attachments/files/15984301/vite_build.log) log for reference.