### PR TITLE
fix: username onboarding on third party login/link

### DIFF
--- a/backend/persistence/identity_persister.go
+++ b/backend/persistence/identity_persister.go
@@ -23,7 +23,7 @@ type identityPersister struct {
 
 func (p identityPersister) GetByID(identityID uuid.UUID) (*models.Identity, error) {
 	identity := &models.Identity{}
-	if err := p.db.EagerPreload("Email", "Email.User").Find(identity, identityID); err != nil {
+	if err := p.db.EagerPreload("Email", "Email.User", "Email.User.Username").Find(identity, identityID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}


### PR DESCRIPTION
# Description

If there is an existing user with a username and that user decides to link a third party account and username onboarding on login is enabled then logging in via third party results in a username onboarding prompt but if the user enters a username, then this leads to an error: if it is the same username it results in a "username already taken" error, if it is a different username it results in a technical error (unique constraint violation on the DB level because there already is a username for this user). The username prompt should not appear if the username is already set.

# Implementation

There's already a [check](https://github.com/teamhanko/hanko/blob/2539c04aefb6810e90b8b0588ed307dcd6b9cb32/backend/flow_api/flow/shared/action_exchange_token.go#L116) in place for ensuring that a username is set but the [persister used to retrieve the identity](https://github.com/teamhanko/hanko/blob/2539c04aefb6810e90b8b0588ed307dcd6b9cb32/backend/flow_api/flow/shared/action_exchange_token.go#L64) does not [preload](https://github.com/teamhanko/hanko/blob/2539c04aefb6810e90b8b0588ed307dcd6b9cb32/backend/persistence/identity_persister.go#L26) the username, hence the check fails.

# How to test

Do a before/after of:

- Configure third party provider of your choice, configure it to allow linking
- Enable usernames, set acquiring usernames on login to true
- Create a user, set a username
- Log in with third party provider
  - before: username is prompted for and the above mentioned errors occur when trying to set a username
  - after: username is not prompted for
