### PR TITLE
feat: validate boolean inputs

### DIFF
--- a/backend/flowpilot/errors.go
+++ b/backend/flowpilot/errors.go
@@ -172,5 +172,5 @@ var (
 )
 
 func createMustBeOneOfError(values []string) InputError {
-	return NewInputError("value_invalid_error", fmt.Sprintf("The value is invalid. Must be one of: %s", strings.Join(values, ",")))
+	return NewInputError("value_invalid_error", fmt.Sprintf("The value is invalid. Must be one of: %s", strings.Join(values, ", ")))
 }


### PR DESCRIPTION
# Description

Validate boolean inputs instead of assuming all values are valid.

# Implementation

Only values that are resolved by `strconv.ParseBool` without an error are now valid input values. 
