### PR TITLE
fix: chinese email template corrected

### DIFF
--- a/backend/mail/locales/passcode.zh-CN.yaml
+++ b/backend/mail/locales/passcode.zh-CN.yaml
@@ -1,9 +1,38 @@
 login_text:
-  description: "文本电子邮件的登录内容。"
-  other: "在您的登录屏幕上输入以下验证码："
+  description: "deng lu"
+  other: "请输入以下验证码以验证您的身份："
 ttl_text:
   description: "验证码的有效时长。"
   other: "验证码在 {{ .TTL }} 分钟内有效。"
 email_subject_login:
   description: ""
-  other: "使用验证码 {{ .Code }} 登录到 {{ .ServiceName }}"
+  other: "您 {{ .ServiceName }} 的验证码为{{ .Code }} "
+subject_email_verification:
+  description: ""
+  other: "使用验证码 {{ .Code }} 验证您的电子邮件地址"
+subject_login:
+  description: ""
+  other: "使用验证码 {{ .Code }} 登录您的账户"
+subject_recovery:
+  description: ""
+  other: "使用验证码 {{ .Code }} 恢复您的账户"
+email_verification_text:
+  description: ""
+  other: "请输入以下验证码以验证您的电子邮件地址："
+recovery_text:
+  description: "恢复邮件的内容。"
+  other: "请在登录页面输入以下验证码："
+
+subject_email_login_attempted:
+  description: "有关尝试登录的通知。"
+  other: "提供的电子邮件地址未被识别"
+email_login_attempted_text:
+  description: "通知收件人，他们或其他人试图使用未被识别的电子邮件地址登录到特定服务。"
+  other: "您或其他人试图登录 {{ .ServiceName }}，但提供的电子邮件地址未被识别。请先创建一个账户。"
+
+subject_email_registration_attempted:
+  description: "有关尝试注册的通知。"
+  other: "提供的电子邮件地址已被占用"
+email_registration_attempted_text:
+  description: "通知收件人，他们或其他人试图使用已注册的电子邮件地址为特定服务注册。"
+  other: "您或其他人试图为 {{ .ServiceName }} 注册电子邮件，但提供的电子邮件地址已被注册。请尝试登录。"


### PR DESCRIPTION
# Description

The existing template for Chinese passcode emails was incomplete and caused the API to crash when a corresponding language header was set in the request. This PR includes a completed and revised template provided by a community member. 