### PR TITLE
feat: add mfa config

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	Emails Emails `yaml:"emails" json:"emails,omitempty" koanf:"emails" jsonschema:"title=emails"`
 	// `log` configures application logging.
 	Log LoggerConfig `yaml:"log" json:"log,omitempty" koanf:"log" jsonschema:"title=log"`
+	// `mfa` configures how multi-factor-authentication behaves.
+	MFA MFA `yaml:"mfa" json:"mfa,omitempty" koanf:"mfa" jsonschema:"title=mfa"`
 	// Deprecated. See child properties for suggested replacements.
 	Passcode Passcode `yaml:"passcode" json:"passcode,omitempty" koanf:"passcode" jsonschema:"title=passcode"`
 	// `passkey` configures how passkeys  are acquired and used.

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -29,6 +29,19 @@ email_delivery:
     port: "2500"
 log:
   log_health_and_metrics: true
+mfa:
+  acquire_on_login: false
+  acquire_on_registration: true
+  enabled: true
+  optional: true
+  security_keys:
+    attestation_preference: direct
+    authenticator_attachment: cross-platform
+    enabled: true
+    limit: 10
+    user_verification: discouraged
+  totp:
+    enabled: true
 passkey:
   enabled: true
   optional: true

--- a/backend/config/config_default.go
+++ b/backend/config/config_default.go
@@ -157,6 +157,22 @@ func DefaultConfig() *Config {
 			MinLength:             3,
 			MaxLength:             32,
 		},
+		MFA: MFA{
+			AcquireOnLogin:        false,
+			AcquireOnRegistration: true,
+			Enabled:               true,
+			Optional:              true,
+			SecurityKeys: SecurityKeys{
+				AttestationPreference:   "direct",
+				AuthenticatorAttachment: "cross-platform",
+				Enabled:                 true,
+				Limit:                   10,
+				UserVerification:        "discouraged",
+			},
+			TOTP: TOTP{
+				Enabled: true,
+			},
+		},
 		Debug: false,
 	}
 }

--- a/backend/config/config_mfa.go
+++ b/backend/config/config_mfa.go
@@ -1,0 +1,36 @@
+package config
+
+type SecurityKeys struct {
+	// `attestation_preference` is used to specify the preference regarding attestation conveyance during
+	// credential generation.
+	AttestationPreference string `yaml:"attestation_preference" json:"attestation_preference,omitempty" koanf:"attestation_preference" split_words:"true" jsonschema:"default=direct,enum=direct,enum=indirect,enum=none"`
+	// `authenticator_attachment`  is used to specify the preference regarding authenticator attachment during credential registration.
+	AuthenticatorAttachment string `yaml:"authenticator_attachment" json:"authenticator_attachment,omitempty" koanf:"authenticator_attachment" split_words:"true" jsonschema:"default=cross-platform,enum=platform,enum=cross-platform,enum=no_preference"`
+	// `enabled` determines whether security keys are eligible for multi-factor-authentication.
+	Enabled bool `yaml:"enabled" json:"enabled,omitempty" koanf:"enabled" jsonschema:"default=true"`
+	// 'limit' determines the maximum number of security keys a user can register.
+	Limit int `yaml:"limit" json:"limit,omitempty" koanf:"limit" jsonschema:"default=10"`
+	// The setting applies to both WebAuthn registration and authentication ceremonies.
+	UserVerification string `yaml:"user_verification" json:"user_verification,omitempty" koanf:"user_verification" split_words:"true" jsonschema:"default=discouraged,enum=required,enum=preferred,enum=discouraged"`
+}
+
+type TOTP struct {
+	// `enabled` determines whether TOTP is eligible for multi-factor-authentication.
+	Enabled bool `yaml:"enabled" json:"enabled,omitempty" koanf:"enabled" jsonschema:"default=true"`
+}
+
+type MFA struct {
+	// `acquire_on_login` configures if users are prompted creating an MFA credential on login.
+	AcquireOnLogin bool `yaml:"acquire_on_login" json:"acquire_on_login,omitempty" koanf:"acquire_on_login" jsonschema:"default=false"`
+	// `acquire_on_registration` configures if users are prompted creating an MFA credential on registration.
+	AcquireOnRegistration bool `yaml:"acquire_on_registration" json:"acquire_on_registration,omitempty" koanf:"acquire_on_registration" jsonschema:"default=true"`
+	// `enabled` determines whether multi-factor-authentication is enabled.
+	Enabled bool `yaml:"enabled" json:"enabled,omitempty" koanf:"enabled" jsonschema:"default=true"`
+	// `optional` determines whether users must create an MFA credential when prompted. The MFA credential cannot be
+	// deleted if multi-factor-authentication is required (`optional: false`).
+	Optional bool `yaml:"optional" json:"optional,omitempty" koanf:"optional" jsonschema:"default=true"`
+	// `security_keys` configures security key settings for multi-factor-authentication
+	SecurityKeys SecurityKeys `yaml:"security_keys" json:"security_keys,omitempty" koanf:"security_keys" jsonschema:"title=security_keys"`
+	// `totp` configures the TOTP (Time-Based One-Time-Password) method for multi-factor-authentication.
+	TOTP TOTP `yaml:"totp" json:"totp,omitempty" koanf:"totp" jsonschema:"title=totp"`
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

Adds new configuration parameters as specified:

- `mfa`
    - `enabled`
        - type: bool
        - default: true
    - `optional`
        - type: bool
        - default: true
    - `acquire_on_registration`
        - type: bool
        - default: true
    - `acquire_on_login`
        - type: bool
        - default: false
    - `totp`
        - `enabled`
            - type: bool
            - default: true
    - `security_keys`
        - `enabled`
            - type: bool
            - default: true
        - `user_verification`
            - type: string
            - enum: "required, preferred, discouraged"
            - default: “discouraged”
        - `attestation_preference`
            - type: string
            - enum: "direct, indirect, none"
            - default: “direct”
        - `authenticator_attachment`
            - type: string
            - enum: ”platform, cross-platform, no_preference"
            - default: “cross-platform”
        - `limit`
            - type: int
            - default: 10

