### PR TITLE
fix: registration success hook execution order

### DIFF
--- a/backend/flow_api/flow/flows.go
+++ b/backend/flow_api/flow/flows.go
@@ -117,9 +117,9 @@ func NewRegistrationFlow(debug bool) flowpilot.Flow {
 			shared.StateRegistrationInit).
 		ErrorState(shared.StateError).
 		BeforeState(shared.StateSuccess,
+			shared.IssueSession{},
 			shared.GetUserData{},
-			registration.CreateUser{},
-			shared.IssueSession{}).
+			registration.CreateUser{}).
 		SubFlows(
 			CapabilitiesSubFlow,
 			CredentialUsageSubFlow,


### PR DESCRIPTION
# Description

Hook execution order is the reverse of the actual argument order for the hook application function (`BeforeState()`), so the issue session hook is run first and user creation is run last. This leads to the issue session hook not having the full data for the created user and hence the JWT also does not contain email of the user. 

Fixes #1596

# Implementation

This commit changes the order so that the issue session hook is run last.


