### PR TITLE
fix: add types for react 19

### DIFF
--- a/frontend/elements/src/Elements.tsx
+++ b/frontend/elements/src/Elements.tsx
@@ -37,6 +37,21 @@ declare global {
   }
 }
 
+// React 19 and later
+declare module "react" {
+  // eslint-disable-next-line no-unused-vars
+  namespace JSX {
+    // eslint-disable-next-line no-unused-vars
+    interface IntrinsicElements {
+      "hanko-auth": HankoAuthElementProps;
+      "hanko-login": HankoAuthElementProps;
+      "hanko-registration": HankoAuthElementProps;
+      "hanko-profile": HankoProfileElementProps;
+      "hanko-events": HankoEventsElementProps;
+    }
+  }
+}
+
 export interface RegisterOptions {
   shadow?: boolean;
   injectStyles?: boolean;

--- a/frontend/elements/src/declarations.d.ts
+++ b/frontend/elements/src/declarations.d.ts
@@ -5,4 +5,4 @@ interface Window {
   _hankoStyle: HTMLStyleElement;
 }
 
-declare module "react"
+declare module "react";

--- a/frontend/elements/src/declarations.d.ts
+++ b/frontend/elements/src/declarations.d.ts
@@ -4,3 +4,5 @@ declare module "*.sass";
 interface Window {
   _hankoStyle: HTMLStyleElement;
 }
+
+declare module "react"


### PR DESCRIPTION
# Description

The JSX namespace was moved to the react module. More information can be found [here](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript).

For backward compatibility the old namespace is still present.

# Test

Update the react dependencies to version 19 in the react example and try to build it.


Fixes #2053 