### PR TITLE
Fix login method chooser

### DIFF
--- a/backend/flow_api/flow/credential_usage/action_continue_to_passcode_confirmation.go
+++ b/backend/flow_api/flow/credential_usage/action_continue_to_passcode_confirmation.go
@@ -18,7 +18,12 @@ func (a ContinueToPasscodeConfirmation) GetDescription() string {
 	return "Send a login passcode code via email."
 }
 
-func (a ContinueToPasscodeConfirmation) Initialize(c flowpilot.InitializationContext) {}
+func (a ContinueToPasscodeConfirmation) Initialize(c flowpilot.InitializationContext) {
+	deps := a.GetDeps(c)
+	if deps.Cfg.Privacy.OnlyShowActualLoginMethods && (!c.Stash().Get(shared.StashPathUserHasEmails).Bool() || !deps.Cfg.Email.Enabled || (deps.Cfg.Email.Enabled && !deps.Cfg.Email.UseForAuthentication)) {
+		c.SuspendAction()
+	}
+}
 
 func (a ContinueToPasscodeConfirmation) Execute(c flowpilot.ExecutionContext) error {
 	if err := c.Stash().Set(shared.StashPathLoginMethod, "passcode"); err != nil {

--- a/backend/flow_api/flow/credential_usage/action_continue_to_password_login.go
+++ b/backend/flow_api/flow/credential_usage/action_continue_to_password_login.go
@@ -17,7 +17,12 @@ func (a ContinueToPasswordLogin) GetDescription() string {
 	return "Continue to the password login."
 }
 
-func (a ContinueToPasswordLogin) Initialize(c flowpilot.InitializationContext) {}
+func (a ContinueToPasswordLogin) Initialize(c flowpilot.InitializationContext) {
+	deps := a.GetDeps(c)
+	if deps.Cfg.Privacy.OnlyShowActualLoginMethods && (!c.Stash().Get(shared.StashPathUserHasPassword).Bool() || !deps.Cfg.Password.Enabled) {
+		c.SuspendAction()
+	}
+}
 
 func (a ContinueToPasswordLogin) Execute(c flowpilot.ExecutionContext) error {
 	return c.Continue(shared.StateLoginPassword)


### PR DESCRIPTION
# Description

Fix the login method chooser when `privacy.only_show_actual_login_methods` is set to `true`. When the user had no password the password option was still present, but must not. Also when `email.use_for_authentication` is set to `false`, the passcode option was still present, but must not.
