### PR TITLE
Compress stash data

### DIFF
--- a/backend/flow_api/handler.go
+++ b/backend/flow_api/handler.go
@@ -124,7 +124,8 @@ func (h *FlowPilotHandler) executeFlow(c echo.Context, flow flowpilot.Flow) erro
 		flowResult, err = flow.Execute(models.NewFlowDB(tx),
 			flowpilot.WithQueryParamKey(queryParamKey),
 			flowpilot.WithQueryParamValue(c.QueryParam(queryParamKey)),
-			flowpilot.WithInputData(inputData))
+			flowpilot.WithInputData(inputData),
+			flowpilot.UseCompression(!h.Cfg.Debug))
 
 		return err
 	}

--- a/backend/flowpilot/context.go
+++ b/backend/flowpilot/context.go
@@ -121,6 +121,8 @@ func createAndInitializeFlow(db FlowDB, flow defaultFlow) (FlowResult, error) {
 		return nil, fmt.Errorf("failed to initialize a new stash: %w", err)
 	}
 
+	s.useCompression(flow.useCompression)
+
 	p := newPayload()
 
 	csrfToken, err := generateRandomString(32)
@@ -188,6 +190,8 @@ func executeFlowAction(db FlowDB, flow defaultFlow) (FlowResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse stash from flow: %w", err)
 	}
+
+	s.useCompression(flow.useCompression)
 
 	// Initialize JSONManagers for payload and flash data.
 	p := newPayload()

--- a/backend/flowpilot/flow.go
+++ b/backend/flowpilot/flow.go
@@ -36,6 +36,13 @@ func WithInputData(inputData InputData) func(*defaultFlow) {
 	}
 }
 
+// UseCompression causes the flow data to be compressed before stored to the db.
+func UseCompression(b bool) func(*defaultFlow) {
+	return func(f *defaultFlow) {
+		f.useCompression = b
+	}
+}
+
 // StateName represents the name of a state in a flow.
 type StateName string
 
@@ -191,6 +198,7 @@ type defaultFlow struct {
 	queryParam        queryParam    // TODO
 	contextValues     contextValues // Values to be used within the flow context.
 	inputData         InputData
+	useCompression    bool
 	queryParamKey     string
 	queryParamValue   string
 


### PR DESCRIPTION


# Description

Adds a new execution option `UseCompression(bool)` to the Flowpilot. It controls whether the stash data should be compressed or not. The Flow API will enable compression when `config.Debug` is `false` or store the stash contents as plaintext otherwise.
