### PR TITLE
fix: session delete action

### DIFF
--- a/backend/flow_api/flow/profile/action_session_delete.go
+++ b/backend/flow_api/flow/profile/action_session_delete.go
@@ -40,10 +40,20 @@ func (a SessionDelete) Initialize(c flowpilot.InitializationContext) {
 		return
 	}
 
+	var deletableSessions []string
 	for _, session := range sessions {
 		if session.ID != currentSessionID {
-			input.AllowedValue(session.ID.String(), session.ID.String())
+			deletableSessions = append(deletableSessions, session.ID.String())
 		}
+	}
+
+	if len(deletableSessions) < 1 {
+		c.SuspendAction()
+		return
+	}
+
+	for _, deletableSession := range deletableSessions {
+		input.AllowedValue(deletableSession, deletableSession)
 	}
 
 	c.AddInputs(input)
@@ -51,6 +61,10 @@ func (a SessionDelete) Initialize(c flowpilot.InitializationContext) {
 
 func (a SessionDelete) Execute(c flowpilot.ExecutionContext) error {
 	deps := a.GetDeps(c)
+
+	if valid := c.ValidateInputData(); !valid {
+		return c.Error(flowpilot.ErrorFormDataInvalid)
+	}
 
 	sessionToBeDeleted := uuid.FromStringOrNil(c.Input().Get("session_id").String())
 


### PR DESCRIPTION
# Description

1. The delete session action is available/present in a response even if there is only one active session and it is equal to the current session.
2. The input is not properly validated so deleting other user's sessions is possible.

# Implementation

1. Suspend the action during initialization if there is no other session than the current one.
2. Validate the input (and hence its allowed values) during execution.

# How to test

1. Log in to establish a session. The action should not be present in the response. Then establish one or more sessions, the action should be present again.
2. Login with users A and B, establish one more session for user A (or else the action would not be present, see 1.).  As user A, try to delete the session from user B. The input should now be validated and an error should be returned (because User B's session is not in the allowed values).

