### PR TITLE
fix: no input error on invalid passkey

### DIFF
--- a/backend/flow_api/flow/credential_usage/action_verify_passcode.go
+++ b/backend/flow_api/flow/credential_usage/action_verify_passcode.go
@@ -60,7 +60,8 @@ func (a VerifyPasscode) Execute(c flowpilot.ExecutionContext) error {
 				}
 			}
 
-			return c.Error(shared.ErrorPasscodeInvalid)
+			c.Input().SetError("code", shared.ErrorPasscodeInvalid)
+			return c.Error(flowpilot.ErrorFormDataInvalid)
 		}
 
 		if errors.Is(err, services.ErrorPasscodeMaxAttemptsReached) {

--- a/backend/flow_api/flow/mfa_creation/action_otp_code_verify.go
+++ b/backend/flow_api/flow/mfa_creation/action_otp_code_verify.go
@@ -39,7 +39,8 @@ func (a OTPCodeVerify) Execute(c flowpilot.ExecutionContext) error {
 	secret := c.Stash().Get(shared.StashPathOTPSecret).String()
 
 	if !totp.Validate(code, secret) {
-		return c.Error(shared.ErrorPasscodeInvalid)
+		c.Input().SetError("otp_code", shared.ErrorPasscodeInvalid)
+		return c.Error(flowpilot.ErrorFormDataInvalid)
 	}
 
 	_ = c.Stash().Set(shared.StashPathUserHasOTPSecret, true)

--- a/backend/flow_api/flow/mfa_usage/action_otp_code_validate.go
+++ b/backend/flow_api/flow/mfa_usage/action_otp_code_validate.go
@@ -63,7 +63,8 @@ func (a OTPCodeValidate) Execute(c flowpilot.ExecutionContext) error {
 	code := c.Input().Get("otp_code").String()
 
 	if !totp.Validate(code, userModel.OTPSecret.Secret) {
-		return c.Error(shared.ErrorPasscodeInvalid)
+		c.Input().SetError("otp_code", shared.ErrorPasscodeInvalid)
+		return c.Error(flowpilot.ErrorFormDataInvalid)
 	}
 
 	err = c.Stash().Set(shared.StashPathMFAUsageMethod, "totp")

--- a/backend/flow_api/flow/shared/errors.go
+++ b/backend/flow_api/flow/shared/errors.go
@@ -7,7 +7,6 @@ import (
 
 var (
 	ErrorNotFound                         = flowpilot.NewFlowError("not_found", "The requested resource was not found.", http.StatusNotFound)
-	ErrorPasscodeInvalid                  = flowpilot.NewFlowError("passcode_invalid", "The passcode is invalid.", http.StatusBadRequest)
 	ErrorPasscodeMaxAttemptsReached       = flowpilot.NewFlowError("passcode_max_attempts_reached", "The passcode was entered wrong too many times.", http.StatusUnauthorized)
 	ErrorPasskeyInvalid                   = flowpilot.NewFlowError("passkey_invalid", "The passkey is invalid.", http.StatusUnauthorized)
 	ErrorRateLimitExceeded                = flowpilot.NewFlowError("rate_limit_exceeded", "The rate limit has been exceeded.", http.StatusTooManyRequests)
@@ -22,4 +21,5 @@ var (
 	ErrorUnknownUsername       = flowpilot.NewInputError("unknown_username_error", "The username is unknown.")
 	ErrorUnknownEmail          = flowpilot.NewInputError("unknown_email_error", "The email address is unknown.")
 	ErrorInvalidUsername       = flowpilot.NewInputError("invalid_username_error", "The username is invalid.")
+	ErrorPasscodeInvalid       = flowpilot.NewInputError("passcode_invalid", "The passcode is invalid.")
 )

--- a/frontend/elements/src/pages/LoginOTPPage.tsx
+++ b/frontend/elements/src/pages/LoginOTPPage.tsx
@@ -45,7 +45,7 @@ const LoginOTPPAge = (props: Props) => {
   };
 
   useEffect(() => {
-    if (flowState.error?.code === "passcode_invalid") setPasscodeDigits([]);
+    setPasscodeDigits([]);
   }, [flowState]);
 
   return (

--- a/frontend/elements/src/pages/PasscodePage.tsx
+++ b/frontend/elements/src/pages/PasscodePage.tsx
@@ -62,8 +62,6 @@ const PasscodePage = (props: Props) => {
     return submitPasscode(passcodeDigits.join(""));
   };
 
-
-
   useEffect(() => {
     const timer = ttl > 0 && setInterval(() => setTtl(ttl - 1), 1000);
     return () => clearInterval(timer);
@@ -85,7 +83,7 @@ const PasscodePage = (props: Props) => {
   }, [resendAfter]);
 
   useEffect(() => {
-    if (flowState.error?.code === "passcode_invalid") setPasscodeDigits([]);
+    setPasscodeDigits([]);
     if (flowState.payload.resend_after >= 0) {
       setResendAfter(flowState.payload.resend_after);
     }


### PR DESCRIPTION
# Description

Fixes the behavior where inputs for code fields (Passcode and OTP pages) do not have field-specific errors attached in the flow response.


# Implementation

- API: The `ErrorPasscodeInvalid` error only occurs on input fields
- API: The top-level error is `ErrorFormDataInvalid` when a wrong Passcode or OTP code was entered.
- Elements: Clear code inputs after each action.
