### PR TITLE
feat: add privacy settings

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -68,6 +68,8 @@ type Config struct {
 	Webauthn WebauthnSettings `yaml:"webauthn" json:"webauthn,omitempty" koanf:"webauthn" jsonschema:"title=webauthn"`
 	// `webhooks` configures HTTP-based callbacks for specific events occurring in the system.
 	Webhooks WebhookSettings `yaml:"webhooks" json:"webhooks,omitempty" koanf:"webhooks" jsonschema:"title=webhooks"`
+	// `privacy` configures privacy settings
+	Privacy Privacy `yaml:"privacy" json:"privacy" koanf:"privacy" jsonschema:"title=privacy"`
 }
 
 var (

--- a/backend/config/config_default.go
+++ b/backend/config/config_default.go
@@ -207,6 +207,10 @@ func DefaultConfig() *Config {
 				Enabled: true,
 			},
 		},
+		Privacy: Privacy{
+			ShowAccountExistenceHints:  false,
+			OnlyShowActualLoginMethods: false,
+		},
 		Debug: false,
 	}
 }

--- a/backend/config/config_privacy.go
+++ b/backend/config/config_privacy.go
@@ -1,0 +1,10 @@
+package config
+
+type Privacy struct {
+	// `show_account_existence_hints` determines whether the user should get a user-friendly response rather than a privacy protecting one. E.g. on sign-up, when enabled the user will get "user already exists" response.
+	// It only has an effect when emails are enabled.
+	ShowAccountExistenceHints bool `yaml:"show_account_existence_hints" json:"show_account_existence_hints,omitempty" koanf:"show_account_existence_hints" split_words:"true" jsonschema:"default=false"`
+	// `only_show_actual_login_methods` determines whether the user will only be prompted with his configured login methods.
+	// It only has an effect when emails are enabled, can be used for authentication and passwords are enabled.
+	OnlyShowActualLoginMethods bool `yaml:"only_show_actual_login_methods" json:"only_show_actual_login_methods,omitempty" koanf:"only_show_actual_login_methods" split_words:"true" jsonschema:"default=false"`
+}

