### PR TITLE
fix(admin-api): return webauthn transports in users endpoints

### DIFF
--- a/backend/persistence/user_persister.go
+++ b/backend/persistence/user_persister.go
@@ -134,7 +134,12 @@ func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email stri
 
 	query := p.db.
 		Q().
-		EagerPreload("Emails", "Emails.PrimaryEmail", "WebauthnCredentials", "Username").
+		EagerPreload(
+			"Emails",
+			"Emails.PrimaryEmail",
+			"WebauthnCredentials",
+			"WebauthnCredentials.Transports",
+			"Username").
 		LeftJoin("emails", "emails.user_id = users.id").
 		LeftJoin("usernames", "usernames.user_id = users.id")
 	query = p.addQueryParamsToSqlQuery(query, userId, email, username)
@@ -156,10 +161,20 @@ func (p *userPersister) List(page int, perPage int, userId uuid.UUID, email stri
 
 func (p *userPersister) All() ([]models.User, error) {
 	users := []models.User{}
-	err := p.db.EagerPreload("Emails", "Emails.PrimaryEmail", "Emails.Identities", "WebauthnCredentials", "Username").All(&users)
+
+	err := p.db.EagerPreload(
+		"Emails",
+		"Emails.PrimaryEmail",
+		"Emails.Identities",
+		"WebauthnCredentials",
+		"WebauthnCredentials.Transports",
+		"Username",
+	).All(&users)
+
 	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return users, nil
 	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch users: %w", err)
 	}


### PR DESCRIPTION
# Description

Our OpenAPI Admin Spec claims that on `/users` endpoints for retrieving user information, the `webauthn_credentials` contain a `transports`  array for every credential. While the key is present in an API response, the value is alwas an empty array because the transports are not preloaded by pop.

# Implementation

Eager preload the transports in the corresponding `UserPersister` methods.

