### PR TITLE
ci: adjust dockerfile FROM commands

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:18.14-alpine as build
+FROM --platform=$BUILDPLATFORM node:18.14-alpine AS build
 RUN apk add --no-cache libc6-compat
 RUN apk update
 

--- a/frontend/Dockerfile.debug
+++ b/frontend/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:18.14-alpine as build
+FROM --platform=$BUILDPLATFORM node:18.14-alpine AS build
 RUN apk add --no-cache libc6-compat
 RUN apk update
 

--- a/quickstart/Dockerfile
+++ b/quickstart/Dockerfile
@@ -1,5 +1,5 @@
 # Build the quickstart binary
-FROM --platform=$BUILDPLATFORM golang:1.20 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20 AS builder
 
 ARG TARGETARCH
 


### PR DESCRIPTION
# Description

Currently there are check warnings for some of our Dockerfiles:

> The 'as' keyword should match the case of the 'from' keyword

[Example](https://github.com/teamhanko/hanko/pull/1963/files) (Scroll down to `Unchanged files with check annotations` section)

# Implementation

Do as the warning says and all-cap the `as` in `FROM` commands in Dockerfiles.

