### PR TITLE
fix: only use transaction connection in a transaction

### DIFF
--- a/backend/flow_api/flow/credential_usage/action_password_login.go
+++ b/backend/flow_api/flow/credential_usage/action_password_login.go
@@ -60,7 +60,7 @@ func (a PasswordLogin) Execute(c flowpilot.ExecutionContext) error {
 	var userID uuid.UUID
 
 	if c.Stash().Get(shared.StashPathEmail).Exists() {
-		emailModel, err := deps.Persister.GetEmailPersister().FindByAddress(c.Stash().Get(shared.StashPathEmail).String())
+		emailModel, err := deps.Persister.GetEmailPersisterWithConnection(deps.Tx).FindByAddress(c.Stash().Get(shared.StashPathEmail).String())
 		if err != nil {
 			return fmt.Errorf("failed to find user by email: %w", err)
 		}

--- a/backend/flow_api/flow/credential_usage/action_resend_passcode.go
+++ b/backend/flow_api/flow/credential_usage/action_resend_passcode.go
@@ -59,7 +59,7 @@ func (a ReSendPasscode) Execute(c flowpilot.ExecutionContext) error {
 		EmailAddress: c.Stash().Get(shared.StashPathEmail).String(),
 		Language:     deps.HttpContext.Request().Header.Get("Accept-Language"),
 	}
-	passcodeResult, err := deps.PasscodeService.SendPasscode(sendParams)
+	passcodeResult, err := deps.PasscodeService.SendPasscode(deps.Tx, sendParams)
 	if err != nil {
 		return fmt.Errorf("passcode service failed: %w", err)
 	}
@@ -79,7 +79,7 @@ func (a ReSendPasscode) Execute(c flowpilot.ExecutionContext) error {
 		},
 	}
 
-	err = utils.TriggerWebhooks(deps.HttpContext, events.EmailSend, webhookData)
+	err = utils.TriggerWebhooks(deps.HttpContext, deps.Tx, events.EmailSend, webhookData)
 	if err != nil {
 		return fmt.Errorf("failed to trigger webhook: %w", err)
 	}

--- a/backend/flow_api/flow/credential_usage/hook_send_passcode.go
+++ b/backend/flow_api/flow/credential_usage/hook_send_passcode.go
@@ -70,7 +70,7 @@ func (h SendPasscode) Execute(c flowpilot.HookExecutionContext) error {
 			Language:     deps.HttpContext.Request().Header.Get("Accept-Language"),
 		}
 
-		passcodeResult, err := deps.PasscodeService.SendPasscode(sendParams)
+		passcodeResult, err := deps.PasscodeService.SendPasscode(deps.Tx, sendParams)
 		if err != nil {
 			return fmt.Errorf("passcode service failed: %w", err)
 		}
@@ -100,7 +100,7 @@ func (h SendPasscode) Execute(c flowpilot.HookExecutionContext) error {
 			},
 		}
 
-		err = utils.TriggerWebhooks(deps.HttpContext, events.EmailSend, webhookData)
+		err = utils.TriggerWebhooks(deps.HttpContext, deps.Tx, events.EmailSend, webhookData)
 		if err != nil {
 			return fmt.Errorf("failed to trigger webhook: %w", err)
 		}

