### PR TITLE
#1806 Add DevContainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "dockerComposeFile": "../deploy/docker-compose/devcontainers-full-setup.yaml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "forwardPorts": [
+    80,
+    8025
+  ]
+}

--- a/deploy/docker-compose/config-devcontainer.yaml
+++ b/deploy/docker-compose/config-devcontainer.yaml
@@ -1,0 +1,28 @@
+database:
+  user: hanko
+  password: hanko
+  host: postgresd
+  port: 5432
+  dialect: postgres
+email_delivery:
+  smtp:
+    host: "mail"
+    port: "1025"
+  from_address: noreply@hanko.io
+secrets:
+  keys:
+    - abcedfghijklmnopqrstuvwxyz
+service:
+  name: Hanko Authentication Service
+webauthn:
+  relying_party:
+    origins:
+      - "http://localhost:8888"
+session:
+  cookie:
+    secure: false # is needed for safari, because safari does not store secure cookies on localhost
+server:
+  public:
+    cors:
+      allow_origins:
+        - "http://localhost:8888"

--- a/deploy/docker-compose/devcontainer-nginx.conf
+++ b/deploy/docker-compose/devcontainer-nginx.conf
@@ -1,0 +1,40 @@
+server {
+ listen 80;
+ server_name hanko-quickstart;
+
+ location /elements.js {
+   proxy_set_header X-Real-IP $remote_addr;
+   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+   proxy_set_header X-NginX-Proxy true;
+   proxy_pass http://elements-nginx/elements/elements.js;
+ }
+
+ location /sdk.modern.js {
+   proxy_set_header X-Real-IP $remote_addr;
+   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+   proxy_set_header X-NginX-Proxy true;
+   proxy_pass http://elements-nginx/frontend-sdk/sdk.modern.js;
+ }
+
+ location /backend/ {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_pass http://hanko:8000/;
+  }
+
+ location /mail/ {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_pass http://mail:8025/;
+  }
+
+
+ location / {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_pass http://quickstart:8080/;
+  }
+}

--- a/deploy/docker-compose/devcontainers-full-setup.yaml
+++ b/deploy/docker-compose/devcontainers-full-setup.yaml
@@ -1,0 +1,119 @@
+version: '3.9'
+services:
+  hanko-migrate:
+    build: ../../backend
+    volumes:
+      - type: bind
+        source: ./config-devcontainer.yaml
+        target: /etc/config/config.yaml
+    command: --config /etc/config/config.yaml migrate up
+    restart: on-failure
+    depends_on:
+      postgresd:
+        condition: service_healthy
+    networks:
+      - intranet
+  hanko:
+    depends_on:
+      hanko-migrate:
+        condition: service_completed_successfully
+    build: ../../backend
+    ports:
+      - '8000:8000' # public
+      - '8001:8001' # admin
+    restart: unless-stopped
+    command: serve --config /etc/config/config.yaml all
+    volumes:
+      - type: bind
+        source: ./config-devcontainer.yaml
+        target: /etc/config/config.yaml
+    networks:
+      - intranet
+    environment:
+      - PASSWORD_ENABLED
+  postgresd:
+    image: postgres:12-alpine
+    ports:
+      - "5442:5432"
+    environment:
+      - POSTGRES_USER=hanko
+      - POSTGRES_PASSWORD=hanko
+      - POSTGRES_DB=hanko
+      - DB_PORT=5442
+    healthcheck:
+      test: pg_isready -U hanko -d hanko
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - intranet
+  elements:
+    image: node:18.14-alpine
+    working_dir: /workspace
+    entrypoint: /bin/sh -c
+    command:
+      - npm install && npm run build:elements:dev
+    volumes:
+      - type: bind
+        source: ../../frontend/
+        target: /workspace
+    networks:
+      - intranet
+  elements-nginx:
+    image: nginx:1-alpine
+    depends_on:
+      elements:
+        condition: service_started
+    ports:
+      - 8089:80
+    networks:
+      - intranet
+    volumes:
+      - ../../frontend/elements/dist/:/usr/share/nginx/html/elements/
+      - ../../frontend/frontend-sdk/dist/:/usr/share/nginx/html/frontend-sdk/
+  quickstart:
+    build: ../../quickstart
+    ports:
+      - "8888:8080"
+    environment:
+      - HANKO_URL=/backend
+      - HANKO_URL_INTERNAL=http://hanko:8000
+      - HANKO_FRONTEND_SDK_URL=/sdk.modern.js
+      - HANKO_ELEMENT_URL=/elements.js
+    networks:
+      - intranet
+  mail:
+    image: mailhog/mailhog:latest
+    restart: always
+    ports:
+      - 2500:1025
+      - 8025:8025
+    networks:
+      - intranet
+  entry:
+    image: nginx
+    volumes:
+      - ./devcontainer-nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      hanko:
+        condition: service_started
+      elements-nginx:
+        condition: service_started
+      mail:
+        condition: service_started
+      quickstart:
+        condition: service_started
+    ports:
+      - '80:80'
+    networks:
+      - intranet
+  devcontainer:
+    image: mcr.microsoft.com/devcontainers/base:ubuntu
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+    networks:
+      - intranet
+networks:
+  intranet:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "test": "turbo run test",
     "start": "turbo run start",
     "build:elements": "turbo build --filter=./frontend-sdk --filter=./elements",
