### PR TITLE
feat: add missing translations

### DIFF
--- a/frontend/elements/src/components/accordion/AddWebauthnCredentialDropdown.tsx
+++ b/frontend/elements/src/components/accordion/AddWebauthnCredentialDropdown.tsx
@@ -46,7 +46,7 @@ const AddWebauthnCredentialDropdown = ({
     >
       <Paragraph>
         {credentialType === "security-key"
-          ? t("texts.setupSecurityKey")
+          ? t("texts.securityKeySetUp")
           : t("texts.setupPasskey")}
       </Paragraph>
       <Form onSubmit={onCredentialSubmit}>

--- a/frontend/elements/src/components/accordion/ManageAuthAppDropdown.tsx
+++ b/frontend/elements/src/components/accordion/ManageAuthAppDropdown.tsx
@@ -70,7 +70,7 @@ const ManageAuthAppDropdown = ({
             loadingSpinnerPosition={"right"}
             dangerous
           >
-            {t("labels.authenticatorAppRemove")}
+            {t("labels.delete")}
           </Link>
         ) : (
           <Link

--- a/frontend/elements/src/i18n/bn.ts
+++ b/frontend/elements/src/i18n/bn.ts
@@ -11,7 +11,7 @@ export const bn: Translation = {
     registerAuthenticator: "একটি পাসকি তৈরি করুন",
     registerConfirm: "অ্যাকাউন্ট তৈরি করুন",
     registerPassword: "নতুন পাসওয়ার্ড সেট করুন",
-    otpSetUp: "[TRANSLATION MISSING]",
+    otpSetUp: "প্রমাণীকরণ অ্যাপ সেট আপ করুন",
     profileEmails: "ইমেইল",
     profilePassword: "পাসওয়ার্ড",
     profilePasskeys: "পাসকি",
@@ -33,16 +33,16 @@ export const bn: Translation = {
     signUp: "নিবন্ধন করুন",
     selectLoginMethod: "লগইন পদ্ধতি নির্বাচন করুন",
     setupLoginMethod: "লগইন পদ্ধতি সেটআপ করুন",
-    mfaSetUp: "[TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    securityKeys: "[TRANSLATION MISSING]",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp: "MFA সেট আপ করুন",
+    securityKeySetUp: "সিকিউরিটি কি যোগ করুন",
+    securityKeyLogin: "সিকিউরিটি কি",
+    otpLogin: "প্রমাণীকরণ কোড",
+    renameSecurityKey: "সিকিউরিটি কি এর নামকরণ করুন",
+    deleteSecurityKey: "সিকিউরিটি কি মুছুন",
+    securityKeys: "সিকিউরিটি কিগুলি",
+    authenticatorApp: "প্রমাণীকরণ অ্যাপ",
+    authenticatorAppAlreadySetUp: "প্রমাণীকরণ অ্যাপ সেট আপ করা হয়েছে",
+    authenticatorAppNotSetUp: "প্রমাণীকরণ অ্যাপ সেট আপ করুন",
   },
   texts: {
     enterPasscode: 'যে পাসকোডটি পাঠানো হয়েছিল "{emailAddress}" এ তা লিখুন.',
@@ -52,9 +52,11 @@ export const bn: Translation = {
       "একটি পাসকি দিয়ে সহজে এবং নিরাপদে আপনার অ্যাকাউন্টে সাইন ইন করুন। দ্রষ্টব্য: আপনার বায়োমেট্রিক ডেটা শুধুমাত্র আপনার ডিভাইসে সংরক্ষিত থাকে এবং কখনই কারো সাথে শেয়ার করা হবে না।",
     createAccount:
       '"{emailAddress}"-এর জন্য কোনো অ্যাকাউন্ট বিদ্যমান নেই। আপনি একটি নতুন অ্যাকাউন্ট তৈরি করতে চান?',
-    otpEnterVerificationCode: "[TRANSLATION MISSING]",
-    otpScanQRCode: "[TRANSLATION MISSING]",
-    otpSecretKey: "[TRANSLATION MISSING]",
+    otpEnterVerificationCode:
+      "আপনার প্রমাণীকরণ অ্যাপ থেকে প্রাপ্ত একবারের পাসওয়ার্ড (OTP) নিচে লিখুন:",
+    otpScanQRCode:
+      "আপনার প্রমাণীকরণ অ্যাপ দিয়ে QR কোড স্ক্যান করুন (যেমন Google Authenticator বা অন্য কোনো TOTP অ্যাপ)। বিকল্পভাবে, আপনি অ্যাপে OTP গোপন কী ম্যানুয়ালি লিখতে পারেন।",
+    otpSecretKey: "OTP গোপন কী",
     passwordFormatHint: "{minLength} এবং {maxLength} অক্ষরের মধ্যে হতে হবে।",
     setPrimaryEmail:
       "এই ইমেইল ঠিকানা আপনার সাথে যোগাযোগ করার জন্য নির্ধারণ করুন।",
@@ -72,15 +74,19 @@ export const bn: Translation = {
     selectLoginMethodForFutureLogins:
       "ভবিষ্যতে লগইনের জন্য একটি প্রয়োজনীয় লগইন পদ্ধতি নির্বাচন করুন।",
     howDoYouWantToLogin: "আপনি কিভাবে লগইন করতে চান?",
-    mfaSetUp: "TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    setupSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING]",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp:
+      "মাল্টি-ফ্যাক্টর প্রমাণীকরণের (MFA) মাধ্যমে আপনার অ্যাকাউন্ট সুরক্ষিত করুন। MFA আপনার লগইন প্রক্রিয়ায় একটি অতিরিক্ত পদক্ষেপ যোগ করে, নিশ্চিত করে যে আপনার পাসওয়ার্ড বা ইমেইল অ্যাকাউন্ট ক্ষতিগ্রস্ত হলে আপনার অ্যাকাউন্ট সুরক্ষিত থাকে।",
+    securityKeyLogin:
+      "আপনার নিরাপত্তা কী সংযুক্ত বা সক্রিয় করুন, তারপর নীচের বোতামটিতে ক্লিক করুন। প্রস্তুত হলে, USB, NFC, আপনার মোবাইল ফোনের মাধ্যমে এটি ব্যবহার করুন। লগইন প্রক্রিয়া সম্পূর্ণ করতে নির্দেশাবলীর অনুসরণ করুন।",
+    otpLogin:
+      "এককালীন পাসওয়ার্ড (OTP) প্রাপ্ত করতে আপনার প্রমাণীকরণ অ্যাপ খুলুন। আপনার লগইন সম্পূর্ণ করতে নীচের ক্ষেত্রে কোড প্রবেশ করুন।",
+    renameSecurityKey: "নিরাপত্তা কী জন্য একটি নাম সেট করুন।",
+    deleteSecurityKey: "এই নিরাপত্তা কীটি আপনার অ্যাকাউন্ট থেকে মুছে ফেলুন।",
+    authenticatorAppAlreadySetUp:
+      "আপনার অ্যাকাউন্ট একটি প্রমাণীকরণ অ্যাপ দ্বারা সুরক্ষিত যা মাল্টি-ফ্যাক্টর প্রমাণীকরণের জন্য সময়-ভিত্তিক এককালীন পাসওয়ার্ড (TOTP) তৈরি করে।",
+    authenticatorAppNotSetUp:
+      "মাল্টি-ফ্যাক্টর প্রমাণীকরণের জন্য সময়-ভিত্তিক এককালীন পাসওয়ার্ড (TOTP) তৈরি করার জন্য একটি প্রমাণীকরণ অ্যাপ দ্বারা আপনার অ্যাকাউন্টটি সুরক্ষিত করুন।",
+    securityKeySetUp: "নিরাপত্তা কী যুক্ত করুন",
   },
   labels: {
     or: "বা",
@@ -88,7 +94,7 @@ export const bn: Translation = {
     yes: "হ্যাঁ",
     email: "ইমেইল",
     continue: "চালিয়ে যান",
-    copied: "[TRANSLATION MISSING]",
+    copied: "নকল করা হয়েছে",
     skip: "এড়িয়ে যান",
     save: "সংরক্ষণ",
     passkey: "পাসওয়ার্ড",
@@ -128,16 +134,15 @@ export const bn: Translation = {
     setUsername: "ব্যবহারকারীর নাম সেট করুন",
     changePassword: "পাসওয়ার্ড পরিবর্তন করুন",
     setPassword: "পাসওয়ার্ড সেট করুন",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    securityKey: "[TRANSLATION MISSING]",
-    securityKeyUse: "[TRANSLATION MISSING]",
-    newSecurityKeyName: "[TRANSLATION MISSING]",
-    createSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppManage: "[TRANSLATION MISSING]",
-    authenticatorAppAdd: "[TRANSLATION MISSING]",
-    authenticatorAppRemove: "[TRANSLATION MISSING]",
-    configured: "[TRANSLATION MISSING]",
-    useAnotherMethod: "[TRANSLATION MISSING]",
+    authenticatorApp: "প্রমাণীকরণ অ্যাপ",
+    securityKey: "নিরাপত্তা কী",
+    securityKeyUse: "নিরাপত্তা কী ব্যবহার করুন",
+    newSecurityKeyName: "নতুন নিরাপত্তা কী নাম",
+    createSecurityKey: "নিরাপত্তা কী তৈরি করুন",
+    authenticatorAppManage: "প্রমাণীকরণ অ্যাপ পরিচালনা করুন",
+    authenticatorAppAdd: "সেট আপ করুন",
+    configured: "কনফিগার করা হয়েছে",
+    useAnotherMethod: "আরেকটি পদ্ধতি ব্যবহার করুন",
   },
   errors: {
     somethingWentWrong:
@@ -164,7 +169,7 @@ export const bn: Translation = {
     thirdPartyUnverifiedEmail:
       "ইমেল যাচাইকরণ প্রয়োজন. অনুগ্রহ করে আপনার প্রদানকারীর সাথে ব্যবহৃত ইমেল ঠিকানা যাচাই করুন।",
     signupDisabled: "অ্যাকাউন্ট নিবন্ধন নিষ্ক্রিয় করা হয়েছে",
-    handlerNotFoundError: "[TRANSLATION MISSING]",
+    handlerNotFoundError: "কার্যকরী পদক্ষেপ পাওয়া যায়নি",
   },
   flowErrors: {
     technical_error:
@@ -193,8 +198,11 @@ export const bn: Translation = {
     value_missing_error: "মান অনুপস্থিত।",
     value_too_long_error: "মানটি খুব দীর্ঘ।",
     value_too_short_error: "মানটি খুব ছোট।",
-    webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
-    webauthn_credential_already_exists: "[TRANSLATION MISSING]",
-    platform_authenticator_required: "[TRANSLATION MISSING]",
+    webauthn_credential_invalid_mfa_only:
+      "এই প্রমাণপত্রটি কেবল দ্বিতীয় ফ্যাক্টর নিরাপত্তা কী হিসাবে ব্যবহার করা যেতে পারে।",
+    webauthn_credential_already_exists:
+      "অনুরোধটি সময়সীমা শেষ হয়ে গেছে, বাতিল হয়েছে অথবা ডিভাইসটি ইতিমধ্যে নিবন্ধিত। পুনরায় চেষ্টা করুন অথবা অন্য একটি ডিভাইস ব্যবহার করে চেষ্টা করুন।",
+    platform_authenticator_required:
+      "আপনার অ্যাকাউন্ট প্ল্যাটফর্ম প্রমাণীকরণকারীদের ব্যবহার করতে কনফিগার করা হয়েছে, তবে আপনার বর্তমান ডিভাইস বা ব্রাউজার এই বৈশিষ্ট্য সমর্থন করে না। দয়া করে একটি সামঞ্জস্যপূর্ণ ডিভাইস বা ব্রাউজার ব্যবহার করে আবার চেষ্টা করুন।",
   },
 };

--- a/frontend/elements/src/i18n/de.ts
+++ b/frontend/elements/src/i18n/de.ts
@@ -11,7 +11,7 @@ export const de: Translation = {
     registerAuthenticator: "Erstellen Sie einen Passkey",
     registerConfirm: "Konto erstellen?",
     registerPassword: "Neues Passwort eingeben",
-    otpSetUp: "[TRANSLATION MISSING]",
+    otpSetUp: "Authenticator-App einrichten",
     profileEmails: "E-Mails",
     profilePassword: "Passwort",
     profilePasskeys: "Passkeys",
@@ -33,16 +33,16 @@ export const de: Translation = {
     signUp: "Registrieren",
     selectLoginMethod: "Wähle die Anmelde-Methode",
     setupLoginMethod: "Anmelde-Methode einrichten",
-    mfaSetUp: "[TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    securityKeys: "[TRANSLATION MISSING]",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp: "MFA einrichten",
+    securityKeySetUp: "Sicherheitsschlüssel hinzufügen",
+    securityKeyLogin: "Sicherheitsschlüssel",
+    otpLogin: "Authentifizierungscode",
+    renameSecurityKey: "Sicherheitsschlüssel umbenennen",
+    deleteSecurityKey: "Sicherheitsschlüssel löschen",
+    securityKeys: "Sicherheitsschlüssel",
+    authenticatorApp: "Authenticator-App",
+    authenticatorAppNotSetUp: "Authenticator-App einrichten",
+    authenticatorAppAlreadySetUp: "Authenticator-App ist eingerichtet",
   },
   texts: {
     enterPasscode:
@@ -53,9 +53,11 @@ export const de: Translation = {
       "Ihr Gerät unterstützt die sichere Anmeldung mit Passkeys. Hinweis: Ihre biometrischen Daten verbleiben sicher auf Ihrem Gerät und werden niemals an unseren Server gesendet.",
     createAccount:
       'Es existiert kein Konto für "{emailAddress}". Möchten Sie ein neues Konto erstellen?',
-    otpEnterVerificationCode: "[TRANSLATION MISSING]",
-    otpScanQRCode: "[TRANSLATION MISSING]",
-    otpSecretKey: "[TRANSLATION MISSING]",
+    otpEnterVerificationCode:
+      "Geben Sie den einmaligen Passwort (OTP) ein, den Sie von Ihrer Authenticator-App erhalten haben:",
+    otpScanQRCode:
+      "Scannen Sie den QR-Code mit Ihrer Authenticator-App (z.B. Google Authenticator oder jede andere TOTP-App). Alternativ können Sie den OTP-Geheimschlüssel manuell in die App eingeben.",
+    otpSecretKey: "OTP-Geheimschlüssel",
     passwordFormatHint:
       "Das Passwort muss zwischen {minLength} und {maxLength} Zeichen lang sein.",
     setPrimaryEmail: "Setzen Sie diese E-Mail-Adresse als Kontaktadresse.",
@@ -75,15 +77,22 @@ export const de: Translation = {
     selectLoginMethodForFutureLogins:
       "Wählen Sie eine der folgenden Anmelde-Methoden aus, um sie für zukünftige Anmeldungen zu verwenden.",
     howDoYouWantToLogin: "Wie möchten Sie sich anmelden?",
-    mfaSetUp: "TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    setupSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING]",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp:
+      "Schützen Sie Ihr Konto mit Mehrfaktor-Authentifizierung (MFA). MFA fügt Ihrer Anmeldeprozedur einen zusätzlichen Schritt hinzu, um sicherzustellen, dass Ihr Konto geschützt bleibt, selbst wenn Ihr Passwort oder E-Mail-Konto kompromittiert wird.",
+    securityKeyLogin:
+      "Verbinden oder aktivieren Sie Ihren Sicherheitsschlüssel und klicken Sie dann auf die Schaltfläche unten. Wenn Sie bereit sind, verwenden Sie USB, NFC oder Ihr Mobilgerät. Befolgen Sie die Anweisungen, um den Anmeldevorgang abzuschließen.",
+    otpLogin:
+      "Öffnen Sie Ihre Authenticator-App, um den einmaligen Passwort (OTP) zu erhalten. Geben Sie den Code im untenstehenden Feld ein, um sich anzumelden.",
+    renameSecurityKey:
+      "Legen Sie einen Namen für den Sicherheitsschlüssel fest.",
+    deleteSecurityKey:
+      "Löschen Sie diesen Sicherheitsschlüssel aus Ihrem Konto.",
+    authenticatorAppAlreadySetUp:
+      "Ihr Konto ist durch eine Authenticator-App geschützt, die zeitbasierte einmalige Passwörter (TOTP) für die Mehrfaktor-Authentifizierung generiert.",
+    authenticatorAppNotSetUp:
+      "Schützen Sie Ihr Konto mit einer Authenticator-App, die zeitbasierte einmalige Passwörter (TOTP) für die Mehrfaktor-Authentifizierung generiert.",
+    securityKeySetUp:
+      "Verwenden Sie einen dedizierten Sicherheitsschlüssel über USB, Bluetooth oder NFC oder Ihr Mobiltelefon. Schließen Sie Ihren Sicherheitsschlüssel an oder aktivieren Sie ihn, und klicken Sie dann auf die Schaltfläche unten und folgen Sie den Anweisungen, um die Registrierung abzuschließen.",
   },
   labels: {
     or: "oder",
@@ -91,7 +100,7 @@ export const de: Translation = {
     yes: "ja",
     email: "E-Mail",
     continue: "Weiter",
-    copied: "[TRANSLATION MISSING]",
+    copied: "kopiert",
     skip: "Überspringen",
     save: "Speichern",
     password: "Passwort",
@@ -131,16 +140,15 @@ export const de: Translation = {
     setUsername: "Benutzernamen setzen",
     changePassword: "Passwort ändern",
     setPassword: "Passwort setzen",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    securityKey: "[TRANSLATION MISSING]",
-    securityKeyUse: "[TRANSLATION MISSING]",
-    newSecurityKeyName: "[TRANSLATION MISSING]",
-    createSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppManage: "[TRANSLATION MISSING]",
-    authenticatorAppAdd: "[TRANSLATION MISSING]",
-    authenticatorAppRemove: "[TRANSLATION MISSING]",
-    configured: "[TRANSLATION MISSING]",
-    useAnotherMethod: "[TRANSLATION MISSING]",
+    authenticatorApp: "Authentifizierungs-App",
+    securityKey: "Sicherheitsschlüssel",
+    securityKeyUse: "Sicherheitsschlüssel verwenden",
+    newSecurityKeyName: "Neuer Sicherheitsschlüsselname",
+    createSecurityKey: "Sicherheitsschlüssel erstellen",
+    authenticatorAppManage: "Authentifizierungs-App verwalten",
+    authenticatorAppAdd: "Einrichten",
+    configured: "konfiguriert",
+    useAnotherMethod: "Eine andere Methode verwenden",
   },
   errors: {
     somethingWentWrong:
@@ -170,7 +178,8 @@ export const de: Translation = {
     thirdPartyUnverifiedEmail:
       "Verifizierung der E-Mail-Adresse erforderlich. Bitte verifizieren sie die genutzte E-Mail-Adresse bei ihrem Provider.",
     signupDisabled: "Die Kontoregistrierung ist deaktiviert.",
-    handlerNotFoundError: "[TRANSLATION MISSING]",
+    handlerNotFoundError:
+      "Der aktuelle Schritt in Ihrem Prozess wird von dieser Anwendungsversion nicht unterstützt.",
   },
   flowErrors: {
     technical_error:
@@ -200,8 +209,11 @@ export const de: Translation = {
     value_missing_error: "Der Wert fehlt.",
     value_too_long_error: "Der Wert ist zu lang.",
     value_too_short_error: "Der Wert ist zu kurz.",
-    webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
-    webauthn_credential_already_exists: "[TRANSLATION MISSING]",
-    platform_authenticator_required: "[TRANSLATION MISSING]",
+    webauthn_credential_invalid_mfa_only:
+      "Diese Anmeldeinformation kann nur als zweite Sicherheitsfaktor verwendet werden.",
+    webauthn_credential_already_exists:
+      "Die Anfrage wurde entweder abgebrochen, abgelaufen oder das Gerät ist bereits registriert. Bitte versuchen Sie es erneut oder verwenden Sie ein anderes Gerät.",
+    platform_authenticator_required:
+      "Ihr Konto ist so konfiguriert, dass es Plattform-Authentifikatoren verwendet, jedoch unterstützt Ihr aktuelles Gerät oder Ihr Browser diese Funktion nicht. Bitte versuchen Sie es mit einem kompatiblen Gerät oder Browser erneut.",
   },
 };

--- a/frontend/elements/src/i18n/en.ts
+++ b/frontend/elements/src/i18n/en.ts
@@ -60,7 +60,7 @@ export const en: Translation = {
     passwordFormatHint:
       "Must be between {minLength} and {maxLength} characters long.",
     securityKeySetUp:
-      "Use a dedicated security key via USB, Bluetooth, or NFC, or your mobile phone or device’s built-in options like Touch ID, Face ID, or Windows Hello. Connect or activate your security key, then click the button below and follow the prompts to complete the registration.",
+      "Use a dedicated security key via USB, Bluetooth, or NFC, or your mobile phone. Connect or activate your security key, then click the button below and follow the prompts to complete the registration.",
     setPrimaryEmail: "Set this email address to be used for contacting you.",
     isPrimaryEmail:
       "This email address will be used to contact you if necessary.",
@@ -79,11 +79,10 @@ export const en: Translation = {
     mfaSetUp:
       "Protect your account with Multi-Factor Authentication (MFA). MFA adds an additional step to your login process, ensuring that even if your password or email account is compromised, your account stays secure.",
     securityKeyLogin:
-      "Connect or activate your security key, then click the button below. Once ready, use it via USB, NFC, your mobile phone, or built-in options like Touch ID, Face ID, or Windows Hello. Follow the prompts to complete the login process.",
+      "Connect or activate your security key, then click the button below. Once ready, use it via USB, NFC, your mobile phone. Follow the prompts to complete the login process.",
     otpLogin:
       "Open your authenticator app to obtain the one-time password (OTP). Enter the code in the field below to complete your login.",
     renameSecurityKey: "Set a name for the security key.",
-    setupSecurityKey: "Set up a security key.",
     deleteSecurityKey: "Delete this security key from your account.",
     authenticatorAppAlreadySetUp:
       "Your account is secured with an authenticator app that generates time-based one-time passwords (TOTP) for multi-factor authentication.",
@@ -143,7 +142,6 @@ export const en: Translation = {
     createSecurityKey: "Create a security key",
     authenticatorAppManage: "Manage authenticator app",
     authenticatorAppAdd: "Set up",
-    authenticatorAppRemove: "Delete OTP secret",
     configured: "configured",
     useAnotherMethod: "Use another method",
   },

--- a/frontend/elements/src/i18n/fr.ts
+++ b/frontend/elements/src/i18n/fr.ts
@@ -11,7 +11,7 @@ export const fr: Translation = {
     registerAuthenticator: "Créer une clé d'identification",
     registerConfirm: "Créer un compte ?",
     registerPassword: "Définir un nouveau mot de passe",
-    otpSetUp: "[TRANSLATION MISSING]",
+    otpSetUp: "Configurer l'application d'authentification",
     profileEmails: "Adresses e-mail",
     profilePassword: "Mot de passe",
     profilePasskeys: "Clés d'identification",
@@ -33,16 +33,17 @@ export const fr: Translation = {
     signUp: "S'inscrire",
     selectLoginMethod: "Sélectionner la méthode de connexion",
     setupLoginMethod: "Configurer la méthode de connexion",
-    mfaSetUp: "[TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    securityKeys: "[TRANSLATION MISSING]",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp: "Configurer MFA",
+    securityKeySetUp: "Ajouter une clé de sécurité",
+    securityKeyLogin: "Clé de sécurité",
+    otpLogin: "Code d'authentification",
+    renameSecurityKey: "Renommer la clé de sécurité",
+    deleteSecurityKey: "Supprimer la clé de sécurité",
+    securityKeys: "Clés de sécurité",
+    authenticatorApp: "Application d'authentification",
+    authenticatorAppAlreadySetUp:
+      "L'application d'authentification est configurée",
+    authenticatorAppNotSetUp: "Configurer l'application d'authentification",
   },
   texts: {
     enterPasscode:
@@ -53,9 +54,11 @@ export const fr: Translation = {
       "Connectez-vous à votre compte facilement et en toute sécurité avec une clé d'identification. Remarque : Vos données biométriques sont uniquement stockées sur vos appareils et ne seront jamais partagées avec qui que ce soit.",
     createAccount:
       'Aucun compte n\'existe pour "{emailAddress}". Voulez-vous créer un nouveau compte ?',
-    otpEnterVerificationCode: "[TRANSLATION MISSING]",
-    otpScanQRCode: "[TRANSLATION MISSING]",
-    otpSecretKey: "[TRANSLATION MISSING]",
+    otpEnterVerificationCode:
+      "Entrez le mot de passe à usage unique (OTP) obtenu à partir de votre application d'authentification ci-dessous :",
+    otpScanQRCode:
+      "Scannez le code QR en utilisant votre application d'authentification (comme Google Authenticator ou toute autre application TOTP). Alternativement, vous pouvez entrer manuellement la clé secrète OTP dans l'application.",
+    otpSecretKey: "Clé secrète OTP",
     passwordFormatHint:
       "Doit contenir entre {minLength} et {maxLength} caractères.",
     setPrimaryEmail: "Définir cette adresse e-mail comme adresse de contact.",
@@ -75,15 +78,20 @@ export const fr: Translation = {
     selectLoginMethodForFutureLogins:
       "Sélectionnez l'une des méthodes de connexion suivantes à utiliser pour les connexions futures.",
     howDoYouWantToLogin: "Comment souhaitez-vous vous connecter ?",
-    mfaSetUp: "TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    setupSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING]",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp:
+      "Protégez votre compte avec l'authentification à plusieurs facteurs (MFA). La MFA ajoute une étape supplémentaire à votre processus de connexion, garantissant que même si votre mot de passe ou votre compte e-mail est compromis, votre compte reste sécurisé.",
+    securityKeyLogin:
+      "Connectez ou activez votre clé de sécurité, puis cliquez sur le bouton ci-dessous. Une fois prêt, utilisez-le via USB, NFC ou votre téléphone mobile. Suivez les instructions pour terminer le processus de connexion.",
+    otpLogin:
+      "Ouvrez votre application d'authentification pour obtenir le mot de passe à usage unique (OTP). Entrez le code dans le champ ci-dessous pour terminer votre connexion.",
+    renameSecurityKey: "Définissez un nom pour la clé de sécurité.",
+    deleteSecurityKey: "Supprimez cette clé de sécurité de votre compte.",
+    authenticatorAppAlreadySetUp:
+      "Votre compte est sécurisé avec une application d'authentification qui génère des mots de passe à usage unique basés sur le temps (TOTP) pour l'authentification à plusieurs facteurs.",
+    authenticatorAppNotSetUp:
+      "Sécurisez votre compte avec une application d'authentification qui génère des mots de passe à usage unique basés sur le temps (TOTP) pour l'authentification à plusieurs facteurs.",
+    securityKeySetUp:
+      "Utilisez une clé de sécurité dédiée via USB, Bluetooth ou NFC, ou votre téléphone mobile. Connectez ou activez votre clé de sécurité, puis cliquez sur le bouton ci-dessous et suivez les instructions pour terminer l'enregistrement.",
   },
   labels: {
     or: "ou",
@@ -91,7 +99,7 @@ export const fr: Translation = {
     yes: "oui",
     email: "E-mail",
     continue: "Continuer",
-    copied: "[TRANSLATION MISSING]",
+    copied: "copié",
     skip: "Passer",
     save: "Enregistrer",
     password: "Mot de passe",
@@ -132,16 +140,15 @@ export const fr: Translation = {
     setUsername: "Définir le nom d'utilisateur",
     changePassword: "Changer le mot de passe",
     setPassword: "Définir le mot de passe",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    securityKey: "[TRANSLATION MISSING]",
-    securityKeyUse: "[TRANSLATION MISSING]",
-    newSecurityKeyName: "[TRANSLATION MISSING]",
-    createSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppManage: "[TRANSLATION MISSING]",
-    authenticatorAppAdd: "[TRANSLATION MISSING]",
-    authenticatorAppRemove: "[TRANSLATION MISSING]",
-    configured: "[TRANSLATION MISSING]",
-    useAnotherMethod: "[TRANSLATION MISSING]",
+    authenticatorApp: "Application d'authentification",
+    securityKey: "Clé de sécurité",
+    securityKeyUse: "Utiliser la clé de sécurité",
+    newSecurityKeyName: "Nouveau nom de clé de sécurité",
+    createSecurityKey: "Créer une clé de sécurité",
+    authenticatorAppManage: "Gérer l'application d'authentification",
+    authenticatorAppAdd: "Configurer",
+    configured: "configuré",
+    useAnotherMethod: "Utiliser une autre méthode",
   },
   errors: {
     somethingWentWrong:
@@ -170,7 +177,7 @@ export const fr: Translation = {
     thirdPartyUnverifiedEmail:
       "Vérification de l'adresse e-mail requise. Veuillez vérifier l'adresse e-mail utilisée avec votre fournisseur.",
     signupDisabled: "L'enregistrement du compte est désactivé.",
-    handlerNotFoundError: "[TRANSLATION MISSING]",
+    handlerNotFoundError: "L'étape actuelle n'est pas prise en charge dans cette version de l'application. Veuillez réessayer plus tard ou contacter l'équipe d'assistance pour obtenir de l'aide.",
   },
   flowErrors: {
     technical_error:
@@ -199,8 +206,11 @@ export const fr: Translation = {
     value_missing_error: "La valeur est manquante.",
     value_too_long_error: "La valeur est trop longue.",
     value_too_short_error: "La valeur est trop courte.",
-    webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
-    webauthn_credential_already_exists: "[TRANSLATION MISSING]",
-    platform_authenticator_required: "[TRANSLATION MISSING]",
+    webauthn_credential_invalid_mfa_only:
+      "Cette identité peut être utilisée uniquement comme clé de sécurité de deuxième facteur.",
+    webauthn_credential_already_exists:
+      "La demande a expiré, a été annulée ou le dispositif est déjà enregistré. Veuillez réessayer ou essayer d'utiliser un autre dispositif.",
+    platform_authenticator_required:
+      "Votre compte est configuré pour utiliser des authentificateurs de plate-forme, mais votre appareil ou navigateur actuel ne prend pas en charge cette fonctionnalité. Veuillez réessayer avec un appareil ou un navigateur compatible.",
   },
 };

--- a/frontend/elements/src/i18n/it.ts
+++ b/frontend/elements/src/i18n/it.ts
@@ -11,7 +11,7 @@ export const it: Translation = {
     registerAuthenticator: "Crea una passkey",
     registerConfirm: "Vuoi creare un account?",
     registerPassword: "Imposta una nuova password",
-    otpSetUp: "[TRANSLATION MISSING]",
+    otpSetUp: "Imposta l'app di autenticazione",
     profileEmails: "Emails",
     profilePassword: "Password",
     profilePasskeys: "Passkeys",
@@ -33,16 +33,16 @@ export const it: Translation = {
     signUp: "Registrati",
     selectLoginMethod: "Seleziona il metodo di accesso",
     setupLoginMethod: "Imposta il metodo di accesso",
-    mfaSetUp: "[TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    securityKeys: "[TRANSLATION MISSING]",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp: "Imposta MFA",
+    securityKeySetUp: "Aggiungi una chiave di sicurezza",
+    securityKeyLogin: "Chiave di sicurezza",
+    otpLogin: "Codice di autenticazione",
+    renameSecurityKey: "Rinomina la chiave di sicurezza",
+    deleteSecurityKey: "Elimina la chiave di sicurezza",
+    securityKeys: "Chiavi di sicurezza",
+    authenticatorApp: "App di autenticazione",
+    authenticatorAppAlreadySetUp: "L'app di autenticazione è già configurata",
+    authenticatorAppNotSetUp: "Imposta l'app di autenticazione",
   },
   texts: {
     enterPasscode: 'Inserisci il codice di accesso inviato a "{emailAddress}".',
@@ -52,9 +52,11 @@ export const it: Translation = {
       "Accedi al tuo account in modo semplice e sicuro con una passkey. Nota: I tuoi dati biometrici sono archiviati solo sui tuoi dispositivi e non saranno condivisi con nessuno.",
     createAccount:
       'Nessun account trovato per "{emailAddress}". Vuoi creare un nuovo account?',
-    otpEnterVerificationCode: "[TRANSLATION MISSING]",
-    otpScanQRCode: "[TRANSLATION MISSING]",
-    otpSecretKey: "[TRANSLATION MISSING]",
+    otpEnterVerificationCode:
+      "Inserisci il codice di verifica generato dalla tua app di autenticazione:",
+    otpScanQRCode:
+      "Scansiona il codice QR con la tua app di autenticazione (come Google Authenticator o un'altra app TOTP). In alternativa, puoi inserire manualmente la chiave segreta OTP nell'app.",
+    otpSecretKey: "Chiave segreta OTP",
     passwordFormatHint:
       "La lunghezza della password deve essere compresa tra i {minLength} e {maxLength} caratteri.",
     setPrimaryEmail:
@@ -73,15 +75,20 @@ export const it: Translation = {
     selectLoginMethodForFutureLogins:
       "Seleziona uno dei seguenti metodi di accesso da utilizzare per i futuri accessi.",
     howDoYouWantToLogin: "Come desideri effettuare l'accesso?",
-    mfaSetUp: "TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    setupSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING]",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp:
+      "Proteggi il tuo account con l'autenticazione a più fattori (MFA). La MFA aggiunge un ulteriore livello di sicurezza al tuo processo di accesso e garantisce che il tuo account rimanga protetto anche se la tua password o il tuo indirizzo email vengono compromessi.",
+    securityKeyLogin:
+      "Collega la tua chiave di sicurezza o attivala, quindi fai clic sul pulsante qui sotto. Una volta pronto, usala tramite USB, NFC o il tuo telefono. Segui le istruzioni per completare il processo di accesso.",
+    otpLogin:
+      "Apri la tua app di autenticazione per ottenere il codice OTP. Inserisci il codice nel campo qui sotto per completare il tuo accesso.",
+    renameSecurityKey: "Imposta un nome per la chiave di sicurezza.",
+    deleteSecurityKey: "Elimina questa chiave di sicurezza dal tuo account.",
+    authenticatorAppAlreadySetUp:
+      "Il tuo account è protetto da un'app di autenticazione che genera codici monouso (TOTP) per l'autenticazione a più fattori.",
+    authenticatorAppNotSetUp:
+      "Proteggi il tuo account con un'app di autenticazione che genera codici monouso (TOTP) per l'autenticazione a più fattori.",
+    securityKeySetUp:
+      "Utilizza una chiave di sicurezza dedicata tramite USB, Bluetooth o NFC oppure il tuo telefono. Collega la tua chiave di sicurezza o attivala, quindi fai clic sul pulsante qui sotto e segui le istruzioni per completare la registrazione.",
   },
   labels: {
     or: "o",
@@ -89,7 +96,7 @@ export const it: Translation = {
     yes: "si",
     email: "Email",
     continue: "Continua",
-    copied: "[TRANSLATION MISSING]",
+    copied: "copiato",
     skip: "Salta",
     save: "Salva",
     password: "Password",
@@ -129,16 +136,15 @@ export const it: Translation = {
     setUsername: "Imposta nome utente",
     changePassword: "Cambia password",
     setPassword: "Imposta password",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    securityKey: "[TRANSLATION MISSING]",
-    securityKeyUse: "[TRANSLATION MISSING]",
-    newSecurityKeyName: "[TRANSLATION MISSING]",
-    createSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppManage: "[TRANSLATION MISSING]",
-    authenticatorAppAdd: "[TRANSLATION MISSING]",
-    authenticatorAppRemove: "[TRANSLATION MISSING]",
-    configured: "[TRANSLATION MISSING]",
-    useAnotherMethod: "[TRANSLATION MISSING]",
+    authenticatorApp: "App di autenticazione",
+    securityKey: "Chiave di sicurezza",
+    securityKeyUse: "Usa chiave di sicurezza",
+    newSecurityKeyName: "Nuovo nome chiave di sicurezza",
+    createSecurityKey: "Crea chiave di sicurezza",
+    authenticatorAppManage: "Gestisci app di autenticazione",
+    authenticatorAppAdd: "Imposta",
+    configured: "configurato",
+    useAnotherMethod: "Usa un altro metodo",
   },
   errors: {
     somethingWentWrong: "Si è verificato un errore tecnico. Riprova più tardi.",
@@ -165,7 +171,7 @@ export const it: Translation = {
     thirdPartyUnverifiedEmail:
       "Verifica email richiesta. Verifica l'indirizzo email utilizzato con il tuo provider.",
     signupDisabled: "La registrazione dell'account è disabilitata.",
-    handlerNotFoundError: "[TRANSLATION MISSING]",
+    handlerNotFoundError: "Il passaggio corrente non è supportato in questa versione dell'applicazione. Per favore riprova più tardi o contatta il team di supporto per ricevere assistenza.",
   },
   flowErrors: {
     technical_error: "Si è verificato un errore tecnico. Riprova più tardi.",
@@ -192,8 +198,11 @@ export const it: Translation = {
     value_missing_error: "Il valore è mancante.",
     value_too_long_error: "Il valore è troppo lungo.",
     value_too_short_error: "Il valore è troppo corto.",
-    webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
-    webauthn_credential_already_exists: "[TRANSLATION MISSING]",
-    platform_authenticator_required: "[TRANSLATION MISSING]",
+    webauthn_credential_invalid_mfa_only:
+      "Questa identità può essere utilizzata solo come secondo fattore di autenticazione.",
+    webauthn_credential_already_exists:
+      "La richiesta è scaduta, è stata annullata o il dispositivo è già registrato. Prova di nuovo o usa un altro dispositivo.",
+    platform_authenticator_required:
+      "Il tuo account è configurato per utilizzare gli autenticatori di piattaforma. Tuttavia, il tuo dispositivo o browser corrente non supporta questa funzione. Prova di nuovo con un dispositivo o un browser compatibile.",
   },
 };

--- a/frontend/elements/src/i18n/pt-BR.ts
+++ b/frontend/elements/src/i18n/pt-BR.ts
@@ -11,7 +11,7 @@ export const ptBR: Translation = {
     registerAuthenticator: "Criar uma chave de acesso",
     registerConfirm: "Concluir cadastro?",
     registerPassword: "Redefina sua senha",
-    otpSetUp: "[TRANSLATION MISSING]",
+    otpSetUp: "Configurar o aplicativo de autenticação",
     profileEmails: "E-mails",
     profilePassword: "Senha",
     profilePasskeys: "Chave de acesso",
@@ -33,16 +33,17 @@ export const ptBR: Translation = {
     signUp: "Registrar",
     selectLoginMethod: "Selecionar método de login",
     setupLoginMethod: "Configurar método de login",
-    mfaSetUp: "[TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    securityKeys: "[TRANSLATION MISSING]",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp: "Configurar MFA",
+    securityKeySetUp: "Adicionar uma chave de segurança",
+    securityKeyLogin: "Chave de segurança",
+    otpLogin: "Código de autenticação",
+    renameSecurityKey: "Renomear chave de segurança",
+    deleteSecurityKey: "Excluir chave de segurança",
+    securityKeys: "Chaves de segurança",
+    authenticatorApp: "Aplicativo de autenticação",
+    authenticatorAppAlreadySetUp:
+      "O aplicativo de autenticação já está configurado",
+    authenticatorAppNotSetUp: "Configurar o aplicativo de autenticação",
   },
   texts: {
     enterPasscode:
@@ -53,9 +54,11 @@ export const ptBR: Translation = {
       "Entre na sua conta de forma fácil e segura com uma chave de acesso. Nota: Os seus dados biométricos são apenas guardados no seu aparelho e nunca serão compartilhados com ninguém.",
     createAccount:
       'Nenhuma conta encontrada para o e-mail "{emailAddress}". Deseja criar uma nova conta?',
-    otpEnterVerificationCode: "[TRANSLATION MISSING]",
-    otpScanQRCode: "[TRANSLATION MISSING]",
-    otpSecretKey: "[TRANSLATION MISSING]",
+    otpEnterVerificationCode:
+      "Insira o código de verificação gerado pelo seu aplicativo de autenticação:",
+    otpScanQRCode:
+      "Escaneie o código QR com seu aplicativo de autenticação (como Google Authenticator ou outro aplicativo TOTP). Alternativamente, você pode inserir manualmente a chave secreta OTP no aplicativo.",
+    otpSecretKey: "Chave secreta OTP",
     passwordFormatHint:
       "Deve conter entre {minLength} e {maxLength} caracteres.",
     setPrimaryEmail:
@@ -74,15 +77,20 @@ export const ptBR: Translation = {
     selectLoginMethodForFutureLogins:
       "Selecione um dos métodos de login a seguir para usar em logins futuros.",
     howDoYouWantToLogin: "Como você deseja fazer login?",
-    mfaSetUp: "TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    setupSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING]",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp:
+      "Proteja sua conta com autenticação de múltiplos fatores (MFA). A MFA adiciona uma camada extra de segurança ao seu processo de login e garante que sua conta permaneça protegida mesmo que sua senha ou endereço de e-mail sejam comprometidos.",
+    securityKeyLogin:
+      "Conecte sua chave de segurança ou ative-a, em seguida, clique no botão abaixo. Quando estiver pronto, use-a via USB, NFC ou seu telefone. Siga as instruções para concluir o processo de login.",
+    otpLogin:
+      "Abra seu aplicativo de autenticação para obter o código OTP. Insira o código no campo abaixo para concluir seu login.",
+    renameSecurityKey: "Defina um nome para a chave de segurança.",
+    deleteSecurityKey: "Exclua esta chave de segurança da sua conta.",
+    authenticatorAppAlreadySetUp:
+      "Sua conta está protegida por um aplicativo de autenticação que gera códigos únicos (TOTP) para autenticação de múltiplos fatores.",
+    authenticatorAppNotSetUp:
+      "Proteja sua conta com um aplicativo de autenticação que gera códigos únicos (TOTP) para autenticação de múltiplos fatores.",
+    securityKeySetUp:
+      "Use uma chave de segurança dedicada via USB, Bluetooth ou NFC ou seu telefone. Conecte sua chave de segurança ou ative-a, em seguida, clique no botão abaixo e siga as instruções para concluir o registro.",
   },
   labels: {
     or: "ou",
@@ -90,7 +98,7 @@ export const ptBR: Translation = {
     yes: "sim",
     email: "E-mail",
     continue: "Continuar",
-    copied: "[TRANSLATION MISSING]",
+    copied: "copiado",
     skip: "Pular",
     save: "Salvar",
     password: "Senha",
@@ -131,16 +139,15 @@ export const ptBR: Translation = {
     setUsername: "Definir nome de usuário",
     changePassword: "Alterar senha",
     setPassword: "Definir senha",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    securityKey: "[TRANSLATION MISSING]",
-    securityKeyUse: "[TRANSLATION MISSING]",
-    newSecurityKeyName: "[TRANSLATION MISSING]",
-    createSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppManage: "[TRANSLATION MISSING]",
-    authenticatorAppAdd: "[TRANSLATION MISSING]",
-    authenticatorAppRemove: "[TRANSLATION MISSING]",
-    configured: "[TRANSLATION MISSING]",
-    useAnotherMethod: "[TRANSLATION MISSING]",
+    authenticatorApp: "Aplicativo de autenticação",
+    securityKey: "Chave de segurança",
+    securityKeyUse: "Usar chave de segurança",
+    newSecurityKeyName: "Novo nome da chave de segurança",
+    createSecurityKey: "Criar chave de segurança",
+    authenticatorAppManage: "Gerenciar aplicativo de autenticação",
+    authenticatorAppAdd: "Configurar",
+    configured: "configurado",
+    useAnotherMethod: "Usar outro método",
   },
   errors: {
     somethingWentWrong:
@@ -167,7 +174,8 @@ export const ptBR: Translation = {
     thirdPartyUnverifiedEmail:
       "Verificação de e-mail necessária. Por favor, verifique o e-mail utilizado com o seu provedor.",
     signupDisabled: "O registro da conta está desativado.",
-    handlerNotFoundError: "[TRANSLATION MISSING]",
+    handlerNotFoundError:
+      "O passo atual não é suportado nesta versão do aplicativo. Por favor, tente novamente mais tarde ou entre em contato com a equipe de suporte para obter ajuda.",
   },
   flowErrors: {
     technical_error:
@@ -195,8 +203,11 @@ export const ptBR: Translation = {
     value_missing_error: "O valor está ausente.",
     value_too_long_error: "O valor é muito longo.",
     value_too_short_error: "O valor é muito curto.",
-    webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
-    webauthn_credential_already_exists: "[TRANSLATION MISSING]",
-    platform_authenticator_required: "[TRANSLATION MISSING]",
+    webauthn_credential_invalid_mfa_only:
+      "Esta identidade pode ser usada apenas como segundo fator de autenticação.",
+    webauthn_credential_already_exists:
+      "A solicitação expirou, foi cancelada ou o dispositivo já está registrado. Tente novamente ou use outro dispositivo.",
+    platform_authenticator_required:
+      "Sua conta está configurada para usar autentificadores de plataforma. No entanto, seu dispositivo ou navegador atual não suporta esse recurso. Tente novamente com um dispositivo ou navegador compatível.",
   },
 };

--- a/frontend/elements/src/i18n/translations.ts
+++ b/frontend/elements/src/i18n/translations.ts
@@ -76,13 +76,11 @@ export interface Translation {
     howDoYouWantToLogin: string;
     deleteSecurityKey: string;
     renameSecurityKey: string;
-    setupSecurityKey: string;
   };
   labels: {
     authenticatorApp: string;
     authenticatorAppAdd: string;
     authenticatorAppManage: string;
-    authenticatorAppRemove: string;
     or: string;
     no: string;
     yes: string;

--- a/frontend/elements/src/i18n/zh.ts
+++ b/frontend/elements/src/i18n/zh.ts
@@ -11,7 +11,7 @@ export const zh: Translation = {
     registerAuthenticator: "创建密钥",
     registerConfirm: "创建账号？",
     registerPassword: "设置新密码",
-    otpSetUp: "[TRANSLATION MISSING]",
+    otpSetUp: "设置身份验证应用",
     profileEmails: "电子邮件",
     profilePassword: "密码",
     profilePasskeys: "密钥",
@@ -33,16 +33,16 @@ export const zh: Translation = {
     signUp: "注册",
     selectLoginMethod: "选择登录方法",
     setupLoginMethod: "设置登录方法",
-    mfaSetUp: "[TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    securityKeys: "[TRANSLATION MISSING]",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp: "设置 MFA",
+    securityKeySetUp: "添加安全密钥",
+    securityKeyLogin: "安全密钥",
+    otpLogin: "验证码",
+    renameSecurityKey: "重命名安全密钥",
+    deleteSecurityKey: "删除安全密钥",
+    securityKeys: "安全密钥",
+    authenticatorApp: "身份验证应用",
+    authenticatorAppAlreadySetUp: "身份验证应用已设置",
+    authenticatorAppNotSetUp: "设置身份验证应用",
   },
   texts: {
     enterPasscode: "输入发送到“{emailAddress}”的验证码。",
@@ -50,9 +50,11 @@ export const zh: Translation = {
     setupPasskey:
       "使用密钥轻松安全地登录您的账户。注意：您的生物识别数据仅存储在您的设备上，永远不会与任何人共享。",
     createAccount: "没有“{emailAddress}”的账户存在。你想要创建一个新账户吗?",
-    otpEnterVerificationCode: "[TRANSLATION MISSING]",
-    otpScanQRCode: "[TRANSLATION MISSING]",
-    otpSecretKey: "[TRANSLATION MISSING]",
+    otpEnterVerificationCode:
+      "在下面输入从身份验证应用获取的一次性密码 (OTP)：",
+    otpScanQRCode:
+      "使用您的身份验证应用扫描二维码（例如 Google Authenticator 或任何其他 TOTP 应用）。另外，您也可以手动输入 OTP 秘密密钥到应用中。",
+    otpSecretKey: "OTP 秘密密钥",
     passwordFormatHint: "必须长在{minLength}和{maxLength}字符之间。",
     setPrimaryEmail: "将此电子邮件地址设置为用于联系您。",
     isPrimaryEmail: "如有必要，此电子邮件地址将用于联系您。",
@@ -68,15 +70,20 @@ export const zh: Translation = {
     selectLoginMethodForFutureLogins:
       "请选择以下登录方法之一以供将来登录使用。",
     howDoYouWantToLogin: "您想如何登录？",
-    mfaSetUp: "TRANSLATION MISSING]",
-    securityKeySetUp: "[TRANSLATION MISSING]",
-    securityKeyLogin: "[TRANSLATION MISSING]",
-    otpLogin: "[TRANSLATION MISSING]",
-    renameSecurityKey: "[TRANSLATION MISSING]",
-    setupSecurityKey: "[TRANSLATION MISSING]",
-    deleteSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppAlreadySetUp: "[TRANSLATION MISSING]",
-    authenticatorAppNotSetUp: "[TRANSLATION MISSING]",
+    mfaSetUp:
+      "通过多因素认证（MFA）保护您的账户。MFA 在您的登录过程中增加了额外的一步，确保即使您的密码或电子邮件账户被泄露，您的账户仍然安全。",
+    securityKeyLogin:
+      "连接或激活您的安全密钥，然后点击下面的按钮。准备好后，通过 USB、NFC 或手机使用它。按照提示完成登录过程。",
+    otpLogin:
+      "打开您的身份验证应用以获取一次性密码（OTP）。在下面的字段中输入代码以完成登录。",
+    renameSecurityKey: "为安全密钥设置名称。",
+    deleteSecurityKey: "从您的账户中删除此安全密钥。",
+    authenticatorAppAlreadySetUp:
+      "您的账户通过身份验证应用保护，该应用生成基于时间的一次性密码 (TOTP) 以实现多因素认证。",
+    authenticatorAppNotSetUp:
+      "使用生成基于时间的一次性密码 (TOTP) 的身份验证应用保护您的账户以实现多因素认证。",
+    securityKeySetUp:
+      "通过 USB、蓝牙或 NFC 使用专用安全密钥，或使用手机。连接或激活您的安全密钥，然后点击下面的按钮，按照提示完成注册。",
   },
   labels: {
     or: "或",
@@ -84,7 +91,7 @@ export const zh: Translation = {
     yes: "是",
     email: "电子邮件",
     continue: "继续",
-    copied: "[TRANSLATION MISSING]",
+    copied: "已复制",
     skip: "跳过",
     save: "保存",
     passkey: "密码",
@@ -124,16 +131,15 @@ export const zh: Translation = {
     setUsername: "设置用户名",
     changePassword: "更改密码",
     setPassword: "设置密码",
-    authenticatorApp: "[TRANSLATION MISSING]",
-    securityKey: "[TRANSLATION MISSING]",
-    securityKeyUse: "[TRANSLATION MISSING]",
-    newSecurityKeyName: "[TRANSLATION MISSING]",
-    createSecurityKey: "[TRANSLATION MISSING]",
-    authenticatorAppManage: "[TRANSLATION MISSING]",
-    authenticatorAppAdd: "[TRANSLATION MISSING]",
-    authenticatorAppRemove: "[TRANSLATION MISSING]",
-    configured: "[TRANSLATION MISSING]",
-    useAnotherMethod: "[TRANSLATION MISSING]",
+    authenticatorApp: "身份验证应用",
+    securityKey: "安全密钥",
+    securityKeyUse: "使用安全密钥",
+    newSecurityKeyName: "新安全密钥名称",
+    createSecurityKey: "创建安全密钥",
+    authenticatorAppManage: "管理身份验证应用",
+    authenticatorAppAdd: "设置",
+    configured: "已配置",
+    useAnotherMethod: "使用其他方法",
   },
   errors: {
     somethingWentWrong: "发生技术错误。请稍后再试。",
@@ -155,7 +161,8 @@ export const zh: Translation = {
     thirdPartyUnverifiedEmail:
       "需要电子邮件验证。请与您的提供商验证使用的电子邮件地址。",
     signupDisabled: "帐户注册被禁用。",
-    handlerNotFoundError: "[TRANSLATION MISSING]",
+    handlerNotFoundError:
+      "当前步骤在此应用程序版本中不受支持。请稍后再试，或联系支持团队以获取帮助。",
   },
   flowErrors: {
     technical_error: "发生技术错误。请稍后再试。",
@@ -178,8 +185,11 @@ export const zh: Translation = {
     value_missing_error: "值丢失。",
     value_too_long_error: "值太长。",
     value_too_short_error: "值太短。",
-    webauthn_credential_invalid_mfa_only: "[TRANSLATION MISSING]",
-    webauthn_credential_already_exists: "[TRANSLATION MISSING]",
-    platform_authenticator_required: "[TRANSLATION MISSING]",
+    webauthn_credential_invalid_mfa_only:
+      "此凭证仅可作为第二因素安全密钥使用。",
+    webauthn_credential_already_exists:
+      "请求已超时、被取消或设备已注册。请重试或尝试使用其他设备。",
+    platform_authenticator_required:
+      "您的账户配置为使用平台身份验证器，但您当前的设备或浏览器不支持该功能。请尝试使用兼容的设备或浏览器重新进行尝试。",
   },
 };


### PR DESCRIPTION
## Missing Translations

- Missing translations have been added.

## Security Key Onboarding

- Removed all references to platform authenticator details.

## Profile Updates

- Updated the "Set up security key" text to match the display on the "stand-alone" page.
- Changed the link text for deleting the OTP secret to simply "Delete".