### PR TITLE
alternative 'change flows'-migration for mysql, mariadb

### DIFF
--- a/backend/persistence/migrations/20240717020707_change_flows.up.fizz
+++ b/backend/persistence/migrations/20240717020707_change_flows.up.fizz
@@ -1,4 +1,8 @@
+{{ if eq .Dialect "mysql" }}
+add_column("flows", "data", "mediumtext", {})
+{{ else }}
 add_column("flows", "data", "string", {"size": 65536})
+{{ end }}
 drop_column("flows", "stash_data")
 drop_column("flows", "current_state")
 drop_column("flows", "previous_state")


### PR DESCRIPTION
# Description

To run the migrations with for **MariaDb**  the migration `add_column("flows", "data", "string", {"size": 65536})` is not applicable. There is no way to use `VARCHAR` of that length. So the type has to be `TEXT` or `MEDIUMTEXT`, both have higher limits than 65536 still working for postgres

# Implementation

When database **dialect** mysql is configured, then migrations will now apply `MEDIUMTEXT`

