### PR TITLE
feat: allow uuids of any version as user ids

### DIFF
--- a/backend/cmd/user/format.go
+++ b/backend/cmd/user/format.go
@@ -81,7 +81,7 @@ type ImportOTPSecret struct {
 // ImportOrExportEntry represents a user to be imported/export to the Hanko database
 type ImportOrExportEntry struct {
 	// UserID optional uuid.v4. If not provided a new one will be generated for the user
-	UserID string `json:"user_id,omitempty" yaml:"user_id" validate:"omitempty,uuid4"`
+	UserID string `json:"user_id,omitempty" yaml:"user_id" validate:"omitempty,uuid"`
 	// Emails optional list of emails
 	Emails Emails `json:"emails" yaml:"emails" jsonschema:"type=array,minItems=1" validate:"required_if=Username 0,unique=Address,dive"`
 	// Username optional username of the user

--- a/backend/dto/admin/email.go
+++ b/backend/dto/admin/email.go
@@ -38,7 +38,7 @@ type EmailRequests interface {
 }
 
 type ListEmailRequestDto struct {
-	UserId string `param:"user_id" validate:"required,uuid4"`
+	UserId string `param:"user_id" validate:"required,uuid"`
 }
 
 type CreateEmailRequestDto struct {

--- a/backend/dto/admin/otp.go
+++ b/backend/dto/admin/otp.go
@@ -6,7 +6,7 @@ import (
 )
 
 type GetOTPRequestDto struct {
-	UserID string `param:"user_id" validate:"required,uuid4"`
+	UserID string `param:"user_id" validate:"required,uuid"`
 }
 
 type OTPDto struct {

--- a/backend/dto/admin/password.go
+++ b/backend/dto/admin/password.go
@@ -12,7 +12,7 @@ type PasswordCredential struct {
 }
 
 type GetPasswordCredentialRequestDto struct {
-	UserID string `param:"user_id" validate:"required,uuid4"`
+	UserID string `param:"user_id" validate:"required,uuid"`
 }
 
 type CreateOrUpdatePasswordCredentialRequestDto struct {

--- a/backend/dto/admin/session.go
+++ b/backend/dto/admin/session.go
@@ -1,7 +1,7 @@
 package admin
 
 type CreateSessionTokenDto struct {
-	UserID    string `json:"user_id" validate:"required,uuid4"`
+	UserID    string `json:"user_id" validate:"required,uuid"`
 	UserAgent string `json:"user_agent"`
 	IpAddress string `json:"ip_address" validate:"omitempty,ip"`
 }
@@ -11,7 +11,7 @@ type CreateSessionTokenResponse struct {
 }
 
 type ListSessionsRequestDto struct {
-	UserID string `param:"user_id" validate:"required,uuid4"`
+	UserID string `param:"user_id" validate:"required,uuid"`
 }
 
 type DeleteSessionRequestDto struct {

--- a/backend/dto/passcode.go
+++ b/backend/dto/passcode.go
@@ -8,7 +8,7 @@ type PasscodeFinishRequest struct {
 }
 
 type PasscodeInitRequest struct {
-	UserId  string  `json:"user_id" validate:"required,uuid4"`
+	UserId  string  `json:"user_id" validate:"required,uuid"`
 	EmailId *string `json:"email_id"`
 }
 

--- a/backend/dto/validator.go
+++ b/backend/dto/validator.go
@@ -58,6 +58,8 @@ func TransformValidationErrors(err error) []string {
 				vErrs[i] = fmt.Sprintf("%s is a required field", err.Field())
 			case "email":
 				vErrs[i] = fmt.Sprintf("%s must be a valid email address", err.Field())
+			case "uuid":
+				vErrs[i] = fmt.Sprintf("%s must be a valid uuid", err.Field())
 			case "uuid4":
 				vErrs[i] = fmt.Sprintf("%s must be a valid uuid4", err.Field())
 			case "url":

--- a/backend/handler/password.go
+++ b/backend/handler/password.go
@@ -43,7 +43,7 @@ func NewPasswordHandler(persister persistence.Persister, sessionManager session.
 }
 
 type PasswordSetBody struct {
-	UserID   string `json:"user_id" validate:"required,uuid4"`
+	UserID   string `json:"user_id" validate:"required,uuid"`
 	Password string `json:"password" validate:"required"`
 }
 
@@ -150,7 +150,7 @@ func (h *PasswordHandler) Set(c echo.Context) error {
 }
 
 type PasswordLoginBody struct {
-	UserId   string `json:"user_id" validate:"required,uuid4"`
+	UserId   string `json:"user_id" validate:"required,uuid"`
 	Password string `json:"password" validate:"required"`
 }
 

--- a/backend/handler/webauthn.go
+++ b/backend/handler/webauthn.go
@@ -232,7 +232,7 @@ func (h *WebauthnHandler) FinishRegistration(c echo.Context) error {
 }
 
 type BeginAuthenticationBody struct {
-	UserID *string `json:"user_id" validate:"uuid4"`
+	UserID *string `json:"user_id" validate:"uuid"`
 }
 
 // BeginAuthentication returns credential assertion options for the WebAuthnAPI.


### PR DESCRIPTION
# How to test
- Import users: 
    -  download [users.json](https://github.com/user-attachments/files/19732810/users.json)
    - `go run main.go import -i users.json` 
- Test all API endpoints that require a user ID whether they work with UUIDs of different versions (use the ones from the import)



