### PR TITLE
ci: remove reviewers from schema generation workflows

### DIFF
--- a/.github/workflows/schema-generate-config.yml
+++ b/.github/workflows/schema-generate-config.yml
@@ -41,7 +41,6 @@ jobs:
             git push origin HEAD
             gh pr create \
               -B main \
-              -r teamhanko/developers \
               -H "chore-autogenerate-config-json-schema-${{ github.run_id }}" \
               -t "chore: autogenerate config JSON schema" \
               -b '# Description

--- a/.github/workflows/schema-generate-import.yml
+++ b/.github/workflows/schema-generate-import.yml
@@ -39,7 +39,6 @@ jobs:
             git push origin HEAD
             gh pr create \
               -B main \
-              -r teamhanko/developers \
               -H "chore-autogenerate-import-json-schema-${{ github.run_id }}" \
               -t "chore: autogenerate import JSON schema" \
               -b '# Description


### PR DESCRIPTION
# Description

The GITHUB_TOKEN used in the workflow does not have permissions to read organization data. Adding team reviewers requires such a permission. 

# Implementation

This commit removes requesting team reviewers when creating the PR via GitHub CLI.
