### PR TITLE
fix: passcode invalid error not shown

### DIFF
--- a/backend/flow_api/flow/credential_usage/action_webauthn_verify_assertion_response.go
+++ b/backend/flow_api/flow/credential_usage/action_webauthn_verify_assertion_response.go
@@ -69,7 +69,9 @@ func (a WebauthnVerifyAssertionResponse) Execute(c flowpilot.ExecutionContext) e
 				return fmt.Errorf("could not create audit log: %w", err)
 			}
 
-			return c.Error(shared.ErrorPasskeyInvalid.Wrap(err))
+			c.SetFlowError(shared.ErrorPasskeyInvalid.Wrap(err))
+
+			return c.Continue(shared.StateError)
 		}
 
 		return fmt.Errorf("failed to verify assertion response: %w", err)


### PR DESCRIPTION
# Description

When using an unknown / invalid passkey, the error page with the corresponding error message will be displayed.
