### PR TITLE
fix: third party loading spinner shown on multiple buttons fixed

### DIFF
--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -111,7 +111,6 @@ export type UIAction =
   | "back"
   | "account_delete"
   | "retry"
-  | "thirdparty-submit"
   | "session-delete"
   | "auth-app-add"
   | "auth-app-remove"

--- a/frontend/elements/src/pages/LoginInitPage.tsx
+++ b/frontend/elements/src/pages/LoginInitPage.tsx
@@ -54,6 +54,9 @@ const LoginInitPage = (props: Props) => {
   const [thirdPartyError, setThirdPartyError] = useState<
     HankoError | undefined
   >(undefined);
+  const [selectedThirdPartyProvider, setSelectedThirdPartyProvider] = useState<
+    string | null
+  >(null);
   const [rememberMe, setRememberMe] = useState<boolean>(false);
 
   const onIdentifierInput = (event: Event) => {
@@ -128,7 +131,7 @@ const LoginInitPage = (props: Props) => {
 
   const onThirdpartySubmit = async (event: Event, name: string) => {
     event.preventDefault();
-    setLoadingAction("thirdparty-submit");
+    setSelectedThirdPartyProvider(name);
 
     const nextState = await flowState.actions
       .thirdparty_oauth({
@@ -136,6 +139,8 @@ const LoginInitPage = (props: Props) => {
         redirect_to: window.location.toString(),
       })
       .run();
+
+    setSelectedThirdPartyProvider(null);
 
     await hanko.flow.run(nextState, stateHandler);
   };
@@ -267,7 +272,7 @@ const LoginInitPage = (props: Props) => {
                     onSubmit={(event) => onThirdpartySubmit(event, v.value)}
                   >
                     <Button
-                      uiAction={"thirdparty-submit"}
+                      isLoading={v.value == selectedThirdPartyProvider}
                       secondary
                       // @ts-ignore
                       icon={

--- a/frontend/elements/src/pages/LoginInitPage.tsx
+++ b/frontend/elements/src/pages/LoginInitPage.tsx
@@ -140,8 +140,11 @@ const LoginInitPage = (props: Props) => {
       })
       .run();
 
+    if (nextState.error) {
+      setSelectedThirdPartyProvider(null);
+    }
+
     await hanko.flow.run(nextState, stateHandler);
-    setSelectedThirdPartyProvider(null);
   };
 
   const showDivider = useMemo(

--- a/frontend/elements/src/pages/LoginInitPage.tsx
+++ b/frontend/elements/src/pages/LoginInitPage.tsx
@@ -140,9 +140,8 @@ const LoginInitPage = (props: Props) => {
       })
       .run();
 
-    setSelectedThirdPartyProvider(null);
-
     await hanko.flow.run(nextState, stateHandler);
+    setSelectedThirdPartyProvider(null);
   };
 
   const showDivider = useMemo(

--- a/frontend/elements/src/pages/RegistrationInitPage.tsx
+++ b/frontend/elements/src/pages/RegistrationInitPage.tsx
@@ -41,6 +41,9 @@ const RegistrationInitPage = (props: Props) => {
   const [thirdPartyError, setThirdPartyError] = useState<
     HankoError | undefined
   >(undefined);
+  const [selectedThirdPartyProvider, setSelectedThirdPartyProvider] = useState<
+    string | null
+  >(null);
   const [rememberMe, setRememberMe] = useState<boolean>(false);
 
   const onIdentifierSubmit = async (event: Event) => {
@@ -79,7 +82,7 @@ const RegistrationInitPage = (props: Props) => {
 
   const onThirdpartySubmit = async (event: Event, name: string) => {
     event.preventDefault();
-    setLoadingAction("thirdparty-submit");
+    setSelectedThirdPartyProvider(name);
 
     const nextState = await flowState.actions
       .thirdparty_oauth({
@@ -87,6 +90,9 @@ const RegistrationInitPage = (props: Props) => {
         redirect_to: window.location.toString(),
       })
       .run();
+
+    setSelectedThirdPartyProvider(null);
+
     await hanko.flow.run(nextState, stateHandler);
   };
 
@@ -193,7 +199,7 @@ const RegistrationInitPage = (props: Props) => {
                     onSubmit={(event) => onThirdpartySubmit(event, v.value)}
                   >
                     <Button
-                      uiAction={"thirdparty-submit"}
+                      isLoading={v.value == selectedThirdPartyProvider}
                       secondary
                       // @ts-ignore
                       icon={


### PR DESCRIPTION
# Description

Fixes an issue where clicking a third-party button, with multiple providers configured, incorrectly displays the loading spinner on all third-party buttons.

# Tests

Configure multiple third-party providers and click the buttons on the login or registration page. Verify that the loading spinner appears only on the buttons you clicked.
