### PR TITLE
fix: fix faulity migration

### DIFF
--- a/backend/persistence/migrations/20240530122100_change_tokens.up.fizz
+++ b/backend/persistence/migrations/20240530122100_change_tokens.up.fizz
@@ -1,6 +1,6 @@
 add_column("tokens", "identity_id", "uuid", {"null":true})
 add_column("tokens", "is_flow", "bool", {"default":false})
-add_column("tokens", "user_created", "bool")
+add_column("tokens", "user_created", "bool", {"default": false})
 
 add_foreign_key("tokens", "identity_id", {"identities": ["id"]}, {
     "on_delete": "cascade",


### PR DESCRIPTION
# Description

Fix a migration which can fail if tokens are stored in the db.

# Tests

Have at least one token in the token table and try to migrate the database from v0.12.0 to v1.0.0, it should work now. Before the migration failed.

