### PR TITLE
chore: add new convenience functions to the sdk

### DIFF
--- a/frontend/elements/src/example.html
+++ b/frontend/elements/src/example.html
@@ -263,14 +263,15 @@ after the user completes the authentication flow), while other events are option
 
         logoutButtonEl.addEventListener("click", () => {
             // Logout the user, triggering the `onUserLoggedOut` event upon success.
-            hanko.user.logout();
+            hanko.logout();
         });
 
-        dialogEl.addEventListener('close', () => {
+        dialogEl.addEventListener('close', async () => {
             // When the dialog, which informs the user that the session has expired, is closed, check if the session
             // has been created again, for example, in another browser window. If it has, there is no need to switch to
             // the hanko-auth component.
-            if (!hanko.session.isValid()) {
+            const { is_valid } = await hanko.validateSession();
+            if (!is_valid) {
                 showAuthComponent(true); // Show authentication component
             }
         });
@@ -287,8 +288,8 @@ after the user completes the authentication flow), while other events are option
         addEventListeners();
 
         // Check if a valid session exists
-        const session = await hanko.sessionClient.validate();
-        if (session.is_valid) {
+        const { is_valid } = await hanko.validateSession();
+        if (is_valid) {
             showAuthComponent(false); // Show profile component
             setVisibility(logoutButtonEl, true); // Show the logout button
         }

--- a/frontend/frontend-sdk/README.md
+++ b/frontend/frontend-sdk/README.md
@@ -382,6 +382,61 @@ hanko.onUserDeleted(() => {
 
 Please Take a look into the [docs](https://teamhanko.github.io/hanko/jsdoc/hanko-frontend-sdk/) for more details.
 
+### Session Management
+
+The SDK provides methods to manage user sessions and retrieve user information.
+
+#### Getting the User Object
+
+Fetches the current user's profile information.
+
+```typescript
+try {
+    const user = await hanko.getUser();
+    console.log("User profile:", user);
+} catch (error) {
+    console.error("Failed to fetch user:", error);
+    // Handle UnauthorizedError or TechnicalError
+}
+```
+
+#### Validating a Session
+
+Checks the validity of the current session.
+
+```typescript
+try {
+    const sessionStatus = await hanko.validateSession();
+    console.log("Session status:", sessionStatus);
+} catch (error) {
+    console.error("Failed to fetch session status:", error);
+    // Handle TechnicalError
+}
+```
+
+#### Getting the Session Token
+
+Retrieves the current session token from the authentication cookie.
+
+```typescript
+const token = hanko.getSessionToken();
+console.log("Session token:", token);
+```
+
+#### Logging out a User
+
+Logs out the current user by invalidating the session.
+
+```typescript
+try {
+    await hanko.logout();
+    console.log("User logged out");
+} catch (error) {
+    console.error("Failed to fetch user logout:", error);
+    // Handle TechnicalError
+}
+```
+
 ### Translation of outgoing emails
 
 If you use the main `Hanko` client provided by the Frontend SDK, you can use the `lang` parameter in the options when

--- a/frontend/frontend-sdk/src/Hanko.ts
+++ b/frontend/frontend-sdk/src/Hanko.ts
@@ -125,20 +125,7 @@ class Hanko extends Listener {
    * @throws {TechnicalError} If an unexpected error occurs
    */
   async getUser(): Promise<User> {
-    const state = await this.createState("profile", {
-      dispatchAfterStateChangeEvent: false,
-      loadFromCache: false,
-    });
-
-    if (state.name == "profile_init") {
-      return state.payload?.user;
-    }
-
-    if (state.status == 401) {
-      throw new UnauthorizedError();
-    }
-
-    throw new TechnicalError();
+    return this.user.getCurrent();
   }
 
   /**

--- a/frontend/frontend-sdk/src/lib/Dto.ts
+++ b/frontend/frontend-sdk/src/lib/Dto.ts
@@ -2,6 +2,17 @@
  * @interface
  * @category SDK
  * @subcategory DTO
+ * @property {string} id - The UUID of the current user.
+ * @ignore
+ */
+export interface Me {
+  id: string;
+}
+
+/**
+ * @interface
+ * @category SDK
+ * @subcategory DTO
  * @property {string} id - The UUID of the email address.
  * @property {string} address - The email address.
  * @property {boolean} is_verified - Indicates whether the email address is verified.

--- a/frontend/frontend-sdk/src/lib/client/UserClient.ts
+++ b/frontend/frontend-sdk/src/lib/client/UserClient.ts
@@ -1,5 +1,7 @@
-import { TechnicalError } from "../Errors";
+import { TechnicalError, UnauthorizedError } from "../Errors";
 import { Client } from "./Client";
+import { User } from "../flow-api/types/payload";
+import { Me } from "../Dto";
 
 /**
  * A class to manage user information.
@@ -9,6 +11,39 @@ import { Client } from "./Client";
  * @extends {Client}
  */
 class UserClient extends Client {
+  /**
+   * Fetches the current user.
+   *
+   * @return {Promise<User>}
+   * @throws {UnauthorizedError}
+   * @throws {RequestTimeoutError}
+   * @throws {TechnicalError}
+   * @see https://docs.hanko.io/api/public#tag/User-Management/operation/IsUserAuthorized
+   * @see https://docs.hanko.io/api/public#tag/User-Management/operation/listUser
+   */
+  async getCurrent(): Promise<User> {
+    const meResponse = await this.client.get("/me");
+
+    if (meResponse.status === 401) {
+      this.client.dispatcher.dispatchSessionExpiredEvent();
+      throw new UnauthorizedError();
+    } else if (!meResponse.ok) {
+      throw new TechnicalError();
+    }
+
+    const me: Me = meResponse.json();
+    const userResponse = await this.client.get(`/users/${me.id}`);
+
+    if (userResponse.status === 401) {
+      this.client.dispatcher.dispatchSessionExpiredEvent();
+      throw new UnauthorizedError();
+    } else if (!userResponse.ok) {
+      throw new TechnicalError();
+    }
+
+    return userResponse.json();
+  }
+
   /**
    * Logs out the current user and expires the existing session cookie. A valid session cookie is required to call the logout endpoint.
    *

--- a/frontend/frontend-sdk/src/lib/flow-api/State.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/State.ts
@@ -33,10 +33,7 @@ export interface AllOptions {
   cacheKey?: string;
 }
 
-export type Options = Pick<
-  AllOptions,
-  "dispatchAfterStateChangeEvent" | "excludeAutoSteps" | "cacheKey"
-> & {
+export type Options = Omit<AllOptions, "previousAction" | "isCached"> & {
   loadFromCache?: boolean;
 };
 
@@ -218,7 +215,7 @@ export class State<TState extends StateName = StateName> {
    * Removes the current state from localStorage.
    * @returns {void}
    */
-  public removeFromLocalStorage() {
+  public removeFromLocalStorage(): void {
     localStorage.removeItem(this.cacheKey);
   }
 

--- a/frontend/frontend-sdk/tests/lib/client/UserClient.spec.ts
+++ b/frontend/frontend-sdk/tests/lib/client/UserClient.spec.ts
@@ -10,6 +10,82 @@ beforeEach(() => {
   });
 });
 
+describe("UserClient.getCurrent()", () => {
+  const userID = "test-user-1";
+  const email = "test-email-1@test";
+  const credentials = [{ id: "test-credential-1" }];
+
+  it("should retrieve currently logged in user", async () => {
+    const responseMe = new Response(new XMLHttpRequest());
+    responseMe.ok = true;
+    responseMe._decodedJSON = {
+      id: userID,
+    };
+
+    const responseUser = new Response(new XMLHttpRequest());
+    responseUser.ok = true;
+    responseUser._decodedJSON = {
+      id: userID,
+      email,
+      webauthn_credentials: credentials,
+    };
+
+    jest
+      .spyOn(userClient.client, "get")
+      .mockResolvedValueOnce(responseMe)
+      .mockResolvedValueOnce(responseUser);
+
+    const user = userClient.getCurrent();
+    await expect(user).resolves.toBe(responseUser._decodedJSON);
+
+    expect(userClient.client.get).toHaveBeenNthCalledWith(1, "/me");
+    expect(userClient.client.get).toHaveBeenNthCalledWith(
+      2,
+      `/users/${userID}`,
+    );
+  });
+
+  it.each`
+    statusMe | statusUsers | error
+    ${400}   | ${200}      | ${"Technical error"}
+    ${401}   | ${200}      | ${"Unauthorized error"}
+    ${404}   | ${200}      | ${"Technical error"}
+    ${200}   | ${400}      | ${"Technical error"}
+    ${200}   | ${401}      | ${"Unauthorized error"}
+    ${200}   | ${404}      | ${"Technical error"}
+    ${200}   | ${500}      | ${"Technical error"}
+    ${500}   | ${200}      | ${"Technical error"}
+  `(
+    "should throw error if API returns an error status",
+    async ({ statusMe, statusUsers, error }) => {
+      const responseMe = new Response(new XMLHttpRequest());
+      responseMe.status = statusMe;
+      responseMe.ok = statusMe >= 200 && statusMe <= 299;
+
+      const responseUser = new Response(new XMLHttpRequest());
+      responseUser.status = statusUsers;
+      responseUser.ok = statusUsers >= 200 && statusUsers <= 299;
+
+      jest
+        .spyOn(userClient.client, "get")
+        .mockResolvedValueOnce(responseMe)
+        .mockResolvedValueOnce(responseUser);
+
+      const user = userClient.getCurrent();
+      await expect(user).rejects.toThrow(error);
+    },
+  );
+
+  it("should throw error on API communication failure", async () => {
+    userClient.client.get = jest
+      .fn()
+      .mockRejectedValue(new Error("Test error"));
+
+    const user = userClient.getCurrent();
+    await expect(user).rejects.toThrowError("Test error");
+  });
+});
+
 describe("UserClient.logout()", () => {
   it.each`
     status


### PR DESCRIPTION
## Description

This pull request enhances the Hanko Frontend SDK by introducing new session management functions (getUser, validateSession, getSessionToken, and logout) and updating related documentation and example code. 

## Implementation

- `Hanko.ts`: Added `getUser()`, `validateSession()`, `getSessionToken()`, `logout()` including JSDoc. 
-  Made `hanko.client`, `hanko.relay` public readonly; `hanko.session`, `hanko.user`, `hanko.cookie` private readonly.
- `README.md`: Added "Session Management" section with examples for new functions.
- `example.html`: Updated to use `hanko.validateSession()` and `hanko.logout()` instead of deprecated methods.
- `State.ts`:Simplified Options type using Omit.



