### PR TITLE
add flow api logging

### DIFF
--- a/backend/flow_api/handler.go
+++ b/backend/flow_api/handler.go
@@ -87,7 +87,6 @@ func (h *FlowPilotHandler) executeFlow(c echo.Context, flow flowpilot.Flow) erro
 		err = h.Persister.Transaction(txFunc)
 		if err != nil {
 			flowResult = flow.ResultFromError(err)
-			c.Logger().Errorf("failed to handle the request: %v", err)
 		}
 	}
 

--- a/backend/flowpilot/errors.go
+++ b/backend/flowpilot/errors.go
@@ -67,9 +67,12 @@ func (e *defaultError) toResponseError(debug bool) *ResponseError {
 		Message: e.Message(),
 	}
 
-	if debug && e.cause != nil {
+	if e.cause != nil {
 		cause := e.cause.Error()
-		publicError.Cause = &cause
+		publicError.Internal = &cause
+		if debug {
+			publicError.Cause = &cause
+		}
 	}
 
 	return publicError

--- a/backend/flowpilot/response.go
+++ b/backend/flowpilot/response.go
@@ -18,9 +18,10 @@ type ResponseActions map[ActionName]ResponseAction
 
 // ResponseError represents an error for public exposure.
 type ResponseError struct {
-	Code    string  `json:"code"`
-	Message string  `json:"message"`
-	Cause   *string `json:"cause,omitempty"`
+	Code     string  `json:"code"`
+	Message  string  `json:"message"`
+	Cause    *string `json:"cause,omitempty"`
+	Internal *string `json:"-"`
 }
 
 type ResponseAllowedValue struct {


### PR DESCRIPTION
# Description

Uses zerolog to log requests to the flow API. The logging middleware from echo could be used but an error from the flow API would not be logged. Thats because the handler function would need to return an error in order to be logged by the middleware, but the flow API handler does not return an error. So the handler logs the requests itself with zerolog.

# TODO

The logs from the flow API handler and from the middleware should log the same values. Currently the middleware logs more values that the flow API handler. We should check which values are needed and which we can remove.
