### PR TITLE
chore: rename error interface

### DIFF
--- a/frontend/elements/src/components/accordion/ListEmailsAccordion.tsx
+++ b/frontend/elements/src/components/accordion/ListEmailsAccordion.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from "preact";
 import { StateUpdater, useContext, useMemo } from "preact/compat";
+import { State, Email } from "@teamhanko/hanko-frontend-sdk";
 
 import styles from "./styles.sass";
 
@@ -9,8 +10,6 @@ import Accordion from "./Accordion";
 import Paragraph from "../paragraph/Paragraph";
 import Headline2 from "../headline/Headline2";
 import Link from "../link/Link";
-import { Email } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/types/payload";
-import { State } from "@teamhanko/hanko-frontend-sdk";
 
 interface Props {
   checkedItemID?: string;

--- a/frontend/elements/src/components/accordion/ListSessionsAccordion.tsx
+++ b/frontend/elements/src/components/accordion/ListSessionsAccordion.tsx
@@ -1,11 +1,11 @@
-import { Session } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/types/payload";
-import { State } from "@teamhanko/hanko-frontend-sdk";
 import { StateUpdater, useContext } from "preact/compat";
+import { TranslateContext } from "@denysvuika/preact-translate";
+import { State, Session } from "@teamhanko/hanko-frontend-sdk";
+
 import Accordion from "./Accordion";
 import { Fragment } from "preact";
 import Paragraph from "../paragraph/Paragraph";
 import Headline2 from "../headline/Headline2";
-import { TranslateContext } from "@denysvuika/preact-translate";
 import Link from "../link/Link";
 import styles from "./styles.sass";
 

--- a/frontend/elements/src/components/accordion/ListWebauthnCredentialsAccordion.tsx
+++ b/frontend/elements/src/components/accordion/ListWebauthnCredentialsAccordion.tsx
@@ -1,15 +1,12 @@
 import { Fragment } from "preact";
 import { StateUpdater, useContext } from "preact/compat";
-
-import { State } from "@teamhanko/hanko-frontend-sdk";
-
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State, WebauthnCredential } from "@teamhanko/hanko-frontend-sdk";
 
 import Accordion from "./Accordion";
 import Paragraph from "../paragraph/Paragraph";
 import Link from "../link/Link";
 import Headline2 from "../headline/Headline2";
-import { WebauthnCredential } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/types/payload";
 import { AppContext } from "../../contexts/AppProvider";
 import RenameWebauthnCredentialPage from "../../pages/RenameWebauthnCredentialPage";
 

--- a/frontend/elements/src/components/error/ErrorBox.tsx
+++ b/frontend/elements/src/components/error/ErrorBox.tsx
@@ -1,7 +1,5 @@
 import { TranslateContext } from "@denysvuika/preact-translate";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
-import { Error as FlowError } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/types/error";
-import { HankoError } from "@teamhanko/hanko-frontend-sdk";
+import { FlowError, HankoError, State } from "@teamhanko/hanko-frontend-sdk";
 import { useContext, useEffect } from "preact/compat";
 import { AppContext } from "../../contexts/AppProvider";
 

--- a/frontend/elements/src/components/error/ErrorMessage.tsx
+++ b/frontend/elements/src/components/error/ErrorMessage.tsx
@@ -1,7 +1,7 @@
 import styles from "./styles.sass";
 import { Fragment, useContext } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
-import { Error as FlowError } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/types/error";
+import { FlowError } from "@teamhanko/hanko-frontend-sdk";
 
 interface Props {
   flowError?: FlowError;

--- a/frontend/elements/src/components/form/Input.tsx
+++ b/frontend/elements/src/components/form/Input.tsx
@@ -1,7 +1,7 @@
 import { h } from "preact";
 import { useContext, useEffect, useMemo, useRef } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
-import { Input as FlowInput } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/types/input";
+import { Input as FlowInput } from "@teamhanko/hanko-frontend-sdk";
 import { AppContext } from "../../contexts/AppProvider";
 import cx from "classnames";
 

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -18,7 +18,7 @@ import {
   TechnicalError,
   State,
   FlowName,
-  Error as FlowError,
+  FlowError,
   LastLogin,
   StateInitConfig,
 } from "@teamhanko/hanko-frontend-sdk";

--- a/frontend/elements/src/pages/CreateEmailPage.tsx
+++ b/frontend/elements/src/pages/CreateEmailPage.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useContext, useState } from "preact/compat";
-
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
@@ -9,7 +9,6 @@ import Button from "../components/form/Button";
 import ErrorBox from "../components/error/ErrorBox";
 import Headline1 from "../components/headline/Headline1";
 
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 import Footer from "../components/wrapper/Footer";
 import Link from "../components/link/Link";

