### PR TITLE
fix: error handling when using zombie passkeys

### DIFF
--- a/backend/flow_api/flow/credential_usage/action_webauthn_verify_assertion_response.go
+++ b/backend/flow_api/flow/credential_usage/action_webauthn_verify_assertion_response.go
@@ -78,7 +78,7 @@ func (a WebauthnVerifyAssertionResponse) Execute(c flowpilot.ExecutionContext) e
 				return fmt.Errorf("could not create audit log: %w", err)
 			}
 
-			return c.Continue(shared.StateError)
+			return c.Continue(c.GetCurrentState())
 		}
 
 		return fmt.Errorf("failed to verify assertion response: %w", err)

--- a/backend/flow_api/flow/login/hook_webauthn_generate_request_options_cond.go
+++ b/backend/flow_api/flow/login/hook_webauthn_generate_request_options_cond.go
@@ -33,7 +33,7 @@ func (a WebauthnGenerateRequestOptionsForConditionalUi) Execute(c flowpilot.Hook
 		return fmt.Errorf("failed to generate webauthn request options: %w", err)
 	}
 
-	err = c.Stash().Set(shared.StashPathWebauthnSessionDataID, sessionDataModel.ID)
+	err = c.Stash().Set(shared.StashPathWebauthnSessionDataID, sessionDataModel.ID.String())
 	if err != nil {
 		return fmt.Errorf("failed to stash webauthn_session_data_id: %w", err)
 	}

--- a/backend/flowpilot/context_action_exec.go
+++ b/backend/flowpilot/context_action_exec.go
@@ -210,10 +210,6 @@ func (aec *defaultActionExecutionContext) Revert() error {
 }
 
 func (aec *defaultActionExecutionContext) Continue(stateNames ...StateName) error {
-	if aec.flowError != nil {
-		return aec.Error(aec.flowError)
-	}
-
 	for _, stateName := range stateNames {
 		if _, ok := aec.flow.stateDetails[stateName]; !ok {
 			return fmt.Errorf("cannot continue, state does not exist: %s", stateName)

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -330,7 +330,11 @@ const AppProvider = ({
           });
         } catch (error) {
           const prevState = await state.actions.back(null).run();
-          setLoadingAction(null);
+          setUIState((prev) => ({
+            ...prev,
+            error: state.error,
+            loadingAction: null,
+          }));
           return hanko.flow.run(prevState, stateHandler);
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

This PR fixes the following issues:

- When using a passkey that has been deleted on the server, the error message “This passkey cannot be used anymore” does not get shown (only when using the passkey button).
- When the first try to login with a passkey fails, the user can not login with a passkey anymore. The user needs to reload the page to be able to login with a passkey (when using conditional ui).

# Implementation

- The first issue was resolved by saving the current state error into the `uiState` after the "back" action is triggered. This ensures that the new state does not overwrite the pre-existing WebAuthN errors. Additionally, the flow API has been updated to avoid transitioning into an error state, as the UI should not display the error page in such cases.

- To address the second issue where a valid passkey could not be used after attempting to use a zombie passkey, the flowpilot logic was adjusted. The problem stemmed from the `c.Continue()` function not updating the state data (specifically, the new WebAuthN Session ID, in this case) when a `FlowError` was present in the context. This behaviour has been changed so that `c.Continue()` now saves the updated state to the database, even in the presence of a `FlowError`. If this behaviour is not desired, the `c.Error()` function should be used instead.



# Tests

1. Create two WebAuthN credentials.
2. Remove one of them from the database.
3. Try to login with the deleted one.
4. Observe that the "This Passkey can not be used anymore" error is displayed correctly when using conditional UI and the Passkey button.
5. After a failed attempt via conditional UI and the error message is still shown, attempt to login with the passkey that has not been deleted.
6. Verify the login attempt was successful.
