### PR TITLE
feat: add webhook env var decoder

### DIFF
--- a/backend/config/webhook_config_test.go
+++ b/backend/config/webhook_config_test.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWebhooks_Decode(t *testing.T) {
+	webhooks := Webhooks{}
+	value := "{\"callback\":\"http://app.com/usercb\",\"events\":[\"user\"]};{\"callback\":\"http://app.com/callback\",\"events\":[\"email.send\"]}"
+	err := webhooks.Decode(value)
+
+	assert.NoError(t, err)
+	assert.Len(t, webhooks, 2, "has 2 elements")
+	for _, webhook := range webhooks {
+		assert.IsType(t, Webhook{}, webhook)
+	}
+}

--- a/backend/docs/Config.md
+++ b/backend/docs/Config.md
@@ -1016,6 +1016,10 @@ webhooks:
     #
     # Callback - Endpoint URL to which the change data will be sent
     #
+    # NOTE: When using environment variables hooks must be defined as in the following example:
+    #
+    # WEBHOOKS_HOOKS={"callback":"http://app.com/usercb","events":["user"]};{"callback":"http://app.com/emailcb","events":["email.send"]}
+    #
     - callback: "<YOUR WEBHOOK ENDPOINT URL>"
       ##
       #


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

The `webhook.hooks` config option is an array of objects. When using environment variables, specifying the hooks such that the `envconfig` package can correctly map the values into the config struct does not seem to be possible with the built-in capabilities.

# Implementation

`envconfig` allows defining custom decoders, though. This PR introduces an implementation so that hooks can be defined via environment variables as follows:

```shell
WEBHOOKS_HOOKS={"callback":"http://app.com/usercb","events":["user"]};{"callback":"http://app.com/emailcb","events":["email.send"]}
```