### PR TITLE
fix: add missing third party provider defaults

### DIFF
--- a/backend/config/config_default.go
+++ b/backend/config/config_default.go
@@ -117,20 +117,28 @@ func DefaultConfig() *Config {
 		},
 		ThirdParty: ThirdParty{
 			Providers: ThirdPartyProviders{
-				Google: ThirdPartyProvider{
-					DisplayName:  "Google",
-					AllowLinking: true,
-				},
-				GitHub: ThirdPartyProvider{
-					DisplayName:  "GitHub",
-					AllowLinking: true,
-				},
 				Apple: ThirdPartyProvider{
 					DisplayName:  "Apple",
 					AllowLinking: true,
 				},
 				Discord: ThirdPartyProvider{
 					DisplayName:  "Discord",
+					AllowLinking: true,
+				},
+				LinkedIn: ThirdPartyProvider{
+					DisplayName:  "LinkedIn",
+					AllowLinking: true,
+				},
+				Microsoft: ThirdPartyProvider{
+					DisplayName:  "Microsoft",
+					AllowLinking: true,
+				},
+				GitHub: ThirdPartyProvider{
+					DisplayName:  "GitHub",
+					AllowLinking: true,
+				},
+				Google: ThirdPartyProvider{
+					DisplayName:  "Google",
 					AllowLinking: true,
 				},
 			},


### PR DESCRIPTION
# Description

Fixes the issue that the provider name for some providers are not properly returned by the backend (and hence not shown in Hanko elements) when defaults are not set.