### PR TITLE
fix: use lowered id to get third party provider

### DIFF
--- a/backend/handler/thirdparty_auth_test.go
+++ b/backend/handler/thirdparty_auth_test.go
@@ -101,7 +101,7 @@ func (s *thirdPartySuite) TestThirdPartyHandler_Auth() {
 			requestedRedirectTo:      "https://app.test.example",
 			expectedBaseURL:          "https://login.test.example",
 			expectedError:            thirdparty.ErrorCodeInvalidRequest,
-			expectedErrorDescription: "unknownProvider",
+			expectedErrorDescription: "unknown provider",
 		},
 		{
 			name:                     "error redirect when requesting a redirectTo that is not allowed",

--- a/backend/test/database.go
+++ b/backend/test/database.go
@@ -57,7 +57,7 @@ func StartDB(name string, dialect string) (*TestDB, error) {
 	hostAndPort := resource.GetHostPort(getPortID(dialect))
 	dsn := getDsn(dialect, hostAndPort)
 
-	_ = resource.Expire(120)
+	_ = resource.Expire(300)
 
 	pool.MaxWait = 120 * time.Second
 	if err = pool.Retry(func() error {

--- a/backend/thirdparty/provider.go
+++ b/backend/thirdparty/provider.go
@@ -94,7 +94,7 @@ func GetProvider(config config.ThirdParty, id string) (OAuthProvider, error) {
 	if strings.HasPrefix(idLower, "custom_") {
 		return getCustomThirdPartyProvider(config, idLower)
 	} else {
-		return getThirdPartyProvider(config, id)
+		return getThirdPartyProvider(config, idLower)
 	}
 }
 


### PR DESCRIPTION
# Description

When trying to get a third party provider the lowered id must be used. This was already in place for getting custom third party providers, but was missing for the predefined ones.