--- a/backend/flow_api/flow/profile/action_account_delete.go
+++ b/backend/flow_api/flow/profile/action_account_delete.go
@@ -63,7 +63,7 @@ func (a AccountDelete) Execute(c flowpilot.ExecutionContext) error {
 
 	deps.HttpContext.SetCookie(cookie)
 
-	err = utils.TriggerWebhooks(deps.HttpContext, events.UserDelete, admin.FromUserModel(*userModel))
+	err = utils.TriggerWebhooks(deps.HttpContext, deps.Tx, events.UserDelete, admin.FromUserModel(*userModel))
 	if err != nil {
 		return fmt.Errorf("failed to trrigger webhook: %w", err)
 	}

--- a/backend/flow_api/flow/registration/action_register_login_identifier.go
+++ b/backend/flow_api/flow/registration/action_register_login_identifier.go
@@ -113,7 +113,7 @@ func (a RegisterLoginIdentifier) Execute(c flowpilot.ExecutionContext) error {
 
 		// Check that email is not already taken
 		// this check is non-exhaustive as the email is not blocked here and might be created after the check here and the user creation
-		emailModel, err := deps.Persister.GetEmailPersister().FindByAddress(email)
+		emailModel, err := deps.Persister.GetEmailPersisterWithConnection(deps.Tx).FindByAddress(email)
 		if err != nil {
 			return err
 		}

--- a/backend/flow_api/services/passcode.go
+++ b/backend/flow_api/services/passcode.go
@@ -42,7 +42,7 @@ type SendPasscodeResult struct {
 
 type Passcode interface {
 	ValidatePasscode(ValidatePasscodeParams) (bool, error)
-	SendPasscode(SendPasscodeParams) (*SendPasscodeResult, error)
+	SendPasscode(*pop.Connection, SendPasscodeParams) (*SendPasscodeResult, error)
 	VerifyPasscodeCode(tx *pop.Connection, passcodeID uuid.UUID, passcode string) error
 }
 
@@ -110,7 +110,7 @@ func (s *passcode) VerifyPasscodeCode(tx *pop.Connection, passcodeID uuid.UUID, 
 	return nil
 }
 
-func (s *passcode) SendPasscode(p SendPasscodeParams) (*SendPasscodeResult, error) {
+func (s *passcode) SendPasscode(tx *pop.Connection, p SendPasscodeParams) (*SendPasscodeResult, error) {
 	code, err := s.passcodeGenerator.Generate()
 	if err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ func (s *passcode) SendPasscode(p SendPasscodeParams) (*SendPasscodeResult, erro
 		UpdatedAt: now,
 	}
 
-	err = s.persister.GetPasscodePersister().Create(passcodeModel)
+	err = s.persister.GetPasscodePersisterWithConnection(tx).Create(passcodeModel)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/handler/admin_router.go
+++ b/backend/handler/admin_router.go
@@ -49,7 +49,7 @@ func NewAdminRouter(cfg *config.Config, persister persistence.Persister, prometh
 		panic(fmt.Errorf("failed to create jwk manager: %w", err))
 	}
 
-	webhookMiddleware := hankoMiddleware.WebhookMiddleware(cfg, jwkManager, persister.GetWebhookPersister(nil))
+	webhookMiddleware := hankoMiddleware.WebhookMiddleware(cfg, jwkManager, persister)
 
 	userHandler := NewUserHandlerAdmin(persister)
 	emailHandler := NewEmailAdminHandler(cfg, persister)

--- a/backend/handler/passcode.go
+++ b/backend/handler/passcode.go
@@ -228,14 +228,14 @@ func (h *PasscodeHandler) Init(c echo.Context) error {
 			return fmt.Errorf("failed to send passcode: %w", err)
 		}
 
-		err = utils.TriggerWebhooks(c, events.EmailSend, webhookData)
+		err = utils.TriggerWebhooks(c, h.persister.GetConnection(), events.EmailSend, webhookData)
 
 		if err != nil {
 			zeroLogger.Warn().Err(err).Msg("failed to trigger webhook")
 		}
 	} else {
 		webhookData.DeliveredByHanko = false
-		err = utils.TriggerWebhooks(c, events.EmailSend, webhookData)
+		err = utils.TriggerWebhooks(c, h.persister.GetConnection(), events.EmailSend, webhookData)
 
 		if err != nil {
 			return fmt.Errorf(fmt.Sprintf("failed to trigger webhook: %s", err))

--- a/backend/handler/public_router.go
+++ b/backend/handler/public_router.go
@@ -77,7 +77,7 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister, promet
 
 	sessionMiddleware := hankoMiddleware.Session(cfg, sessionManager)
 
-	webhookMiddleware := hankoMiddleware.WebhookMiddleware(cfg, jwkManager, persister.GetWebhookPersister(nil))
+	webhookMiddleware := hankoMiddleware.WebhookMiddleware(cfg, jwkManager, persister)
 
 	e.POST("/registration", flowAPIHandler.RegistrationFlowHandler, webhookMiddleware)
 	e.POST("/login", flowAPIHandler.LoginFlowHandler, webhookMiddleware)

--- a/backend/handler/thirdparty.go
+++ b/backend/handler/thirdparty.go
@@ -201,7 +201,7 @@ func (h *ThirdPartyHandler) Callback(c echo.Context) error {
 	}
 
 	if accountLinkingResult.WebhookEvent != nil {
-		err = webhookUtils.TriggerWebhooks(c, *accountLinkingResult.WebhookEvent, admin.FromUserModel(*accountLinkingResult.User))
+		err = webhookUtils.TriggerWebhooks(c, h.persister.GetConnection(), *accountLinkingResult.WebhookEvent, admin.FromUserModel(*accountLinkingResult.User))
 		if err != nil {
 			c.Logger().Warn(err)
 		}

--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -158,7 +158,7 @@ func (h *UserHandler) Create(c echo.Context) error {
 		}
 
 		if !h.cfg.Email.RequireVerification {
-			err = utils.TriggerWebhooks(c, events.UserCreate, admin.FromUserModel(newUser))
+			err = utils.TriggerWebhooks(c, tx, events.UserCreate, admin.FromUserModel(newUser))
 			if err != nil {
 				c.Logger().Warn(err)
 			}
@@ -288,7 +288,7 @@ func (h *UserHandler) Delete(c echo.Context) error {
 
 		c.SetCookie(cookie)
 
-		err = utils.TriggerWebhooks(c, events.UserDelete, admin.FromUserModel(*user))
+		err = utils.TriggerWebhooks(c, tx, events.UserDelete, admin.FromUserModel(*user))
 		if err != nil {
 			c.Logger().Warn(err)
 		}

--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -51,7 +51,7 @@ func (h *UserHandlerAdmin) Delete(c echo.Context) error {
 		return fmt.Errorf("failed to delete user: %w", err)
 	}
 
-	err = utils.TriggerWebhooks(c, events.UserDelete, admin.FromUserModel(*user))
+	err = utils.TriggerWebhooks(c, h.persister.GetConnection(), events.UserDelete, admin.FromUserModel(*user))
 	if err != nil {
 		c.Logger().Warn(err)
 	}
@@ -284,7 +284,7 @@ func (h *UserHandlerAdmin) Create(c echo.Context) error {
 
 	userDto := admin.FromUserModel(*user)
 
-	err = utils.TriggerWebhooks(c, events.UserCreate, userDto)
+	err = utils.TriggerWebhooks(c, h.persister.GetConnection(), events.UserCreate, userDto)
 	if err != nil {
 		c.Logger().Warn(err)
 	}

--- a/backend/middleware/webhook.go
+++ b/backend/middleware/webhook.go
@@ -8,7 +8,7 @@ import (
 	"github.com/teamhanko/hanko/backend/webhooks"
 )
 
-func WebhookMiddleware(cfg *config.Config, jwkManager hankoJwk.Manager, persister persistence.WebhookPersister) echo.MiddlewareFunc {
+func WebhookMiddleware(cfg *config.Config, jwkManager hankoJwk.Manager, persister persistence.Persister) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) error {
 

--- a/backend/webhooks/manager_test.go
+++ b/backend/webhooks/manager_test.go
@@ -27,7 +27,7 @@ func (s *managerSuite) TestNewManager() {
 	cfg := config.Config{}
 	jwkManager := test.JwkManager{}
 
-	manager, err := NewManager(&cfg, s.Storage.GetWebhookPersister(nil), jwkManager, nil)
+	manager, err := NewManager(&cfg, s.Storage, jwkManager, nil)
 	s.NoError(err)
 	s.NotEmpty(manager)
 }
@@ -36,7 +36,7 @@ func (s *managerSuite) TestManager_GenerateJWT() {
 	cfg := config.Config{}
 	jwkManager := test.JwkManager{}
 
-	manager, err := NewManager(&cfg, s.Storage.GetWebhookPersister(nil), jwkManager, nil)
+	manager, err := NewManager(&cfg, s.Storage, jwkManager, nil)
 
 	testData := "lorem-ipsum"
 
@@ -55,10 +55,10 @@ func (s *managerSuite) TestManager_TriggerWithoutHook() {
 	cfg := config.Config{}
 	jwkManager := test.JwkManager{}
 
-	manager, err := NewManager(&cfg, s.Storage.GetWebhookPersister(nil), jwkManager, nil)
+	manager, err := NewManager(&cfg, s.Storage, jwkManager, nil)
 	s.Require().NoError(err)
 
-	manager.Trigger(events.UserCreate, "lorem-ipsum")
+	manager.Trigger(s.Storage.GetConnection(), events.UserCreate, "lorem-ipsum")
 
 	// give it 1 sec to trigger
 	time.Sleep(1 * time.Second)
@@ -87,10 +87,10 @@ func (s *managerSuite) TestManager_TriggerWithConfigHook() {
 	}
 
 	jwkManager := test.JwkManager{}
-	manager, err := NewManager(&cfg, s.Storage.GetWebhookPersister(nil), jwkManager, nil)
+	manager, err := NewManager(&cfg, s.Storage, jwkManager, nil)
 	s.Require().NoError(err)
 
-	manager.Trigger(events.UserCreate, "lorem-ipsum")
+	manager.Trigger(s.Storage.GetConnection(), events.UserCreate, "lorem-ipsum")
 
 	// give it 1 sec to trigger
 	time.Sleep(1 * time.Second)
@@ -120,10 +120,10 @@ func (s *managerSuite) TestManager_TriggerWithDisabledConfigHook() {
 	}
 
 	jwkManager := test.JwkManager{}
-	manager, err := NewManager(&cfg, s.Storage.GetWebhookPersister(nil), jwkManager, nil)
+	manager, err := NewManager(&cfg, s.Storage, jwkManager, nil)
 	s.Require().NoError(err)
 
-	manager.Trigger(events.UserCreate, "lorem-ipsum")
+	manager.Trigger(s.Storage.GetConnection(), events.UserCreate, "lorem-ipsum")
 
 	// give it 1 sec to trigger
 	time.Sleep(1 * time.Second)
@@ -145,10 +145,10 @@ func (s *managerSuite) TestManager_TriggerWithDbHook() {
 
 	s.createTestDatabaseWebhook(persister, true, server.URL)
 
-	manager, err := NewManager(&cfg, persister, jwkManager, nil)
+	manager, err := NewManager(&cfg, s.Storage, jwkManager, nil)
 	s.Require().NoError(err)
 
-	manager.Trigger(events.UserCreate, "lorem-ipsum")
+	manager.Trigger(s.Storage.GetConnection(), events.UserCreate, "lorem-ipsum")
 
 	// give it 1 sec to trigger
 	time.Sleep(1 * time.Second)
@@ -169,10 +169,10 @@ func (s *managerSuite) TestManager_TriggerWithDisabledDbHook() {
 
 	s.createTestDatabaseWebhook(persister, false, server.URL)
 
-	manager, err := NewManager(&cfg, persister, jwkManager, nil)
+	manager, err := NewManager(&cfg, s.Storage, jwkManager, nil)
 	s.Require().NoError(err)
 
-	manager.Trigger(events.UserCreate, "lorem-ipsum")
+	manager.Trigger(s.Storage.GetConnection(), events.UserCreate, "lorem-ipsum")
 
 	// give it 1 sec to trigger
 	time.Sleep(1 * time.Second)

--- a/backend/webhooks/utils/webhook.go
+++ b/backend/webhooks/utils/webhook.go
@@ -11,17 +11,16 @@ import (
 	"github.com/teamhanko/hanko/backend/webhooks/events"
 )
 
-func TriggerWebhooks(ctx echo.Context, evt events.Event, data interface{}) error {
+func TriggerWebhooks(ctx echo.Context, tx *pop.Connection, evt events.Event, data interface{}) error {
 	webhookCtx := ctx.Get("webhook_manager")
 	if webhookCtx == nil {
 		return fmt.Errorf("unable to load webhooks manager from webhook middleware")
 	}
 
 	webhookManager := webhookCtx.(webhooks.Manager)
-	webhookManager.Trigger(evt, data)
+	webhookManager.Trigger(tx, evt, data)
 
 	return nil
-
 }
 
 func NotifyUserChange(ctx echo.Context, tx *pop.Connection, persister persistence.Persister, event events.Event, userId uuid.UUID) {
@@ -31,7 +30,7 @@ func NotifyUserChange(ctx echo.Context, tx *pop.Connection, persister persistenc
 		return
 	}
 
-	err = TriggerWebhooks(ctx, event, admin.FromUserModel(*updatedUser))
+	err = TriggerWebhooks(ctx, tx, event, admin.FromUserModel(*updatedUser))
 	if err != nil {
 		ctx.Logger().Warn(err)
 	}

--- a/backend/webhooks/utils/webhook_test.go
+++ b/backend/webhooks/utils/webhook_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/gobuffalo/pop/v6"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 	"github.com/teamhanko/hanko/backend/webhooks/events"
@@ -13,7 +14,7 @@ type testManager struct {
 	TestFunc func()
 }
 
-func (tm *testManager) Trigger(evt events.Event, data interface{}) {
+func (tm *testManager) Trigger(tx *pop.Connection, evt events.Event, data interface{}) {
 	tm.TestFunc()
 }
 
@@ -28,7 +29,7 @@ func TestWebhook_TriggerWithoutManager(t *testing.T) {
 
 	ctx := e.NewContext(req, rec)
 
-	err := TriggerWebhooks(ctx, "user", "lorem")
+	err := TriggerWebhooks(ctx, nil, "user", "lorem")
 	require.Error(t, err)
 
 	err = e.Close()
@@ -47,7 +48,7 @@ func TestWebhook_Trigger(t *testing.T) {
 	ctx := e.NewContext(req, rec)
 	ctx.Set("webhook_manager", tm)
 
-	err := TriggerWebhooks(ctx, "user", "lorem")
+	err := TriggerWebhooks(ctx, nil, "user", "lorem")
 	require.NoError(t, err)
 
 	err = e.Close()


### PR DESCRIPTION
# Description

Only use the initiated transaction connection when connecting to the database. When the transaction connection is not used inside of a transaction block, the connection pool can run out of connections and block the whole application, because a transaction blocks the one connection until the transaction is finished.

E.g. when 5 requests are incoming (on the same time) on the flow API endpoints and trigger the `register_login_identifier` a passcode is created, stored into the db, the current implementation created the passcodeModel with a different connection, because all connections are used (because of the incoming requests) and the pool cannot create new connections, all requests are blocked.

# Implementation

Always use the transaction connection in a transaction block.

# Tests

I used https://github.com/grafana/k6 to load test the application. The script can be found below.

# Todos

<!-- Are there any other outstanding issues or tasks that must be solved before this change can be possibly merged? -->

# Additional context

```
import http from 'k6/http';
import {sleep} from 'k6';

export const options = {
    // A number specifying the number of VUs to run concurrently.
    vus: 100,
    // A string specifying the total duration of the test run.
    duration: '1s',
};

// The function that defines VU logic.
//
// See https://grafana.com/docs/k6/latest/examples/get-started-with-k6/ to learn more
// about authoring k6 scripts.
//

const baseUrl = "http://localhost:8000"

const charset = 'abcdefghijklmnopqrstuvwxyz'

export default function () {
    let res = http.post(`${baseUrl}/registration`)

    if (res.status > 299) {
        console.log("res.statusCode: ", res.status)
    }

    let body = res.json()
    const data = {
        csrf_token: body.csrf_token,
        input_data: {
            webauthn_available: true,
            webauthn_conditional_mediation_available: true
        }
    }

    let res2 = http.post(`${baseUrl}${body.actions.register_client_capabilities.href}`, JSON.stringify(data), {
        headers: {'Content-Type': 'application/json'},
    })
    if (res2.status > 299) {
        console.log("res2.statusCode: ", res2.status)
    }

    let length = 20
    let random = ''
    while (length--) random += charset[(Math.random() * charset.length) | 0]

    let body2 = res2.json()
    const data2 = {
        csrf_token: body2.csrf_token,
        input_data: {
            email: `${random}@example.com`,
            username: null
        }
    }

    let res3 = http.post(`${baseUrl}${body2.actions.register_login_identifier.href}`, JSON.stringify(data2), {
        headers: {'Content-Type': 'application/json'},
    })
    if (res3.status > 299) {
        console.log("res3.statusCode: ", res3.status)
    }
    console.log("body: ", res3.json())
    sleep(1)
}
```
