### PR TITLE
fix: fix email verified check for saml

### DIFF
--- a/backend/ee/saml/provider/saml.go
+++ b/backend/ee/saml/provider/saml.go
@@ -76,7 +76,7 @@ func (sp *BaseSamlProvider) GetUserData(assertionInfo *saml2.AssertionInfo) *thi
 
 	email := thirdparty.Email{
 		Email:    emailAddress,
-		Verified: assertionValues.Get(attributeMap.EmailVerified) != "",
+		Verified: assertionValues.Get(attributeMap.EmailVerified) == "true",
 		Primary:  true,
 	}
 


### PR DESCRIPTION
# Description

Fix the email_verified check in the Hanko SAML provider.

# Implementation

Currently it is only check if the field in the SAML response is not an empty string, but when the SAML provider returns `false` for the email_verified field the Hanko SAML provider interprets it as `true`. Now it check if the value is `true` and when it is not, the email_verified field in Hanko will be set to `false`.

# Tests

E.g. Use the quickstart app and setup SAML in hanko and login with an user which email is not verified and check in the profile that the email is not verified.