--- a/backend/flow_api/flow/registration/action_register_login_identifier.go
+++ b/backend/flow_api/flow/registration/action_register_login_identifier.go
@@ -117,10 +117,10 @@ func (a RegisterLoginIdentifier) Execute(c flowpilot.ExecutionContext) error {
 		if err != nil {
 			return err
 		}
-		// Do not return an error when only identifier is email and email verification is on (account enumeration protection)
+		// Do not return an error when only identifier is email and email verification is on (account enumeration protection) and privacy setting is off
 		if emailModel != nil {
 			// E-mail address already exists
-			if !deps.Cfg.Email.RequireVerification {
+			if !deps.Cfg.Email.RequireVerification || deps.Cfg.Privacy.ShowAccountExistenceHints {
 				c.Input().SetError("email", shared.ErrorEmailAlreadyExists)
 				return c.Error(flowpilot.ErrorFormDataInvalid)
 			} else {

--- a/backend/flow_api/flow/shared/errors.go
+++ b/backend/flow_api/flow/shared/errors.go
@@ -20,5 +20,6 @@ var (
 	ErrorEmailAlreadyExists    = flowpilot.NewInputError("email_already_exists", "The email address already exists.")
 	ErrorUsernameAlreadyExists = flowpilot.NewInputError("username_already_exists", "The username already exists.")
 	ErrorUnknownUsername       = flowpilot.NewInputError("unknown_username_error", "The username is unknown.")
+	ErrorUnknownEmail          = flowpilot.NewInputError("unknown_email_error", "The email address is unknown.")
 	ErrorInvalidUsername       = flowpilot.NewInputError("invalid_username_error", "The username is invalid.")
 )

--- a/frontend/elements/src/i18n/bn.ts
+++ b/frontend/elements/src/i18n/bn.ts
@@ -196,6 +196,7 @@ export const bn: Translation = {
     rate_limit_exceeded:
       "অনেকগুলি অনুরোধ করা হয়েছে। অনুরোধকৃত অপারেশন পুনরায় প্রয়াত করতে অপেক্ষা করুন।",
     unknown_username_error: "ব্যবহারকারীর নাম অজানা।",
+    unknown_email_error: "ইমেইল ঠিকানাটি অজানা।",
     username_already_exists: "ব্যবহারকারীর নাম ইতিমধ্যে নেওয়া হয়েছে।",
     invalid_username_error:
       "ব্যবহারকারীর নাম শুধুমাত্র অক্ষর, সংখ্যা এবং আন্ডারস্কোর থাকতে পারে।",

--- a/frontend/elements/src/i18n/de.ts
+++ b/frontend/elements/src/i18n/de.ts
@@ -206,6 +206,7 @@ export const de: Translation = {
     rate_limit_exceeded:
       "Zu viele Anfragen wurden gestellt. Bitte warten Sie, um die angeforderte Operation zu wiederholen.",
     unknown_username_error: "Der Benutzername ist unbekannt.",
+    unknown_email_error: "Die Email Adresse ist unbekannt.",
     username_already_exists: "Der Benutzername ist bereits vergeben.",
     invalid_username_error:
       "Der Benutzername darf nur Buchstaben, Zahlen und Unterstriche enthalten.",

--- a/frontend/elements/src/i18n/en.ts
+++ b/frontend/elements/src/i18n/en.ts
@@ -196,6 +196,7 @@ export const en: Translation = {
     rate_limit_exceeded:
       "Too many requests have been made. Please wait to repeat the requested operation.",
     unknown_username_error: "The username is unknown.",
+    unknown_email_error: "The email address is unknown.",
     username_already_exists: "The username is already taken.",
     invalid_username_error:
       "The username must contain only letters, numbers, and underscores.",

--- a/frontend/elements/src/i18n/fr.ts
+++ b/frontend/elements/src/i18n/fr.ts
@@ -205,6 +205,7 @@ export const fr: Translation = {
     rate_limit_exceeded:
       "Trop de demandes ont été effectuées. Veuillez patienter pour répéter l'opération demandée.",
     unknown_username_error: "Le nom d'utilisateur est inconnu.",
+    unknown_email_error: "L'adresse e-mail est inconnue.",
     username_already_exists: "Le nom d'utilisateur est déjà pris.",
     invalid_username_error:
       "Le nom d'utilisateur ne doit contenir que des lettres, des chiffres et des traits de soulignement.",

--- a/frontend/elements/src/i18n/it.ts
+++ b/frontend/elements/src/i18n/it.ts
@@ -198,6 +198,7 @@ export const it: Translation = {
     rate_limit_exceeded:
       "Troppe richieste sono state effettuate. Si prega di attendere per ripetere l'operazione richiesta.",
     unknown_username_error: "Il nome utente è sconosciuto.",
+    unknown_email_error: "L'indirizzo email è sconosciuto.",
     username_already_exists: "Il nome utente è già in uso.",
     invalid_username_error:
       "Il nome utente deve contenere solo lettere, numeri e trattini bassi.",

--- a/frontend/elements/src/i18n/pt-BR.ts
+++ b/frontend/elements/src/i18n/pt-BR.ts
@@ -202,6 +202,7 @@ export const ptBR: Translation = {
     rate_limit_exceeded:
       "Foram feitas muitas solicitações. Por favor, aguarde para repetir a operação solicitada.",
     unknown_username_error: "O nome de usuário é desconhecido.",
+    unknown_email_error: "O endereço de e-mail é desconhecido.",
     username_already_exists: "O nome de usuário já está em uso.",
     invalid_username_error:
       "O nome de usuário deve conter apenas letras, números e sublinhados.",

--- a/frontend/elements/src/i18n/translations.ts
+++ b/frontend/elements/src/i18n/translations.ts
@@ -172,6 +172,7 @@ export interface Translation {
     passcode_max_attempts_reached: string;
     rate_limit_exceeded: string;
     unknown_username_error: string;
+    unknown_email_error: string;
     username_already_exists: string;
     invalid_username_error: string;
     email_already_exists: string;

--- a/frontend/elements/src/i18n/zh.ts
+++ b/frontend/elements/src/i18n/zh.ts
@@ -186,6 +186,7 @@ export const zh: Translation = {
       "密码输入错误次数太多。请请求一个新的验证码。",
     rate_limit_exceeded: "请求过多。请等待重复所请求的操作。",
     unknown_username_error: "用户名未知。",
+    unknown_email_error: "电子邮件地址未知。",
     username_already_exists: "用户名已被使用。",
     invalid_username_error: "用户名只能包含字母、数字和下划线。",
     email_already_exists: "电子邮件已被使用。",


### PR DESCRIPTION
# Description

Add two privacy settings, one that disables account enumeration protection (`show_account_existence_hints`) and one that only returns actual configured login methods of the user (`only_show_actual_login_methods`).

Although otherwise discussed these two settings also have an effect when email verification is disabled. And therefore the settings are added to a `privacy` section in the settings.

# Implementation

Added some checks that if the settings are enabled an error might be returned e.g. the account or email does not exist.

# Tests

Enable and disable email, email.use_for_authentication , username, password and check that errors are returned when user already exists or does not exists and that only authentication methods are returned that the user has configures. 

MFA methods are not changed because they are only already returned when they are configured by the user.

# Todos

We should add a page in the docs that describes these two settings.


