### PR TITLE
chore: improved error handling

### DIFF
--- a/backend/flow_api/flow/capabilities/action_send_capabilities.go
+++ b/backend/flow_api/flow/capabilities/action_send_capabilities.go
@@ -24,6 +24,8 @@ func (a RegisterClientCapabilities) Initialize(c flowpilot.InitializationContext
 }
 
 func (a RegisterClientCapabilities) Execute(c flowpilot.ExecutionContext) error {
+	deps := a.GetDeps(c)
+
 	if valid := c.ValidateInputData(); !valid {
 		return c.Error(flowpilot.ErrorFormDataInvalid)
 	}
@@ -42,6 +44,13 @@ func (a RegisterClientCapabilities) Execute(c flowpilot.ExecutionContext) error 
 
 	platformAuthenticatorAvailable := c.Input().Get("webauthn_platform_authenticator_available").Bool()
 	err = c.Stash().Set(shared.StashPathWebauthnPlatformAuthenticatorAvailable, platformAuthenticatorAvailable)
+	if err != nil {
+		return err
+	}
+
+	attachmentSupported := platformAuthenticatorAvailable ||
+		deps.Cfg.MFA.SecurityKeys.AuthenticatorAttachment != "platform"
+	err = c.Stash().Set(shared.StashPathSecurityKeyAttachmentSupported, attachmentSupported)
 	if err != nil {
 		return err
 	}

--- a/backend/flow_api/flow/mfa_creation/action_continue_to_security_key_creation.go
+++ b/backend/flow_api/flow/mfa_creation/action_continue_to_security_key_creation.go
@@ -19,8 +19,9 @@ func (a ContinueToSecurityKeyCreation) GetDescription() string {
 
 func (a ContinueToSecurityKeyCreation) Initialize(c flowpilot.InitializationContext) {
 	deps := a.GetDeps(c)
+	attachmentSupported := c.Stash().Get(shared.StashPathSecurityKeyAttachmentSupported).Bool()
 
-	if !deps.Cfg.MFA.Enabled || !deps.Cfg.MFA.SecurityKeys.Enabled {
+	if !deps.Cfg.MFA.Enabled || !deps.Cfg.MFA.SecurityKeys.Enabled || !attachmentSupported {
 		c.SuspendAction()
 		return
 	}

--- a/backend/flow_api/flow/mfa_usage/action_continue_to_login_security_key.go
+++ b/backend/flow_api/flow/mfa_usage/action_continue_to_login_security_key.go
@@ -19,8 +19,9 @@ func (a ContinueToLoginSecurityKey) GetDescription() string {
 
 func (a ContinueToLoginSecurityKey) Initialize(c flowpilot.InitializationContext) {
 	deps := a.GetDeps(c)
+	attachmentSupported := c.Stash().Get(shared.StashPathSecurityKeyAttachmentSupported).Bool()
 
-	if !deps.Cfg.MFA.SecurityKeys.Enabled || !c.Stash().Get(shared.StashPathUserHasWebauthnCredential).Bool() {
+	if !deps.Cfg.MFA.SecurityKeys.Enabled || !c.Stash().Get(shared.StashPathUserHasWebauthnCredential).Bool() || !attachmentSupported {
 		c.SuspendAction()
 	}
 }

--- a/backend/flow_api/flow/shared/const_stash_paths.go
+++ b/backend/flow_api/flow/shared/const_stash_paths.go
@@ -15,6 +15,7 @@ const (
 	StashPathPasscodeID                             = "sticky.passcode_id"
 	StashPathPasscodeTemplate                       = "passcode_template"
 	StashPathPasswordRecoveryPending                = "pw_recovery_pending"
+	StashPathSecurityKeyAttachmentSupported         = "security_key_attachment_supported"
 	StashPathSkipUserCreation                       = "skip_user_creation"
 	StashPathThirdPartyProvider                     = "third_party_provider"
 	StashPathUserHasEmails                          = "user_has_emails"

--- a/backend/flow_api/flow/shared/errors.go
+++ b/backend/flow_api/flow/shared/errors.go
@@ -13,6 +13,7 @@ var (
 	ErrorRateLimitExceeded                = flowpilot.NewFlowError("rate_limit_exceeded", "The rate limit has been exceeded.", http.StatusTooManyRequests)
 	ErrorUnauthorized                     = flowpilot.NewFlowError("unauthorized", "The session is invalid.", http.StatusUnauthorized)
 	ErrorWebauthnCredentialInvalidMFAOnly = flowpilot.NewFlowError("webauthn_credential_invalid_mfa_only", "This credential can be used as a second factor security key only.", http.StatusUnauthorized)
+	ErrorPlatformAuthenticatorRequired    = flowpilot.NewFlowError("platform_authenticator_required", "The device or browser does not support the required platform authenticators.", http.StatusUnauthorized)
 )
 
 var (

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -19,6 +19,7 @@ import {
 
 import {
   Hanko,
+  HankoError,
   TechnicalError,
   UnauthorizedError,
   WebauthnSupport,
@@ -247,7 +248,9 @@ const AppProvider = ({
 
   const handleError = (e: any) => {
     setLoadingAction(null);
-    setPage(<ErrorPage error={new TechnicalError(e)} />);
+    setPage(
+      <ErrorPage error={e instanceof HankoError ? e : new TechnicalError(e)} />,
+    );
   };
 
   const stateHandler: Handlers & { onError: (e: any) => void } = useMemo(
@@ -296,7 +299,7 @@ const AppProvider = ({
               .run();
 
             setLoadingAction(null);
-            stateHandler[nextState.name](nextState);
+            await hanko.flow.run(nextState, stateHandler);
           }
         })();
       },
@@ -328,7 +331,7 @@ const AppProvider = ({
           .run();
 
         setLoadingAction(null);
-        stateHandler[nextState.name](nextState);
+        await hanko.flow.run(nextState, stateHandler);
       },
       onboarding_create_passkey(state) {
         setPage(<RegisterPasskeyPage state={state} />);
@@ -343,7 +346,7 @@ const AppProvider = ({
         } catch (e) {
           const prevState = await state.actions.back(null).run();
           setLoadingAction(null);
-          stateHandler[prevState.name](prevState);
+          await hanko.flow.run(prevState, stateHandler);
           setUIState((prev) => ({
             ...prev,
             error: {
@@ -361,7 +364,7 @@ const AppProvider = ({
           .run();
 
         setLoadingAction(null);
-        stateHandler[nextState.name](nextState);
+        await hanko.flow.run(nextState, stateHandler);
       },
       async webauthn_credential_verification(state) {
         let attestationResponse: PublicKeyCredentialWithAttestationJSON;
@@ -373,7 +376,7 @@ const AppProvider = ({
         } catch (e) {
           const prevState = await state.actions.back(null).run();
           setLoadingAction(null);
-          stateHandler[prevState.name](prevState);
+          await hanko.flow.run(prevState, stateHandler);
           setUIState((prev) => ({
             ...prev,
             error: {
@@ -390,7 +393,7 @@ const AppProvider = ({
           })
           .run();
 
-        stateHandler[nextState.name](nextState);
+        await hanko.flow.run(nextState, stateHandler);
       },
       login_password(state) {
         setPage(<LoginPasswordPage state={state} />);
@@ -455,7 +458,7 @@ const AppProvider = ({
             window.location.pathname + searchParams.toString(),
           );
 
-          stateHandler[nextState.name](nextState);
+          await hanko.flow.run(nextState, stateHandler);
         } else {
           setUIState((prev) => ({
             ...prev,

--- a/frontend/elements/src/i18n/bn.ts
+++ b/frontend/elements/src/i18n/bn.ts
@@ -164,6 +164,7 @@ export const bn: Translation = {
     thirdPartyUnverifiedEmail:
       "ইমেল যাচাইকরণ প্রয়োজন. অনুগ্রহ করে আপনার প্রদানকারীর সাথে ব্যবহৃত ইমেল ঠিকানা যাচাই করুন।",
     signupDisabled: "অ্যাকাউন্ট নিবন্ধন নিষ্ক্রিয় করা হয়েছে",
+    handlerNotFoundError: "[TRANSLATION MISSING]",
   },
   flowErrors: {
     technical_error:
@@ -194,5 +195,6 @@ export const bn: Translation = {
     value_too_short_error: "মানটি খুব ছোট।",
     webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
     webauthn_credential_already_exists: "[TRANSLATION MISSING]",
+    platform_authenticator_required: "[TRANSLATION MISSING]",
   },
 };

--- a/frontend/elements/src/i18n/de.ts
+++ b/frontend/elements/src/i18n/de.ts
@@ -170,6 +170,7 @@ export const de: Translation = {
     thirdPartyUnverifiedEmail:
       "Verifizierung der E-Mail-Adresse erforderlich. Bitte verifizieren sie die genutzte E-Mail-Adresse bei ihrem Provider.",
     signupDisabled: "Die Kontoregistrierung ist deaktiviert.",
+    handlerNotFoundError: "[TRANSLATION MISSING]",
   },
   flowErrors: {
     technical_error:
@@ -201,5 +202,6 @@ export const de: Translation = {
     value_too_short_error: "Der Wert ist zu kurz.",
     webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
     webauthn_credential_already_exists: "[TRANSLATION MISSING]",
+    platform_authenticator_required: "[TRANSLATION MISSING]",
   },
 };

--- a/frontend/elements/src/i18n/en.ts
+++ b/frontend/elements/src/i18n/en.ts
@@ -171,6 +171,8 @@ export const en: Translation = {
     thirdPartyUnverifiedEmail:
       "Email verification required. Please verify the used email address with your provider.",
     signupDisabled: "Account registration is disabled.",
+    handlerNotFoundError:
+      "The current step in your process is not supported by this application version. Please try again later or contact support if the issue persists.",
   },
   flowErrors: {
     technical_error: "A technical error has occurred. Please try again later.",
@@ -201,5 +203,7 @@ export const en: Translation = {
       "This credential can be used as a second factor security key only.",
     webauthn_credential_already_exists:
       "The request either timed out, was canceled or the device is already registered. Please try again or try using another device.",
+    platform_authenticator_required:
+      "Your account is configured to use platform authenticators, but your current device or browser does not support this feature. Please try again with a compatible device or browser.",
   },
 };

--- a/frontend/elements/src/i18n/fr.ts
+++ b/frontend/elements/src/i18n/fr.ts
@@ -170,6 +170,7 @@ export const fr: Translation = {
     thirdPartyUnverifiedEmail:
       "Vérification de l'adresse e-mail requise. Veuillez vérifier l'adresse e-mail utilisée avec votre fournisseur.",
     signupDisabled: "L'enregistrement du compte est désactivé.",
+    handlerNotFoundError: "[TRANSLATION MISSING]",
   },
   flowErrors: {
     technical_error:
@@ -200,5 +201,6 @@ export const fr: Translation = {
     value_too_short_error: "La valeur est trop courte.",
     webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
     webauthn_credential_already_exists: "[TRANSLATION MISSING]",
+    platform_authenticator_required: "[TRANSLATION MISSING]",
   },
 };

--- a/frontend/elements/src/i18n/it.ts
+++ b/frontend/elements/src/i18n/it.ts
@@ -165,6 +165,7 @@ export const it: Translation = {
     thirdPartyUnverifiedEmail:
       "Verifica email richiesta. Verifica l'indirizzo email utilizzato con il tuo provider.",
     signupDisabled: "La registrazione dell'account è disabilitata.",
+    handlerNotFoundError: "[TRANSLATION MISSING]",
   },
   flowErrors: {
     technical_error: "Si è verificato un errore tecnico. Riprova più tardi.",
@@ -193,5 +194,6 @@ export const it: Translation = {
     value_too_short_error: "Il valore è troppo corto.",
     webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
     webauthn_credential_already_exists: "[TRANSLATION MISSING]",
+    platform_authenticator_required: "[TRANSLATION MISSING]",
   },
 };

--- a/frontend/elements/src/i18n/pt-BR.ts
+++ b/frontend/elements/src/i18n/pt-BR.ts
@@ -167,6 +167,7 @@ export const ptBR: Translation = {
     thirdPartyUnverifiedEmail:
       "Verificação de e-mail necessária. Por favor, verifique o e-mail utilizado com o seu provedor.",
     signupDisabled: "O registro da conta está desativado.",
+    handlerNotFoundError: "[TRANSLATION MISSING]",
   },
   flowErrors: {
     technical_error:
@@ -196,5 +197,6 @@ export const ptBR: Translation = {
     value_too_short_error: "O valor é muito curto.",
     webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
     webauthn_credential_already_exists: "[TRANSLATION MISSING]",
+    platform_authenticator_required: "[TRANSLATION MISSING]",
   },
 };

--- a/frontend/elements/src/i18n/translations.ts
+++ b/frontend/elements/src/i18n/translations.ts
@@ -152,6 +152,7 @@ export interface Translation {
     thirdPartyMultipleAccounts: string;
     thirdPartyUnverifiedEmail: string;
     signupDisabled: string;
+    handlerNotFoundError: string;
   };
   flowErrors: {
     technical_error: string;
@@ -168,6 +169,7 @@ export interface Translation {
     not_found: string;
     flow_discontinuity_error: string;
     operation_not_permitted_error: string;
+    platform_authenticator_required: string;
     form_data_invalid_error: string;
     unauthorized: string;
     value_missing_error: string;

--- a/frontend/elements/src/i18n/zh.ts
+++ b/frontend/elements/src/i18n/zh.ts
@@ -155,6 +155,7 @@ export const zh: Translation = {
     thirdPartyUnverifiedEmail:
       "需要电子邮件验证。请与您的提供商验证使用的电子邮件地址。",
     signupDisabled: "帐户注册被禁用。",
+    handlerNotFoundError: "[TRANSLATION MISSING]",
   },
   flowErrors: {
     technical_error: "发生技术错误。请稍后再试。",
@@ -179,5 +180,6 @@ export const zh: Translation = {
     value_too_short_error: "值太短。",
     webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
     webauthn_credential_already_exists: "[TRANSLATION MISSING]",
+    platform_authenticator_required: "[TRANSLATION MISSING]",
   },
 };

--- a/frontend/elements/src/pages/CreateEmailPage.tsx
+++ b/frontend/elements/src/pages/CreateEmailPage.tsx
@@ -21,7 +21,7 @@ type Props = {
 
 const CreateEmailPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { stateHandler, setLoadingAction } = useContext(AppContext);
+  const { hanko, stateHandler, setLoadingAction } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
   const [email, setEmail] = useState<string>();
 
@@ -38,7 +38,7 @@ const CreateEmailPage = (props: Props) => {
       .email_address_set({ email })
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onSkipClick = async (event: Event) => {
@@ -46,7 +46,7 @@ const CreateEmailPage = (props: Props) => {
     setLoadingAction("skip");
     const nextState = await flowState.actions.skip(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   return (

--- a/frontend/elements/src/pages/CreateOTPSecretPage.tsx
+++ b/frontend/elements/src/pages/CreateOTPSecretPage.tsx
@@ -24,7 +24,8 @@ const CreateOTPSecretPage = (props: Props) => {
   const numberOfDigits = 6;
   const { t } = useContext(TranslateContext);
   const { flowState } = useFlowState(props.state);
-  const { uiState, setLoadingAction, stateHandler } = useContext(AppContext);
+  const { hanko, uiState, setLoadingAction, stateHandler } =
+    useContext(AppContext);
   const [passcodeDigits, setPasscodeDigits] = useState<string[]>([]);
 
   const submitPasscode = useCallback(
@@ -36,7 +37,7 @@ const CreateOTPSecretPage = (props: Props) => {
         .run();
 
       setLoadingAction(null);
-      stateHandler[nextState.name](nextState);
+      await hanko.flow.run(nextState, stateHandler);
     },
     [flowState, setLoadingAction, stateHandler],
   );
@@ -59,7 +60,7 @@ const CreateOTPSecretPage = (props: Props) => {
     setLoadingAction("back");
     const nextState = await flowState.actions.back(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   useEffect(() => {

--- a/frontend/elements/src/pages/CreatePasswordPage.tsx
+++ b/frontend/elements/src/pages/CreatePasswordPage.tsx
@@ -22,7 +22,7 @@ type Props = {
 
 const CreatePasswordPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { stateHandler, setLoadingAction } = useContext(AppContext);
+  const { hanko, stateHandler, setLoadingAction } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
   const [password, setPassword] = useState<string>();
 
@@ -39,7 +39,7 @@ const CreatePasswordPage = (props: Props) => {
       .register_password({ new_password: password })
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onBackClick = async (event: Event) => {
@@ -47,7 +47,7 @@ const CreatePasswordPage = (props: Props) => {
     setLoadingAction("back");
     const nextState = await flowState.actions.back(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onSkipClick = async (event: Event) => {
@@ -55,7 +55,7 @@ const CreatePasswordPage = (props: Props) => {
     setLoadingAction("skip");
     const nextState = await flowState.actions.skip(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   return (

--- a/frontend/elements/src/pages/CreateSecurityKeyPage.tsx
+++ b/frontend/elements/src/pages/CreateSecurityKeyPage.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 const CreateSecurityKeyPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { setLoadingAction, stateHandler } = useContext(AppContext);
+  const { hanko, setLoadingAction, stateHandler } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
 
   const onPasskeySubmit = async (event: Event) => {
@@ -32,7 +32,7 @@ const CreateSecurityKeyPage = (props: Props) => {
       .webauthn_generate_creation_options(null)
       .run();
 
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onBackClick = async (event: Event) => {
@@ -40,7 +40,7 @@ const CreateSecurityKeyPage = (props: Props) => {
     setLoadingAction("back");
     const nextState = await flowState.actions.back(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   return (

--- a/frontend/elements/src/pages/CreateUsernamePage.tsx
+++ b/frontend/elements/src/pages/CreateUsernamePage.tsx
@@ -21,7 +21,7 @@ type Props = {
 
 const CreateUsernamePage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { stateHandler, setLoadingAction } = useContext(AppContext);
+  const {  hanko, stateHandler, setLoadingAction } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
   const [username, setUsername] = useState<string>();
 
@@ -38,7 +38,7 @@ const CreateUsernamePage = (props: Props) => {
       .username_create({ username })
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onSkipClick = async (event: Event) => {
@@ -46,7 +46,7 @@ const CreateUsernamePage = (props: Props) => {
     setLoadingAction("skip");
     const nextState = await flowState.actions.skip(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   return (

--- a/frontend/elements/src/pages/CredentialOnboardingChooser.tsx
+++ b/frontend/elements/src/pages/CredentialOnboardingChooser.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 const CredentialOnboardingChooserPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { setLoadingAction, stateHandler } = useContext(AppContext);
+  const { hanko, setLoadingAction, stateHandler } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
 
   const onPasskeySelectSubmit = async (event: Event) => {
@@ -32,7 +32,7 @@ const CredentialOnboardingChooserPage = (props: Props) => {
       .continue_to_passkey_registration(null)
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onPasswordSelectSubmit = async (event: Event) => {
@@ -42,7 +42,7 @@ const CredentialOnboardingChooserPage = (props: Props) => {
       .continue_to_password_registration(null)
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onBackClick = async (event: Event) => {
@@ -50,7 +50,7 @@ const CredentialOnboardingChooserPage = (props: Props) => {
     setLoadingAction("back");
     const nextState = await flowState.actions.back(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onSkipClick = async (event: Event) => {
@@ -58,7 +58,7 @@ const CredentialOnboardingChooserPage = (props: Props) => {
     setLoadingAction("skip");
     const nextState = await flowState.actions.skip(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   return (

--- a/frontend/elements/src/pages/EditPasswordPage.tsx
+++ b/frontend/elements/src/pages/EditPasswordPage.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 const EditPasswordPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { stateHandler, setLoadingAction } = useContext(AppContext);
+  const { hanko, stateHandler, setLoadingAction } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
   const [password, setPassword] = useState<string>();
 
@@ -37,7 +37,7 @@ const EditPasswordPage = (props: Props) => {
       .password_recovery({ new_password: password })
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   return (

--- a/frontend/elements/src/pages/LoginInitPage.tsx
+++ b/frontend/elements/src/pages/LoginInitPage.tsx
@@ -33,6 +33,7 @@ const LoginInitPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
   const {
     init,
+    hanko,
     initialComponentName,
     setLoadingAction,
     uiState,
@@ -71,7 +72,7 @@ const LoginInitPage = (props: Props) => {
 
     setIdentifierToUIState(identifier);
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onPasskeySubmit = async (event: Event) => {
@@ -83,7 +84,7 @@ const LoginInitPage = (props: Props) => {
       .webauthn_generate_request_options(null)
       .run();
 
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onRegisterClick = async (event: Event) => {
@@ -124,7 +125,7 @@ const LoginInitPage = (props: Props) => {
       })
       .run();
 
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const showDivider = useMemo(

--- a/frontend/elements/src/pages/LoginMethodChooser.tsx
+++ b/frontend/elements/src/pages/LoginMethodChooser.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 const LoginMethodChooserPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { setLoadingAction, stateHandler } = useContext(AppContext);
+  const { hanko, setLoadingAction, stateHandler } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
 
   const onPasswordSelectSubmit = async (event: Event) => {
@@ -32,7 +32,7 @@ const LoginMethodChooserPage = (props: Props) => {
       .continue_to_password_login(null)
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onPasscodeSelectSubmit = async (event: Event) => {
@@ -42,7 +42,7 @@ const LoginMethodChooserPage = (props: Props) => {
       .continue_to_passcode_confirmation(null)
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onBackClick = async (event: Event) => {
@@ -50,7 +50,7 @@ const LoginMethodChooserPage = (props: Props) => {
     setLoadingAction("back");
     const nextState = await flowState.actions.back(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   return (

--- a/frontend/elements/src/pages/LoginOTPPage.tsx
+++ b/frontend/elements/src/pages/LoginOTPPage.tsx
@@ -23,7 +23,7 @@ const LoginOTPPAge = (props: Props) => {
   const numberOfDigits = 6;
   const { t } = useContext(TranslateContext);
   const { flowState } = useFlowState(props.state);
-  const { setLoadingAction, stateHandler } = useContext(AppContext);
+  const { hanko, setLoadingAction, stateHandler } = useContext(AppContext);
   const [passcodeDigits, setPasscodeDigits] = useState<string[]>([]);
 
   const submitPasscode = useCallback(
@@ -35,9 +35,9 @@ const LoginOTPPAge = (props: Props) => {
         .run();
 
       setLoadingAction(null);
-      stateHandler[nextState.name](nextState);
+      await hanko.flow.run(nextState, stateHandler);
     },
-    [flowState, setLoadingAction, stateHandler],
+    [hanko, flowState, setLoadingAction, stateHandler],
   );
 
   const onPasscodeInput = (digits: string[]) => {
@@ -60,7 +60,7 @@ const LoginOTPPAge = (props: Props) => {
       .continue_to_login_security_key(null)
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   useEffect(() => {

--- a/frontend/elements/src/pages/LoginPasswordPage.tsx
+++ b/frontend/elements/src/pages/LoginPasswordPage.tsx
@@ -21,7 +21,7 @@ type Props = {
 
 const LoginPasswordPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { stateHandler, setLoadingAction } = useContext(AppContext);
+  const { hanko, stateHandler, setLoadingAction } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
   const [password, setPassword] = useState<string>();
   const [passwordRetryAfter, setPasswordRetryAfter] = useState<number>();
@@ -39,7 +39,7 @@ const LoginPasswordPage = (props: Props) => {
       .password_login({ password })
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onRecoveryClick = async (event: Event) => {
@@ -49,7 +49,7 @@ const LoginPasswordPage = (props: Props) => {
       .continue_to_passcode_confirmation_recovery(null)
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onBackClick = async (event: Event) => {
@@ -57,7 +57,7 @@ const LoginPasswordPage = (props: Props) => {
     setLoadingAction("back");
     const nextState = await flowState.actions.back(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onChooseMethodClick = async (event: Event) => {
@@ -67,7 +67,7 @@ const LoginPasswordPage = (props: Props) => {
       .continue_to_login_method_chooser(null)
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const recoveryLink = useMemo(

--- a/frontend/elements/src/pages/LoginSecurityKeyPage.tsx
+++ b/frontend/elements/src/pages/LoginSecurityKeyPage.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 const LoginSecurityKeyPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { setLoadingAction, stateHandler } = useContext(AppContext);
+  const { hanko, setLoadingAction, stateHandler } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
 
   const onSubmit = async (event: Event) => {
@@ -32,7 +32,7 @@ const LoginSecurityKeyPage = (props: Props) => {
       .webauthn_generate_request_options(null)
       .run();
 
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onClick = async (event: Event) => {
@@ -40,7 +40,7 @@ const LoginSecurityKeyPage = (props: Props) => {
     setLoadingAction("skip");
     const nextState = await flowState.actions.continue_to_login_otp(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   return (

--- a/frontend/elements/src/pages/MFAMethodChooserPage.tsx
+++ b/frontend/elements/src/pages/MFAMethodChooserPage.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 const MFAMMethodChooserPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { setLoadingAction, stateHandler } = useContext(AppContext);
+  const { hanko, setLoadingAction, stateHandler } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
 
   const onSecurityKeySubmit = async (event: Event) => {
@@ -32,7 +32,7 @@ const MFAMMethodChooserPage = (props: Props) => {
       .continue_to_security_key_creation(null)
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onTOTPSubmit = async (event: Event) => {
@@ -42,7 +42,7 @@ const MFAMMethodChooserPage = (props: Props) => {
       .continue_to_otp_secret_creation(null)
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onSkipClick = async (event: Event) => {
@@ -50,7 +50,7 @@ const MFAMMethodChooserPage = (props: Props) => {
     setLoadingAction("skip");
     const nextState = await flowState.actions.skip(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onBackClick = async (event: Event) => {
@@ -58,7 +58,7 @@ const MFAMMethodChooserPage = (props: Props) => {
     setLoadingAction("back");
     const nextState = await flowState.actions.back(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const singleAction = useMemo(() => {

--- a/frontend/elements/src/pages/PasscodePage.tsx
+++ b/frontend/elements/src/pages/PasscodePage.tsx
@@ -30,6 +30,7 @@ const PasscodePage = (props: Props) => {
   const { t } = useContext(TranslateContext);
   const { flowState } = useFlowState(props.state);
   const {
+    hanko,
     uiState,
     setUIState,
     setLoadingAction,
@@ -54,9 +55,9 @@ const PasscodePage = (props: Props) => {
       const nextState = await flowState.actions.verify_passcode({ code }).run();
 
       setLoadingAction(null);
-      stateHandler[nextState.name](nextState);
+      await hanko.flow.run(nextState, stateHandler);
     },
-    [flowState, setLoadingAction, stateHandler],
+    [hanko, flowState, setLoadingAction, stateHandler],
   );
 
   const onPasscodeInput = (digits: string[]) => {
@@ -77,7 +78,7 @@ const PasscodePage = (props: Props) => {
     setLoadingAction("passcode-resend");
     const nextState = await flowState.actions.resend_passcode(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onBackClick = async (event: Event) => {
@@ -85,7 +86,7 @@ const PasscodePage = (props: Props) => {
     setLoadingAction("back");
     const nextState = await flowState.actions.back(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   useEffect(() => {

--- a/frontend/elements/src/pages/ProfilePage.tsx
+++ b/frontend/elements/src/pages/ProfilePage.tsx
@@ -347,7 +347,7 @@ const ProfilePage = (props: Props) => {
           </Paragraph>
         </Fragment>
       ) : null}
-      {flowState.payload.user.mfa_config.security_keys_enabled ? (
+      {flowState.payload.user.mfa_config?.security_keys_enabled ? (
         <Fragment>
           <Headline1>{t("headlines.securityKeys")}</Headline1>
           <Paragraph>
@@ -376,14 +376,14 @@ const ProfilePage = (props: Props) => {
           </Paragraph>
         </Fragment>
       ) : null}
-      {flowState.payload.user.mfa_config.totp_enabled ? (
+      {flowState.payload.user.mfa_config?.totp_enabled ? (
         <Fragment>
           <Headline1>{t("headlines.authenticatorApp")}</Headline1>
           <Paragraph>
             <ManageAuthAppDropdown
               onConnect={onAuthAppSetUp}
               onDelete={onAuthAppRemove}
-              authAppSetUp={flowState.payload.user.mfa_config.auth_app_set_up}
+              authAppSetUp={flowState.payload.user.mfa_config?.auth_app_set_up}
               checkedItemID={checkedItemID}
               setCheckedItemID={setCheckedItemID}
             />

--- a/frontend/elements/src/pages/RegisterPasskeyPage.tsx
+++ b/frontend/elements/src/pages/RegisterPasskeyPage.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 const RegisterPasskeyPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
-  const { setLoadingAction, stateHandler } = useContext(AppContext);
+  const { hanko, setLoadingAction, stateHandler } = useContext(AppContext);
   const { flowState } = useFlowState(props.state);
 
   const onPasskeySubmit = async (event: Event) => {
@@ -31,8 +31,7 @@ const RegisterPasskeyPage = (props: Props) => {
     const nextState = await flowState.actions
       .webauthn_generate_creation_options(null)
       .run();
-
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onSkipClick = async (event: Event) => {
@@ -40,7 +39,7 @@ const RegisterPasskeyPage = (props: Props) => {
     setLoadingAction("skip");
     const nextState = await flowState.actions.skip(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onBackClick = async (event: Event) => {
@@ -48,7 +47,7 @@ const RegisterPasskeyPage = (props: Props) => {
     setLoadingAction("back");
     const nextState = await flowState.actions.back(null).run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   return (
@@ -63,7 +62,11 @@ const RegisterPasskeyPage = (props: Props) => {
           </Button>
         </Form>
       </Content>
-      <Footer hidden={!flowState.actions.skip?.(null) && !flowState.actions.back?.(null)}>
+      <Footer
+        hidden={
+          !flowState.actions.skip?.(null) && !flowState.actions.back?.(null)
+        }
+      >
         <Link
           uiAction={"back"}
           onClick={onBackClick}

--- a/frontend/elements/src/pages/RegistrationInitPage.tsx
+++ b/frontend/elements/src/pages/RegistrationInitPage.tsx
@@ -26,6 +26,7 @@ const RegistrationInitPage = (props: Props) => {
   const { t } = useContext(TranslateContext);
   const {
     init,
+    hanko,
     uiState,
     setUIState,
     stateHandler,
@@ -49,7 +50,7 @@ const RegistrationInitPage = (props: Props) => {
       })
       .run();
     setLoadingAction(null);
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const onUsernameInput = (event: Event) => {
@@ -83,8 +84,7 @@ const RegistrationInitPage = (props: Props) => {
         redirect_to: window.location.toString(),
       })
       .run();
-
-    stateHandler[nextState.name](nextState);
+    await hanko.flow.run(nextState, stateHandler);
   };
 
   const showDivider = useMemo(

--- a/frontend/frontend-sdk/src/lib/flow-api/Flow.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/Flow.ts
@@ -2,6 +2,7 @@ import { Client } from "../client/Client";
 import { State, isState } from "./State";
 import { Action } from "./types/action";
 import { FetchNextState, FlowPath, Handlers } from "./types/state-handling";
+import { HankoError } from "../Errors";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -93,7 +94,8 @@ class Flow extends Client {
   };
 }
 
-export class HandlerNotFoundError extends Error {
+export class HandlerNotFoundError extends HankoError {
+  // eslint-disable-next-line require-jsdoc
   constructor(public state: State<any>) {
     super(
       `No handler found for state: ${
@@ -101,7 +103,9 @@ export class HandlerNotFoundError extends Error {
           ? `"${state.name}"`
           : `(${typeof state.name})`
       }`,
+      "handlerNotFoundError",
     );
+    Object.setPrototypeOf(this, HandlerNotFoundError.prototype);
   }
 }
 


### PR DESCRIPTION
This pull request introduces two new error types: `HandlerNotFoundError `(JavaScript only) and `PlatformAuthenticatorRequiredError`. These errors handle specific scenarios related to flow states and platform authenticator support during the MFA process.

## `HandlerNotFoundError` (JavaScript only)
This error is triggered when the flow-api returns a state that the client does not recognize. You can simulate this scenario by renaming an existing state and navigating to the state with a Hanko element. If the client encounters an unknown state, the following error message will appear:

> "The current step in your process is not supported by this application version. Please try again later or contact support if the issue persists."

## `PlatformAuthenticatorRequiredError`
This error handles currently cases where the security key attachment is set to "platform," but platform authenticators are not supported by the client. The behavior differs based on the MFA onboarding configuration:

1. MFA onboarding is required and OTP is disabled:
If the platform attachment is not supported, an error will be displayed.

2. MFA onboarding is optional and no MFA method is enabled or supported:
The MFA onboarding will be skipped in this case.

3. During login:
If a user enters their password and a previously configured MFA method requires a platform authenticator that is unsupported (with OTP disabled or not configured), the error will be shown at this point as well.

**Future Improvements:**
- Display the error during registration, even before reaching the onboarding process.
- Use the error when only passkeys are enabled, and the client does not support them.