### PR TITLE
feat: enhance session response

### DIFF
--- a/backend/handler/session.go
+++ b/backend/handler/session.go
@@ -47,7 +47,7 @@ func (h *SessionHandler) ValidateSession(c echo.Context) error {
 
 			claims, err := dto.GetClaimsFromToken(token)
 			if err != nil {
-				return c.JSON(http.StatusOK, dto.ValidateSessionResponse{IsValid: false})
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("failed to parse token claims: %w", err))
 			}
 
 			sessionModel, err := h.persister.GetSessionPersister().Get(claims.SessionID)
@@ -96,7 +96,7 @@ func (h *SessionHandler) ValidateSessionFromBody(c echo.Context) error {
 
 	claims, err := dto.GetClaimsFromToken(token)
 	if err != nil {
-		return c.JSON(http.StatusOK, dto.ValidateSessionResponse{IsValid: false})
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("failed to parse token claims: %w", err))
 	}
 
 	sessionModel, err := h.persister.GetSessionPersister().Get(claims.SessionID)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

This PR introduces improvements to the session validation process, focusing on extracting claims from JWT tokens.

<!-- Brief description of WHAT you’re doing and WHY. -->

<!-- If applicable, add references to fixed/related issues (e.g. add "Fixes #<issue>"/"Relates to#<issue>".  -->

# Implementation

- dto/session.go:
  - Added a new Claims struct to represent JWT claims, providing a standardized structure for parsing token data.
  - Implemented `GetClaimsFromToken` function for parsing and validating JWT token claims.
  - Updated `ValidateSessionResponse` to include the Claims field while keeping deprecated fields (ExpirationTime, UserID) for backward compatibility.

- handler/session.go:
  - Replaced manual token parsing with `GetClaimsFromToken` for extracting claims.
  - Simplified logic in `ValidateSession` and `ValidateSessionFromBody` handlers:
    - Validated session IDs and claims directly.
    - Updated response payload to use the new Claims structure.
 
# Todos

- Deprecate usage of ExpirationTime and UserID in the SDK and migrate to the new structure.

# Additional Context

This PR relates the the changes made in the docs: https://github.com/teamhanko/docs/pull/110