--- a/frontend/elements/src/pages/CreateOTPSecretPage.tsx
+++ b/frontend/elements/src/pages/CreateOTPSecretPage.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "preact";
 import { useCallback, useContext, useEffect, useState } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Button from "../components/form/Button";
 import Content from "../components/wrapper/Content";
@@ -12,7 +13,6 @@ import Paragraph from "../components/paragraph/Paragraph";
 import Headline1 from "../components/headline/Headline1";
 import Link from "../components/link/Link";
 import OTPCreationDetails from "../components/otp/OTPCreationDetails";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 
 interface Props {

--- a/frontend/elements/src/pages/CreatePasswordPage.tsx
+++ b/frontend/elements/src/pages/CreatePasswordPage.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useContext, useState } from "preact/compat";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import { TranslateContext } from "@denysvuika/preact-translate";
 
@@ -10,7 +11,6 @@ import ErrorBox from "../components/error/ErrorBox";
 import Paragraph from "../components/paragraph/Paragraph";
 import Headline1 from "../components/headline/Headline1";
 
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 import Footer from "../components/wrapper/Footer";
 import Link from "../components/link/Link";

--- a/frontend/elements/src/pages/CreateSecurityKeyPage.tsx
+++ b/frontend/elements/src/pages/CreateSecurityKeyPage.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "preact";
 import { useContext } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
@@ -11,7 +12,6 @@ import Paragraph from "../components/paragraph/Paragraph";
 import Headline1 from "../components/headline/Headline1";
 
 import Link from "../components/link/Link";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 
 interface Props {

--- a/frontend/elements/src/pages/CreateUsernamePage.tsx
+++ b/frontend/elements/src/pages/CreateUsernamePage.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useContext, useState } from "preact/compat";
-
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
@@ -9,7 +9,6 @@ import Button from "../components/form/Button";
 import ErrorBox from "../components/error/ErrorBox";
 import Headline1 from "../components/headline/Headline1";
 
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 import Footer from "../components/wrapper/Footer";
 import Link from "../components/link/Link";

--- a/frontend/elements/src/pages/CredentialOnboardingChooser.tsx
+++ b/frontend/elements/src/pages/CredentialOnboardingChooser.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "preact";
 import { useContext } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
@@ -9,8 +10,6 @@ import ErrorBox from "../components/error/ErrorBox";
 import Footer from "../components/wrapper/Footer";
 import Headline1 from "../components/headline/Headline1";
 import Link from "../components/link/Link";
-
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 
 import { useFlowState } from "../hooks/UseFlowState";
 import Paragraph from "../components/paragraph/Paragraph";

--- a/frontend/elements/src/pages/DeviceTrustPage.tsx
+++ b/frontend/elements/src/pages/DeviceTrustPage.tsx
@@ -1,14 +1,13 @@
 import { Fragment } from "preact";
 import { useContext } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
 import Button from "../components/form/Button";
 import ErrorBox from "../components/error/ErrorBox";
 import Headline1 from "../components/headline/Headline1";
-
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 
 import { useFlowState } from "../hooks/UseFlowState";
 import Paragraph from "../components/paragraph/Paragraph";

--- a/frontend/elements/src/pages/EditPasswordPage.tsx
+++ b/frontend/elements/src/pages/EditPasswordPage.tsx
@@ -1,4 +1,5 @@
 import { useContext, useState } from "preact/compat";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import { TranslateContext } from "@denysvuika/preact-translate";
 
