### PR TITLE
fix security key login

### DIFF
--- a/backend/flow_api/flow/credential_usage/action_webauthn_verify_assertion_response.go
+++ b/backend/flow_api/flow/credential_usage/action_webauthn_verify_assertion_response.go
@@ -92,7 +92,8 @@ func (a WebauthnVerifyAssertionResponse) Execute(c flowpilot.ExecutionContext) e
 		}
 	}
 
-	if c.Stash().Get(shared.StashPathUserID).Exists() && c.Stash().Get(shared.StashPathUserID).String() != userModel.ID.String() {
+	userIdStash := c.Stash().Get(shared.StashPathUserID)
+	if userIdStash.Exists() && userIdStash.String() != uuid.Nil.String() && userIdStash.String() != userModel.ID.String() {
 		err = deps.AuditLogger.CreateWithConnection(
 			deps.Tx,
 			deps.HttpContext,


### PR DESCRIPTION
# Description

The MFA login with security key due to wrongly used validation method of the webauthn library. The security key validation must not use the validation method for discoverable credentials, because the MFA credential is not created as a discoverable credential. Because of the usage of the wrong method a MFA login with a security key never succeeds.

# Implementation

Use the correct webauthn validation method to validate the MFA security key response.

# Tests

1. Create a new user with a security key as MFA method
2. Try to login with the security key