-    "build:elements:dev": "turbo build:dev --filter=./elements"
+    "build:elements:dev": "turbo build:dev --filter=@teamhanko/hanko-elements"
   },
   "devDependencies": {
     "turbo": "^1.10.7"


### PR DESCRIPTION
# Description
Add DevContainers based on quickstart-project to improve the handling of the development environment. Ports 80 (quickstart project) and 8025 (mailhog) are forwarded within the DevContainer setup. 

Addressing #1806.

# Implementation

- add devcontainer.json based on docker compose
- add a docker-compose file for devcontainer setup 
- there were issues to make mailslurper accessible through codespace port forwarding therefore it has been replaced by [mailhog](https://github.com/mailhog/MailHog)

# Tests

The setup can be tried here:
- https://github.com/MarianPalkus/hanko
- "Code" -> "Codespaces ..." -> "New with options..."
- <img width="1029" alt="Screenshot 2024-10-19 at 00 55 50" src="https://github.com/user-attachments/assets/8a85b75a-3726-4f13-821b-53762860f4c3">
- Select branch "devcontainers" and "create codespace"
- <img width="815" alt="Screenshot 2024-10-19 at 00 57 38" src="https://github.com/user-attachments/assets/843deb5e-49c8-4899-bce2-ec9e5094d76d">
- the codespace should be opened
- After initialization has finished (might take some minutes) the quickstart-page can be accessed via "Ports" -> Port 80 -> "Open in Browser"
- <img width="939" alt="Screenshot 2024-10-19 at 00 44 26" src="https://github.com/user-attachments/assets/4f85607f-b36f-4c0c-b9f2-7f21651b32c5">
- mailhog can be accessed via "Ports" -> Port 8025 -> "Open in Browser"

The quickstart-example should be fully working:

<img width="836" alt="Screenshot 2024-10-19 at 00 44 50" src="https://github.com/user-attachments/assets/77b86d61-3bd8-4aab-9806-fd5293c3299b">

<img width="592" alt="Screenshot 2024-10-19 at 00 44 42" src="https://github.com/user-attachments/assets/1598b688-3974-46c0-9ba8-fa13fd37c5e0">



# Todos

- [ ] the service `entry` in the devcontainer docker-compose file might not be required 
- [ ] code changes should directly be visible in the quickstart-page: configure hmr/fast refresh for elements and frontend-sdk and watch-build for backend
- [ ] devcontainer-docker-compose-file and custom config files might be moved to the `.devcontainers` directory
- [ ] webauthn origin config might be wrong 

 
# Additional context

<!-- Add any other relevant context pertaining to the proposed change. For example, if the change can be visualized,
include screenshots or diagrams to indicate the state before and after the change. -->