@@ -10,7 +11,6 @@ import ErrorBox from "../components/error/ErrorBox";
 import Paragraph from "../components/paragraph/Paragraph";
 import Headline1 from "../components/headline/Headline1";
 
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 
 type Props = {

--- a/frontend/elements/src/pages/ErrorPage.tsx
+++ b/frontend/elements/src/pages/ErrorPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useContext, useEffect, useState } from "preact/compat";
+import { State, HankoError } from "@teamhanko/hanko-frontend-sdk";
 
 import { TranslateContext } from "@denysvuika/preact-translate";
 import { AppContext } from "../contexts/AppProvider";
@@ -8,8 +9,6 @@ import Button from "../components/form/Button";
 import Content from "../components/wrapper/Content";
 import Headline1 from "../components/headline/Headline1";
 import ErrorBox from "../components/error/ErrorBox";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
-import { HankoError } from "@teamhanko/hanko-frontend-sdk";
 import { useFlowState } from "../hooks/UseFlowState";
 
 interface Props {

--- a/frontend/elements/src/pages/LoginInitPage.tsx
+++ b/frontend/elements/src/pages/LoginInitPage.tsx
@@ -5,9 +5,11 @@ import {
   useMemo,
   useState,
 } from "preact/compat";
-
-import { HankoError, WebauthnSupport } from "@teamhanko/hanko-frontend-sdk";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
+import {
+  State,
+  HankoError,
+  WebauthnSupport,
+} from "@teamhanko/hanko-frontend-sdk";
 
 import { AppContext } from "../contexts/AppProvider";
 import { TranslateContext } from "@denysvuika/preact-translate";

--- a/frontend/elements/src/pages/LoginMethodChooser.tsx
+++ b/frontend/elements/src/pages/LoginMethodChooser.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "preact";
 import { useContext } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
@@ -9,8 +10,6 @@ import ErrorBox from "../components/error/ErrorBox";
 import Footer from "../components/wrapper/Footer";
 import Headline1 from "../components/headline/Headline1";
 import Link from "../components/link/Link";
-
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 
 import { useFlowState } from "../hooks/UseFlowState";
 import Paragraph from "../components/paragraph/Paragraph";

--- a/frontend/elements/src/pages/LoginOTPPage.tsx
+++ b/frontend/elements/src/pages/LoginOTPPage.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "preact";
 import { useCallback, useContext, useEffect, useState } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Button from "../components/form/Button";
 import Content from "../components/wrapper/Content";
@@ -10,7 +11,6 @@ import CodeInput from "../components/form/CodeInput";
 import ErrorBox from "../components/error/ErrorBox";
 import Paragraph from "../components/paragraph/Paragraph";
 import Headline1 from "../components/headline/Headline1";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 import Link from "../components/link/Link";
 

--- a/frontend/elements/src/pages/LoginPasswordPage.tsx
+++ b/frontend/elements/src/pages/LoginPasswordPage.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from "preact";
 import { useContext, useEffect, useMemo, useState } from "preact/compat";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import { TranslateContext } from "@denysvuika/preact-translate";
 
@@ -11,7 +12,6 @@ import Button from "../components/form/Button";
 import ErrorBox from "../components/error/ErrorBox";
 import Link from "../components/link/Link";
 import Headline1 from "../components/headline/Headline1";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 
 type Props = {

--- a/frontend/elements/src/pages/LoginSecurityKeyPage.tsx
+++ b/frontend/elements/src/pages/LoginSecurityKeyPage.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "preact";
 import { useContext } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
@@ -11,7 +12,6 @@ import Paragraph from "../components/paragraph/Paragraph";
 import Headline1 from "../components/headline/Headline1";
 
 import Link from "../components/link/Link";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 
 interface Props {

--- a/frontend/elements/src/pages/MFAMethodChooserPage.tsx
+++ b/frontend/elements/src/pages/MFAMethodChooserPage.tsx
@@ -1,14 +1,13 @@
 import { Fragment } from "preact";
 import { useContext, useMemo } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
 import Button from "../components/form/Button";
 import ErrorBox from "../components/error/ErrorBox";
 import Headline1 from "../components/headline/Headline1";
-
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 
 import { useFlowState } from "../hooks/UseFlowState";
 import Paragraph from "../components/paragraph/Paragraph";

--- a/frontend/elements/src/pages/PasscodePage.tsx
+++ b/frontend/elements/src/pages/PasscodePage.tsx
@@ -6,6 +6,8 @@ import {
   useMemo,
   useState,
 } from "preact/compat";
+import { State } from "@teamhanko/hanko-frontend-sdk";
+
 import { AppContext } from "../contexts/AppProvider";
 import { TranslateContext } from "@denysvuika/preact-translate";
 
@@ -18,7 +20,6 @@ import ErrorBox from "../components/error/ErrorBox";
 import Paragraph from "../components/paragraph/Paragraph";
 import Headline1 from "../components/headline/Headline1";
 import Link from "../components/link/Link";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 
 interface Props {

--- a/frontend/elements/src/pages/ProfilePage.tsx
+++ b/frontend/elements/src/pages/ProfilePage.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "preact";
 import { useContext, useState } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import { useFlowState } from "../hooks/UseFlowState";
 import { AppContext } from "../contexts/AppProvider";

--- a/frontend/elements/src/pages/RegisterPasskeyPage.tsx
+++ b/frontend/elements/src/pages/RegisterPasskeyPage.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "preact";
 import { useContext } from "preact/compat";
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
@@ -11,7 +12,6 @@ import Paragraph from "../components/paragraph/Paragraph";
 import Headline1 from "../components/headline/Headline1";
 
 import Link from "../components/link/Link";
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
 import { useFlowState } from "../hooks/UseFlowState";
 
 interface Props {

--- a/frontend/elements/src/pages/RegistrationInitPage.tsx
+++ b/frontend/elements/src/pages/RegistrationInitPage.tsx
@@ -1,10 +1,9 @@
 import { Fragment } from "preact";
-import { useContext, useEffect, useMemo, useState } from "preact/compat";
-
-import { State } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/State";
+import { useContext, useMemo, useState } from "preact/compat";
+import { TranslateContext } from "@denysvuika/preact-translate";
+import { State } from "@teamhanko/hanko-frontend-sdk";
 
 import { AppContext } from "../contexts/AppProvider";
-import { TranslateContext } from "@denysvuika/preact-translate";
 import { useFlowState } from "../hooks/UseFlowState";
 
 import Content from "../components/wrapper/Content";

--- a/frontend/elements/src/pages/RenameWebauthnCredentialPage.tsx
+++ b/frontend/elements/src/pages/RenameWebauthnCredentialPage.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "preact";
 import { useContext, useState } from "preact/compat";
-
 import { TranslateContext } from "@denysvuika/preact-translate";
+import { State, WebauthnCredential } from "@teamhanko/hanko-frontend-sdk";
 
 import Content from "../components/wrapper/Content";
 import Form from "../components/form/Form";
@@ -12,8 +12,6 @@ import Paragraph from "../components/paragraph/Paragraph";
 import Headline1 from "../components/headline/Headline1";
 import Footer from "../components/wrapper/Footer";
 import Link from "../components/link/Link";
-import { WebauthnCredential } from "@teamhanko/hanko-frontend-sdk/dist/lib/flow-api/types/payload";
-import { State } from "@teamhanko/hanko-frontend-sdk";
 
 type Props = {
   oldName: string;

--- a/frontend/frontend-sdk/src/index.ts
+++ b/frontend/frontend-sdk/src/index.ts
@@ -107,7 +107,7 @@ export type { CookieSameSite };
 // Flow
 export * from "./lib/flow-api/State";
 export * from "./lib/flow-api/types/flow";
-export * from "./lib/flow-api/types/error";
+export * from "./lib/flow-api/types/flowError";
 export * from "./lib/flow-api/types/payload";
 export * from "./lib/flow-api/types/state";
 export * from "./lib/flow-api/types/input";

--- a/frontend/frontend-sdk/src/lib/flow-api/State.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/State.ts
@@ -1,7 +1,7 @@
 import { Hanko } from "../../Hanko";
 import { Actions, Payloads, StateName } from "./types/state";
 import { Input } from "./types/input";
-import { Error } from "./types/error";
+import { FlowError } from "./types/flowError";
 import { Action as ActionType } from "./types/action";
 import { AnyState, FlowName, FlowResponse } from "./types/flow";
 import { autoSteps } from "./auto-steps";
@@ -69,7 +69,7 @@ type ExtractInputValues<TInputs> = {
 export class State<TState extends StateName = StateName> {
   public readonly name: TState;
   public readonly flowName: FlowName;
-  public error?: Error;
+  public error?: FlowError;
   public readonly payload?: Payloads[TState];
   public readonly actions: ActionMap<TState>;
   public readonly csrfToken: string;
@@ -368,11 +368,11 @@ export class State<TState extends StateName = StateName> {
 
   /**
    * Creates an error flow response.
-   * @param {Error} error - The error to include in the response.
+   * @param {FlowError} error - The error to include in the response.
    * @returns {FlowResponse<"error">} A flow response with error details.
    * @private
    */
-  private static createErrorResponse(error: Error): FlowResponse<"error"> {
+  private static createErrorResponse(error: FlowError): FlowResponse<"error"> {
     return {
       actions: null,
       csrf_token: "",
@@ -447,7 +447,7 @@ export class Action<TInputs> {
    * @param {ActionRunConfig} [config={}] - Configuration options.
    * @param {boolean} [config.dispatchAfterStateChangeEvent=true] - Whether to dispatch an event after state change.
    * @returns {Promise<AnyState>} A promise resolving to the next state.
-   * @throws {Error} If the action is disabled or already invoked.
+   * @throws {FlowError} If the action is disabled or already invoked.
    */
   async run(
     inputValues: ExtractInputValues<TInputs> = null,

--- a/frontend/frontend-sdk/src/lib/flow-api/types/flow.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/types/flow.ts
@@ -1,5 +1,5 @@
 import { StateName, Actions, Payloads } from "./state";
-import { Error } from "./error";
+import { FlowError } from "./flowError";
 import { State } from "../State";
 
 type PickStates<TState extends StateName> = TState;
@@ -40,5 +40,5 @@ export interface FlowResponse<TState extends StateName> {
   payload?: Payloads[TState];
   actions?: Actions[TState];
   csrf_token: string;
-  error?: Error;
+  error?: FlowError;
 }

--- a/frontend/frontend-sdk/src/lib/flow-api/types/flowError.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/types/flowError.ts
@@ -1,7 +1,5 @@
-interface Error {
+export interface FlowError {
   code: string;
   message: string;
   cause?: string;
 }
-
-export type { Error };

--- a/frontend/frontend-sdk/src/lib/flow-api/types/input.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/types/input.ts
@@ -1,4 +1,4 @@
-import { Error } from "./error";
+import { FlowError } from "./flowError";
 import {
   PublicKeyCredentialWithAssertionJSON,
   PublicKeyCredentialWithAttestationJSON,
@@ -12,7 +12,7 @@ export interface Input<TValue> {
   readonly max_length?: number;
   readonly required?: boolean;
   readonly hidden?: boolean;
-  readonly error?: Error;
+  readonly error?: FlowError;
   readonly allowed_values?: AllowedInputValues[];
 }
 

--- a/frontend/frontend-sdk/tests/lib/events/Dispatcher.spec.ts
+++ b/frontend/frontend-sdk/tests/lib/events/Dispatcher.spec.ts
@@ -1,5 +1,5 @@
 import { Dispatcher } from "../../../src/lib/events/Dispatcher";
-import { CustomEventWithDetail, Email, SessionDetail } from "../../../src";
+import { CustomEventWithDetail, SessionDetail } from "../../../src";
 
 describe("Dispatcher", () => {
   let dispatcher: Dispatcher;


### PR DESCRIPTION
# Description

When I try to compile the SDK via Parcel, the following error occurs: 

```bash
@parcel/core: hanko/frontend/frontend-sdk/src/lib/flow-api/types/error.ts does not export 'Error'

hanko/frontend/frontend-sdk/src/lib/flow-api/State.ts:4:10
    3 | import { Input } from "./types/input";
  > 4 | import { Error } from "./types/error";
```

# Implementation

- Renamed the error interface to `FlowError`
- Correct SDK import paths in `hanko-elements``
- Removed an unused import