### PR TITLE
feat: add passkey option to login method chooser

### DIFF
--- a/backend/flow_api/flow/flows.go
+++ b/backend/flow_api/flow/flows.go
@@ -35,6 +35,7 @@ var CredentialUsageSubFlow = flowpilot.NewSubFlow(shared.FlowCredentialUsage).
 	State(shared.StateLoginMethodChooser,
 		credential_usage.ContinueToPasswordLogin{},
 		credential_usage.ContinueToPasscodeConfirmation{},
+		credential_usage.WebauthnGenerateRequestOptions{},
 		shared.Back{},
 	).
 	State(shared.StateLoginPassword,

--- a/frontend/elements/src/pages/LoginMethodChooser.tsx
+++ b/frontend/elements/src/pages/LoginMethodChooser.tsx
@@ -46,6 +46,16 @@ const LoginMethodChooserPage = (props: Props) => {
     await hanko.flow.run(nextState, stateHandler);
   };
 
+  const onPasskeySelectSubmit = async (event: Event) => {
+    event.preventDefault();
+    setLoadingAction("passkey-submit");
+    const nextState = await flowState.actions
+      .webauthn_generate_request_options(null)
+      .run();
+    setLoadingAction(null);
+    await hanko.flow.run(nextState, stateHandler);
+  };
+
   const onBackClick = async (event: Event) => {
     event.preventDefault();
     setLoadingAction("back");
@@ -82,6 +92,18 @@ const LoginMethodChooserPage = (props: Props) => {
             icon={"password"}
           >
             {t("labels.password")}
+          </Button>
+        </Form>
+        <Form
+          hidden={!flowState.actions.webauthn_generate_request_options?.(null)}
+          onSubmit={onPasskeySelectSubmit}
+        >
+          <Button
+            secondary={true}
+            uiAction={"passkey-submit"}
+            icon={"passkey"}
+          >
+            {t("labels.passkey")}
           </Button>
         </Form>
       </Content>

--- a/frontend/frontend-sdk/src/lib/flow-api/types/action.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/types/action.ts
@@ -68,6 +68,7 @@ export interface ProfileInitActions {
 export interface LoginMethodChooserActions {
   readonly continue_to_password_login?: Action<null>;
   readonly continue_to_passcode_confirmation?: Action<null>;
+  readonly webauthn_generate_request_options?: Action<null>;
   readonly back: Action<null>;
 }
 


### PR DESCRIPTION
# Description

Add a passkey option to the login method chooser when the `privacy.only_show_actual_login_methods` option is set to `true`. Also, when passkey is the only option to login for a user and the user enters his identifier, the webauthn api is triggered automatically.

# Implementation

When the user enters his identifier, it is checked which login method he can use and decided if the login method chooser is show, or when the user only has one login method if it should be triggered automatically.

# Tests

Set `privacy.only_show_actual_login_methods` to `true` in the config and create users with different login methods available and try to login with them.
