### PR TITLE
Feat: remember last used login method

### DIFF
--- a/backend/flow_api/flow/credential_usage/action_continue_to_passcode_confirmation_recovery.go
+++ b/backend/flow_api/flow/credential_usage/action_continue_to_passcode_confirmation_recovery.go
@@ -27,6 +27,10 @@ func (a ContinueToPasscodeConfirmationRecovery) Initialize(c flowpilot.Initializ
 }
 
 func (a ContinueToPasscodeConfirmationRecovery) Execute(c flowpilot.ExecutionContext) error {
+	if err := c.Stash().Set(shared.StashPathLoginMethod, "password"); err != nil {
+		return fmt.Errorf("failed to set login_method to stash: %w", err)
+	}
+
 	if len(c.Stash().Get(shared.StashPathUserID).String()) > 0 {
 		if err := c.Stash().Set(shared.StashPathPasscodeTemplate, "recovery"); err != nil {
 			return fmt.Errorf("failed to set passcode_template to the stash: %w", err)

--- a/backend/flow_api/flow/profile/hook_get_profile_data.go
+++ b/backend/flow_api/flow/profile/hook_get_profile_data.go
@@ -21,17 +21,7 @@ func (h GetProfileData) Execute(c flowpilot.HookExecutionContext) error {
 		return errors.New("no valid session")
 	}
 
-	profileData := dto.ProfileDataFromUserModel(userModel)
-	profileData.MFAConfig.TOTPEnabled = deps.Cfg.MFA.Enabled && deps.Cfg.MFA.TOTP.Enabled
-	profileData.MFAConfig.SecurityKeysEnabled = deps.Cfg.MFA.Enabled && deps.Cfg.MFA.SecurityKeys.Enabled
-
-	if !deps.Cfg.Passkey.Enabled {
-		profileData.Passkeys = nil
-	}
-
-	if !profileData.MFAConfig.SecurityKeysEnabled {
-		profileData.SecurityKeys = nil
-	}
+	profileData := dto.ProfileDataFromUserModel(userModel, &deps.Cfg)
 
 	err := c.Payload().Set("user", profileData)
 	if err != nil {

--- a/backend/flow_api/flow/shared/action_exchange_token.go
+++ b/backend/flow_api/flow/shared/action_exchange_token.go
@@ -86,6 +86,14 @@ func (a ExchangeToken) Execute(c flowpilot.ExecutionContext) error {
 		return fmt.Errorf("failed to determine onboarding stattes: %w", err)
 	}
 
+	if err := c.Stash().Set(StashPathLoginMethod, "third_party"); err != nil {
+		return fmt.Errorf("failed to set login_method to the stash: %w", err)
+	}
+
+	if err := c.Stash().Set(StashPathThirdPartyProvider, identity.ProviderName); err != nil {
+		return fmt.Errorf("failed to set third_party_provider to the stash: %w", err)
+	}
+
 	return c.Continue(onboardingStates...)
 }
 

--- a/backend/flow_api/flow/shared/const_stash_paths.go
+++ b/backend/flow_api/flow/shared/const_stash_paths.go
@@ -16,6 +16,7 @@ const (
 	StashPathPasscodeTemplate                       = "passcode_template"
 	StashPathPasswordRecoveryPending                = "pw_recovery_pending"
 	StashPathSkipUserCreation                       = "skip_user_creation"
+	StashPathThirdPartyProvider                     = "third_party_provider"
 	StashPathUserHasEmails                          = "user_has_emails"
 	StashPathUserHasOTPSecret                       = "user_hat_otp_secret"
 	StashPathUserHasPasskey                         = "user_has_passkey"

--- a/backend/flow_api/flow/shared/hook_get_user_data.go
+++ b/backend/flow_api/flow/shared/hook_get_user_data.go
@@ -24,7 +24,7 @@ func (h GetUserData) Execute(c flowpilot.HookExecutionContext) error {
 		return fmt.Errorf("failed to get user from db: %w", err)
 	}
 
-	err = c.Payload().Set("user", dto.ProfileDataFromUserModel(userModel))
+	err = c.Payload().Set("user", dto.ProfileDataFromUserModel(userModel, &deps.Cfg))
 	if err != nil {
 		return fmt.Errorf("failed to set user payload: %w", err)
 	}

--- a/backend/flow_api/flow/shared/hook_issue_session.go
+++ b/backend/flow_api/flow/shared/hook_issue_session.go
@@ -89,19 +89,21 @@ func (h IssueSession) Execute(c flowpilot.HookExecutionContext) error {
 		}
 	}
 
-	if err := c.Payload().Set("last_login.login_method", loginMethod.String()); err != nil {
-		return fmt.Errorf("failed to set login_method to the payload: %w", err)
-	}
-
-	if thirdPartyProvider.Exists() {
-		if err := c.Payload().Set("last_login.third_party_provider", thirdPartyProvider.String()); err != nil {
-			return fmt.Errorf("failed to set third_party_provider to the payload: %w", err)
+	if loginMethod.Exists() {
+		if err := c.Payload().Set("last_login.login_method", loginMethod.String()); err != nil {
+			return fmt.Errorf("failed to set login_method to the payload: %w", err)
 		}
-	}
 
-	if mfaMethod.Exists() {
-		if err := c.Payload().Set("last_login.mfa_method", mfaMethod.String()); err != nil {
-			return fmt.Errorf("failed to set mfa_method to the payload: %w", err)
+		if thirdPartyProvider.Exists() {
+			if err := c.Payload().Set("last_login.third_party_provider", thirdPartyProvider.String()); err != nil {
+				return fmt.Errorf("failed to set third_party_provider to the payload: %w", err)
+			}
+		}
+
+		if mfaMethod.Exists() {
+			if err := c.Payload().Set("last_login.mfa_method", mfaMethod.String()); err != nil {
+				return fmt.Errorf("failed to set mfa_method to the payload: %w", err)
+			}
 		}
 	}
 

--- a/frontend/elements/src/Elements.tsx
+++ b/frontend/elements/src/Elements.tsx
@@ -133,6 +133,7 @@ export const register = async (
     translations: null,
     translationsLocation: "/i18n",
     fallbackLanguage: "en",
+    storageKey: "hanko",
     ...options,
   };
 
@@ -148,6 +149,7 @@ export const register = async (
   globalOptions.translations = options.translations || defaultTranslations;
   globalOptions.translationsLocation = options.translationsLocation;
   globalOptions.fallbackLanguage = options.fallbackLanguage;
+  globalOptions.storageKey = options.storageKey;
   await Promise.all([
     _register({
       ...options,

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -420,10 +420,12 @@ const AppProvider = ({
         setPage(<CreatePasswordPage state={state} />);
       },
       success(state) {
-        localStorage.setItem(
-          storageKeyLastLogin,
-          JSON.stringify(state.payload.last_login),
-        );
+        if (state.payload?.last_login) {
+          localStorage.setItem(
+            storageKeyLastLogin,
+            JSON.stringify(state.payload.last_login),
+          );
+        }
         hanko.relay.dispatchSessionCreatedEvent(hanko.session.get());
         lastActionSucceeded();
       },

--- a/frontend/frontend-sdk/src/lib/flow-api/types/payload.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/types/payload.ts
@@ -79,8 +79,15 @@ export interface ProfilePayload {
   readonly user: User;
 }
 
+export interface LastLogin {
+  readonly login_method: string;
+  readonly mfa_method?: string;
+  readonly third_party_provider?: string;
+}
+
 export interface SuccessPayload {
   readonly user: User;
+  readonly last_login: LastLogin;
 }
 
 export interface ThirdPartyPayload {

--- a/frontend/frontend-sdk/src/lib/flow-api/types/payload.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/types/payload.ts
@@ -91,7 +91,7 @@ export interface LastLogin {
 
 export interface SuccessPayload {
   readonly user: User;
-  readonly last_login: LastLogin;
+  readonly last_login?: LastLogin;
 }
 
 export interface ThirdPartyPayload {

--- a/frontend/frontend-sdk/src/lib/flow-api/types/payload.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/types/payload.ts
@@ -79,9 +79,13 @@ export interface ProfilePayload {
   readonly user: User;
 }
 
+export type LoginMethod = "password" | "passkey" | "passcode" | "third_party";
+
+export type MFAMethod = "totp" | "security_key";
+
 export interface LastLogin {
-  readonly login_method: string;
-  readonly mfa_method?: string;
+  readonly login_method: LoginMethod;
+  readonly mfa_method?: MFAMethod;
   readonly third_party_provider?: string;
 }
 


### PR DESCRIPTION
The 'success' state can now contain data about the recent login. This data is stored in localStorage and can be accessed during the next login via the 'AppProvider' to, for example, label certain buttons in the UI with 'last used'.