### PR TITLE
fix: use TriggerWebhook function instead of NotifyUserChange

### DIFF
--- a/backend/flow_api/flow/profile/action_account_delete.go
+++ b/backend/flow_api/flow/profile/action_account_delete.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"fmt"
 	auditlog "github.com/teamhanko/hanko/backend/audit_log"
+	"github.com/teamhanko/hanko/backend/dto/admin"
 	"github.com/teamhanko/hanko/backend/flow_api/flow/shared"
 	"github.com/teamhanko/hanko/backend/flowpilot"
 	"github.com/teamhanko/hanko/backend/persistence/models"
@@ -61,7 +62,11 @@ func (a AccountDelete) Execute(c flowpilot.ExecutionContext) error {
 	}
 
 	deps.HttpContext.SetCookie(cookie)
-	utils.NotifyUserChange(deps.HttpContext, deps.Tx, deps.Persister, events.UserDelete, userModel.ID)
+
+	err = utils.TriggerWebhooks(deps.HttpContext, deps.Tx, events.UserDelete, admin.FromUserModel(*userModel))
+	if err != nil {
+		return fmt.Errorf("failed to trrigger webhook: %w", err)
+	}
 
 	return c.Continue(shared.StateProfileAccountDeleted)
 }


### PR DESCRIPTION
# Description

When a user is deleted through the Flow API the application throws a nil pointer dereference error.

# Implementation

The `NotifyUserChange` function tries to get the user from the database but since the user was deleted the user is not present anymore and therefore `nil` is returned. To fix it, the account delete event is triggered through `TriggerWebhook`.
