### PR TITLE
fix: do not suspend webauthn action for MFA

### DIFF
--- a/backend/flow_api/flow/profile/action_webauthn_verify_attestation_response.go
+++ b/backend/flow_api/flow/profile/action_webauthn_verify_attestation_response.go
@@ -22,7 +22,7 @@ func (a WebauthnVerifyAttestationResponse) GetDescription() string {
 func (a WebauthnVerifyAttestationResponse) Initialize(c flowpilot.InitializationContext) {
 	deps := a.GetDeps(c)
 
-	if !deps.Cfg.Passkey.Enabled || !c.Stash().Get(shared.StashPathWebauthnAvailable).Bool() {
+	if !c.Stash().Get(shared.StashPathWebauthnAvailable).Bool() || (!deps.Cfg.Passkey.Enabled && !(deps.Cfg.MFA.Enabled && deps.Cfg.MFA.SecurityKeys.Enabled)) {
 		c.SuspendAction()
 	}
 


### PR DESCRIPTION
# Description

The `webauthn_verify_attestation_response` action was disabled when passkeys are disabled or whne no webauthn is available on the device. But when security keys and MFA are also enabled, the action is need t in order to create a security key.

# Implementation

Only suspend the `webauthn_verify_attestation_response` action when passkeys, and security keys are disabled.

# Tests

Try to create a new security key when passkeys are disabled.

