### PR TITLE
fix: reintroduce server-side session config

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -20,6 +20,10 @@ type Config struct {
 	// options, to new ones. If set to `false`, these values have to be set manually if non-default values should be
 	// used.
 	ConvertLegacyConfig bool `yaml:"convert_legacy_config" json:"convert_legacy_config,omitempty" koanf:"convert_legacy_config" split_words:"true" jsonschema:"default=false"`
+	// `covert_legacy_session_config`, if set to `true`, automatically copies the set of deprecated server-side session
+	// configuration options to the new ones. If set to `false`, these values have to be set manually if non-default
+	// values should be used.
+	ConvertLegacyServerSideSessionConfig bool `yaml:"convert_legacy_server_side_session_config" json:"convert_legacy_server_side_session_config" koanf:"convert_legacy_server_side_session_config" split_words:"true" jsonschema:"default=true"`
 	// `database` configures database connection settings.
 	Database Database `yaml:"database" json:"database,omitempty" koanf:"database" jsonschema:"title=database"`
 	// `debug`, if set to `true`, adds additional debugging information to flow API responses.
@@ -186,9 +190,23 @@ func (c *Config) convertLegacyConfig() {
 	c.Webauthn.Timeouts.Registration = c.Webauthn.Timeout
 }
 
+func (c *Config) convertLegacyServerSideSessionConfig() {
+	if c.Session.ServerSide != nil && c.Session.ServerSide.Enabled {
+		c.Session.AllowRevocation = true
+		c.Session.AcquireIPAddress = true
+		c.Session.AcquireUserAgent = true
+		c.Session.Limit = c.Session.ServerSide.Limit
+		c.Session.ShowOnProfile = true
+	}
+}
+
 func (c *Config) PostProcess() error {
 	if c.ConvertLegacyConfig {
 		c.convertLegacyConfig()
+	}
+
+	if c.ConvertLegacyServerSideSessionConfig {
+		c.convertLegacyServerSideSessionConfig()
 	}
 
 	err := c.ThirdParty.PostProcess()

--- a/backend/config/config_default.go
+++ b/backend/config/config_default.go
@@ -4,7 +4,8 @@ import "time"
 
 func DefaultConfig() *Config {
 	return &Config{
-		ConvertLegacyConfig: false,
+		ConvertLegacyConfig:                  false,
+		ConvertLegacyServerSideSessionConfig: true,
 		Service: Service{
 			Name: "Hanko Authentication Service",
 		},

--- a/backend/config/config_session.go
+++ b/backend/config/config_session.go
@@ -35,6 +35,9 @@ type Session struct {
 	Limit int `yaml:"limit" json:"limit,omitempty" koanf:"limit" jsonschema:"default=5"`
 	// `show_on_profile` indicates that the sessions should be listed on the profile.
 	ShowOnProfile bool `yaml:"show_on_profile" json:"show_on_profile,omitempty" koanf:"show_on_profile" jsonschema:"default=true"`
+	// Deprecated. Use settings in parent object.
+	//`server_side` contains configuration for server-side sessions.
+	ServerSide *ServerSide `yaml:"server_side" json:"server_side" koanf:"server_side"`
 }
 
 func (s *Session) Validate() error {
@@ -83,4 +86,14 @@ func (c *Cookie) GetName() string {
 	}
 
 	return "hanko"
+}
+
+type ServerSide struct {
+	// `enabled` determines whether server-side sessions are enabled.
+	//
+	// NOTE: When enabled the session endpoint must be used in order to check if a session is still valid.
+	Enabled bool `yaml:"enabled" json:"enabled,omitempty" koanf:"enabled" jsonschema:"default=false"`
+	// `limit` determines the maximum number of server-side sessions a user can have. When the limit is exceeded,
+	// older sessions are invalidated.
+	Limit int `yaml:"limit" json:"limit,omitempty" koanf:"limit" jsonschema:"default=100"`
 }


### PR DESCRIPTION
# Description

Reintroduce server-side session config for backward compatibility.

# Implementation

When server-side sessions are enabled set the "new" session config parameters. This behaviour can be disabled by setting 
`convert_legacy_server_side_session_config` to `false`.

