### PR TITLE
fix: don't use config file when failed to load

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -89,6 +89,7 @@ func Load(cfgFile *string) (*Config, error) {
 		*cfgFile = DefaultConfigFilePath
 	}
 
+	c := DefaultConfig()
 	k, err := LoadFile(cfgFile, yaml.Parser())
 	if err != nil {
 		if *cfgFile != DefaultConfigFilePath {
@@ -97,12 +98,10 @@ func Load(cfgFile *string) (*Config, error) {
 		log.Println("failed to load config, skipping...")
 	} else {
 		log.Println("Using config file:", *cfgFile)
-	}
-
-	c := DefaultConfig()
-	err = k.Unmarshal("", c)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+		err = k.Unmarshal("", c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+		}
 	}
 
 	err = envconfig.Process("", c)


### PR DESCRIPTION
# Description

The config loading mechanism always tries to unmarshal the config file, even when it could not be loaded. The file should only be unmarshalled when the file could be loaded successfully.

# Implementation

Move the `Unmarshal` function into the if statement where we know that the file was loaded successfully.

# Tests

Try to start the backend with missing config file.

