### PR TITLE
Refactor: Aligned the button content in center

### DIFF
--- a/frontend/elements/example.css
+++ b/frontend/elements/example.css
@@ -319,18 +319,21 @@
 }
 
 .hanko_loadingSpinnerWrapperIcon {
-    justify-content: flex-start;
+    display: flex; 
+    justify-content: center; 
+    align-items: center; 
     width: 100%;
-    column-gap: 10px;
-    margin-left: 10px
+    margin: 0;
 }
 
 .hanko_loadingSpinnerWrapper,
 .hanko_loadingSpinnerWrapperIcon {
-    display: inline-flex;
+    display: flex; 
+    justify-content: center; 
     align-items: center;
     height: 100%;
-    margin: 0 5px
+    width: 100%; 
+    margin: 0;
 }
 
 .hanko_loadingSpinnerWrapper .hanko_loadingSpinner,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

This PR solves the issue of button content not being in center because of some inconsistent styling used in the example.css file. Refactored the code by introducing flexbox in it and aligning everything to the center.

<!-- If applicable, add references to fixed/related issues (e.g. add "Fixes #<issue>"/"Relates to#<issue>".  -->
Fixes: #1220 

# Implementation
Just needed to figure out where the applied class is present. Found it, and got to know that flexbox is not applied to it correctly. So changed the classes accordingly.


# Tests
Basic CSS change, no tests required.

# Todos
No

# Additional context
Attaching the screenshot of the code file changed for reference:
![Screenshot (116)](https://github.com/user-attachments/assets/d74c1195-9b85-4983-9aaf-798103eb02a4)

