### PR TITLE
feat: return complete user in admin API

### DIFF
--- a/backend/cmd/user/import_test.go
+++ b/backend/cmd/user/import_test.go
@@ -213,7 +213,7 @@ func (s *importSuite) Test_addToDatabase() {
 
 			s.SetupTest()
 			tt.wantErr(t, addToDatabase(tt.args.entries, tt.args.persister), fmt.Sprintf("addToDatabase(%v, %v)", tt.args.entries, tt.args.persister))
-			users, err := tt.args.persister.GetUserPersister().List(0, 100, uuid.Nil, "", "")
+			users, err := tt.args.persister.GetUserPersister().List(0, 100, uuid.Nil, "", "", "")
 			log.Println(users)
 			s.NoError(err)
 			s.Equal(tt.wantNumUsers, len(users))

--- a/backend/dto/admin/identity.go
+++ b/backend/dto/admin/identity.go
@@ -1,0 +1,27 @@
+package admin
+
+import (
+	"github.com/gofrs/uuid"
+	"github.com/teamhanko/hanko/backend/persistence/models"
+	"time"
+)
+
+type Identity struct {
+	ID           uuid.UUID `json:"id"`
+	ProviderID   string    `json:"provider_id"`
+	ProviderName string    `json:"provider_name"`
+	EmailID      uuid.UUID `json:"email_id"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+func FromIdentityModel(model models.Identity) Identity {
+	return Identity{
+		ID:           model.ID,
+		ProviderID:   model.ProviderID,
+		ProviderName: model.ProviderName,
+		EmailID:      model.EmailID,
+		CreatedAt:    model.CreatedAt,
+		UpdatedAt:    model.UpdatedAt,
+	}
+}

--- a/backend/dto/admin/password.go
+++ b/backend/dto/admin/password.go
@@ -1,0 +1,12 @@
+package admin
+
+import (
+	"github.com/gofrs/uuid"
+	"time"
+)
+
+type PasswordCredential struct {
+	ID        uuid.UUID `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/backend/dto/admin/user.go
+++ b/backend/dto/admin/user.go
@@ -11,8 +11,11 @@ type User struct {
 	ID                  uuid.UUID                        `json:"id"`
 	WebauthnCredentials []dto.WebauthnCredentialResponse `json:"webauthn_credentials,omitempty"`
 	Emails              []Email                          `json:"emails,omitempty"`
+	Username            *Username                        `json:"username,omitempty"`
 	CreatedAt           time.Time                        `json:"created_at"`
 	UpdatedAt           time.Time                        `json:"updated_at"`
+	Password            *PasswordCredential              `json:"password,omitempty"`
+	Identities          []Identity                       `json:"identities,omitempty"`
 }
 
 // FromUserModel Converts the DB model to a DTO object
@@ -22,20 +25,42 @@ func FromUserModel(model models.User) User {
 		credentials[i] = *dto.FromWebauthnCredentialModel(&model.WebauthnCredentials[i])
 	}
 	emails := make([]Email, len(model.Emails))
+	var identities = make([]Identity, 0)
 	for i := range model.Emails {
 		emails[i] = *FromEmailModel(&model.Emails[i])
+		for j := range model.Emails[i].Identities {
+			identities = append(identities, FromIdentityModel(model.Emails[i].Identities[j]))
+		}
 	}
+	var username *Username = nil
+	if model.Username != nil {
+		username = FromUsernameModel(model.Username)
+	}
+
+	var passwordCredential *PasswordCredential = nil
+	if model.PasswordCredential != nil {
+		passwordCredential = &PasswordCredential{
+			ID:        model.PasswordCredential.ID,
+			CreatedAt: model.PasswordCredential.CreatedAt,
+			UpdatedAt: model.PasswordCredential.UpdatedAt,
+		}
+	}
+
 	return User{
 		ID:                  model.ID,
 		WebauthnCredentials: credentials,
 		Emails:              emails,
+		Username:            username,
 		CreatedAt:           model.CreatedAt,
 		UpdatedAt:           model.UpdatedAt,
+		Password:            passwordCredential,
+		Identities:          identities,
 	}
 }
 
 type CreateUser struct {
 	ID        uuid.UUID     `json:"id"`
-	Emails    []CreateEmail `json:"emails" validate:"required,gte=1,unique=Address,dive"`
+	Emails    []CreateEmail `json:"emails" validate:"unique=Address,dive"`
+	Username  *string       `json:"username"`
 	CreatedAt time.Time     `json:"created_at"`
 }

--- a/backend/dto/admin/username.go
+++ b/backend/dto/admin/username.go
@@ -1,0 +1,24 @@
+package admin
+
+import (
+	"github.com/gofrs/uuid"
+	"github.com/teamhanko/hanko/backend/persistence/models"
+	"time"
+)
+
+type Username struct {
+	ID        uuid.UUID `json:"id"`
+	Username  string    `json:"username"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// FromEmailModel Converts the DB model to a DTO object
+func FromUsernameModel(model *models.Username) *Username {
+	return &Username{
+		ID:        model.ID,
+		Username:  model.Username,
+		CreatedAt: model.CreatedAt,
+		UpdatedAt: model.UpdatedAt,
+	}
+}

--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -177,7 +177,9 @@ func (h *UserHandlerAdmin) Create(c echo.Context) error {
 		}
 	}
 
-	if primaryEmails > 1 {
+	if primaryEmails == 0 && len(body.Emails) > 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "at least one primary email must be provided")
+	} else if primaryEmails > 1 {
 		return echo.NewHTTPError(http.StatusBadRequest, "only one primary email is allowed")
 	}
 

--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -64,6 +64,7 @@ type UserListRequest struct {
 	Page          int    `query:"page"`
 	Email         string `query:"email"`
 	UserId        string `query:"user_id"`
+	Username      string `query:"username"`
 	SortDirection string `query:"sort_direction"`
 }
 
@@ -101,13 +102,14 @@ func (h *UserHandlerAdmin) List(c echo.Context) error {
 	}
 
 	email := strings.ToLower(request.Email)
+	username := strings.ToLower(request.Username)
 
-	users, err := h.persister.GetUserPersister().List(request.Page, request.PerPage, userId, email, request.SortDirection)
+	users, err := h.persister.GetUserPersister().List(request.Page, request.PerPage, userId, email, username, request.SortDirection)
 	if err != nil {
 		return fmt.Errorf("failed to get list of users: %w", err)
 	}
 
-	userCount, err := h.persister.GetUserPersister().Count(userId, email)
+	userCount, err := h.persister.GetUserPersister().Count(userId, email, username)
 	if err != nil {
 		return fmt.Errorf("failed to get total count of users: %w", err)
 	}
@@ -154,6 +156,10 @@ func (h *UserHandlerAdmin) Create(c echo.Context) error {
 		return dto.ToHttpError(err)
 	}
 
+	if len(body.Emails) == 0 && (body.Username == nil || *body.Username == "") {
+		return echo.NewHTTPError(http.StatusBadRequest, "at least one of [Emails, Username] must be set")
+	}
+
 	// if no userID is provided, create a new one
 	if body.ID.IsNil() {
 		userId, err := uuid.NewV4()
@@ -171,9 +177,7 @@ func (h *UserHandlerAdmin) Create(c echo.Context) error {
 		}
 	}
 
-	if primaryEmails == 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, "at least one primary email must be provided")
-	} else if primaryEmails > 1 {
+	if primaryEmails > 1 {
 		return echo.NewHTTPError(http.StatusBadRequest, "only one primary email is allowed")
 	}
 
@@ -236,6 +240,25 @@ func (h *UserHandlerAdmin) Create(c echo.Context) error {
 				if err != nil {
 					return fmt.Errorf("failed to set email '%s' as primary for user '%v': %w", mail.Address, u.ID, err)
 				}
+			}
+		}
+
+		if body.Username != nil {
+			username := models.NewUsername(u.ID, *body.Username)
+			err = tx.Create(username)
+			if err != nil {
+				var pgErr *pgconn.PgError
+				var mysqlErr *mysql.MySQLError
+				if errors.As(err, &pgErr) {
+					if pgErr.Code == "23505" {
+						return echo.NewHTTPError(http.StatusConflict, fmt.Errorf("failed to create username '%s' for user '%v': %w", username.Username, u.ID, fmt.Errorf("username already exists")))
+					}
+				} else if errors.As(err, &mysqlErr) {
+					if mysqlErr.Number == 1062 {
+						return echo.NewHTTPError(http.StatusConflict, fmt.Errorf("failed to create username '%s' for user '%v': %w", username.Username, u.ID, fmt.Errorf("username already exists")))
+					}
+				}
+				return fmt.Errorf("failed to create email '%s' for user '%v': %w", username.Username, u.ID, err)
 			}
 		}
 		return nil

--- a/backend/handler/user_admin_test.go
+++ b/backend/handler/user_admin_test.go
@@ -38,7 +38,7 @@ func (s *userAdminSuite) TestUserHandlerAdmin_Delete() {
 
 	s.Equal(http.StatusNoContent, rec.Code)
 
-	count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "")
+	count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "", "")
 	s.Require().NoError(err)
 	s.Equal(2, count)
 }
@@ -59,7 +59,7 @@ func (s *userAdminSuite) TestUserHandlerAdmin_Delete_UnknownUserId() {
 
 	s.Equal(http.StatusNotFound, rec.Code)
 
-	count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "")
+	count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "", "")
 	s.Require().NoError(err)
 	s.Equal(3, count)
 }

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -52,7 +52,7 @@ func (s *userSuite) TestUserHandler_Create_TokenInCookie() {
 		s.NoError(err)
 		s.False(user.UserID.IsNil())
 
-		count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "")
+		count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "", "")
 		s.NoError(err)
 		s.Equal(1, count)
 
@@ -97,7 +97,7 @@ func (s *userSuite) TestUserHandler_Create_TokenInHeader() {
 		s.NoError(err)
 		s.False(user.UserID.IsNil())
 
-		count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "")
+		count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "", "")
 		s.NoError(err)
 		s.Equal(1, count)
 
@@ -137,7 +137,7 @@ func (s *userSuite) TestUserHandler_Create_CaseInsensitive() {
 		s.NoError(err)
 		s.False(user.UserID.IsNil())
 
-		count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "")
+		count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "", "")
 		s.NoError(err)
 		s.Equal(1, count)
 

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -572,7 +572,7 @@ func (s *userSuite) TestUserHandler_Delete() {
 		s.Equal("Max-Age=0", strings.TrimSpace(split[2]))
 	}
 
-	count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "")
+	count, err := s.Storage.GetUserPersister().Count(uuid.Nil, "", "")
 	s.NoError(err)
 	s.Equal(0, count)
 }

--- a/backend/persistence/user_persister.go
+++ b/backend/persistence/user_persister.go
@@ -16,9 +16,9 @@ type UserPersister interface {
 	Create(models.User) error
 	Update(models.User) error
 	Delete(models.User) error
-	List(page int, perPage int, userId uuid.UUID, email string, sortDirection string) ([]models.User, error)
+	List(page int, perPage int, userId uuid.UUID, email string, username string, sortDirection string) ([]models.User, error)
 	All() ([]models.User, error)
-	Count(userId uuid.UUID, email string) (int, error)
+	Count(userId uuid.UUID, email string, username string) (int, error)
 	GetByUsername(username string) (*models.User, error)
 }
 
@@ -129,17 +129,17 @@ func (p *userPersister) Delete(user models.User) error {
 	return nil
 }
 
-func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, sortDirection string) ([]models.User, error) {
+func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, username string, sortDirection string) ([]models.User, error) {
 	users := []models.User{}
 
 	query := p.db.
 		Q().
-		EagerPreload("Emails", "Emails.PrimaryEmail", "WebauthnCredentials").
+		EagerPreload("Emails", "Emails.PrimaryEmail", "WebauthnCredentials", "Username").
 		LeftJoin("emails", "emails.user_id = users.id").
 		LeftJoin("usernames", "usernames.user_id = users.id")
-	query = p.addQueryParamsToSqlQuery(query, userId, email)
+	query = p.addQueryParamsToSqlQuery(query, userId, email, username)
 	err := query.GroupBy("users.id").
-		Having("count(emails.id) > 0").
+		Having("count(emails.id) > 0 OR count(usernames.id) > 0").
 		Order(fmt.Sprintf("users.created_at %s", sortDirection)).
 		Paginate(page, perPage).
 		All(&users)
@@ -156,7 +156,7 @@ func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email stri
 
 func (p *userPersister) All() ([]models.User, error) {
 	users := []models.User{}
-	err := p.db.EagerPreload("Emails", "Emails.PrimaryEmail", "Emails.Identities", "WebauthnCredentials", "Usernames").All(&users)
+	err := p.db.EagerPreload("Emails", "Emails.PrimaryEmail", "Emails.Identities", "WebauthnCredentials", "Username").All(&users)
 	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return users, nil
 	}
@@ -167,13 +167,14 @@ func (p *userPersister) All() ([]models.User, error) {
 	return users, nil
 }
 
-func (p *userPersister) Count(userId uuid.UUID, email string) (int, error) {
+func (p *userPersister) Count(userId uuid.UUID, email string, username string) (int, error) {
 	query := p.db.
 		Q().
-		LeftJoin("emails", "emails.user_id = users.id")
-	query = p.addQueryParamsToSqlQuery(query, userId, email)
+		LeftJoin("emails", "emails.user_id = users.id").
+		LeftJoin("usernames", "usernames.user_id = users.id")
+	query = p.addQueryParamsToSqlQuery(query, userId, email, username)
 	count, err := query.GroupBy("users.id").
-		Having("count(emails.id) > 0").
+		Having("count(emails.id) > 0 OR count(usernames.id) > 0").
 		Count(&models.User{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to get user count: %w", err)
@@ -182,10 +183,15 @@ func (p *userPersister) Count(userId uuid.UUID, email string) (int, error) {
 	return count, nil
 }
 
-func (p *userPersister) addQueryParamsToSqlQuery(query *pop.Query, userId uuid.UUID, email string) *pop.Query {
-	if email != "" {
+func (p *userPersister) addQueryParamsToSqlQuery(query *pop.Query, userId uuid.UUID, email string, username string) *pop.Query {
+	if email != "" && username != "" {
+		query = query.Where("emails.address LIKE ? OR usernames.username LIKE ?", "%"+email+"%", "%"+username+"%")
+	} else if email != "" {
 		query = query.Where("emails.address LIKE ?", "%"+email+"%")
+	} else if username != "" {
+		query = query.Where("usernames.username LIKE ?", "%"+username+"%")
 	}
+
 	if !userId.IsNil() {
 		query = query.Where("users.id = ?", userId)
 	}

--- a/backend/test/user_persister.go
+++ b/backend/test/user_persister.go
@@ -64,7 +64,7 @@ func (p *userPersister) Delete(user models.User) error {
 	return nil
 }
 
-func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, sortDirection string) ([]models.User, error) {
+func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email string, username string, sortDirection string) ([]models.User, error) {
 	if len(p.users) == 0 {
 		return p.users, nil
 	}
@@ -96,7 +96,7 @@ func (p *userPersister) All() ([]models.User, error) {
 	return p.users, nil
 }
 
-func (p *userPersister) Count(userId uuid.UUID, email string) (int, error) {
+func (p *userPersister) Count(userId uuid.UUID, email string, username string) (int, error) {
 	return len(p.users), nil
 }
 


### PR DESCRIPTION

# Description

Add username, identities and password credential to the return object when calling /users/{user_id} from the admin API.
The password credential does not include the password hash, only the metadata is returned.

The added information is always returned without considering the config, e.g. when password credentials are associated with users they are also returned when passwords are disabled by the config.



