### PR TITLE
fix: respect length requirements username

### DIFF
--- a/backend/flow_api/flow/profile/action_username_create.go
+++ b/backend/flow_api/flow/profile/action_username_create.go
@@ -38,6 +38,8 @@ func (a UsernameCreate) Initialize(c flowpilot.InitializationContext) {
 	c.AddInputs(flowpilot.StringInput("username").
 		Preserve(true).
 		Required(true).
+		MinLength(deps.Cfg.Username.MinLength).
+		MaxLength(deps.Cfg.Username.MaxLength).
 		TrimSpace(true).
 		LowerCase(true))
 }

--- a/backend/flow_api/flow/profile/action_username_update.go
+++ b/backend/flow_api/flow/profile/action_username_update.go
@@ -38,6 +38,8 @@ func (a UsernameUpdate) Initialize(c flowpilot.InitializationContext) {
 	c.AddInputs(flowpilot.StringInput("username").
 		Preserve(true).
 		Required(true).
+		MinLength(deps.Cfg.Username.MinLength).
+		MaxLength(deps.Cfg.Username.MaxLength).
 		TrimSpace(true).
 		LowerCase(true))
 }


### PR DESCRIPTION
# Description

Respect the length requirements of the username when creating or changing it. Currently when the username is set or changed in the profile the username can have any length and the config parameters have no effect. Also this is true when the username is set during a login flow.
