### PR TITLE
chore: remove unused attribute for experimental features

### DIFF
--- a/frontend/elements/README.md
+++ b/frontend/elements/README.md
@@ -24,8 +24,6 @@ that provides the underlying functionalities.
   - [Adding New Translations](#adding-new-translations)
   - [Using External Files](#using-external-files)
   - [Fallback Language](#fallback-language)
-- [Experimental Features](#experimental-features)
-  - [Conditional Mediation / Autofill assisted Requests](#conditional-mediation--autofill-assisted-requests)
 - [Live Demo](#live-demo)
 - [Examples](#examples)
 - [Frontend framework integrations](#frontend-framework-integrations)
@@ -190,8 +188,6 @@ Dedicated UI for the registration:
 - `prefilled-email` Used to prefill the email input field.
 - `prefilled-username` Used to prefill the username input field.
 - `lang` Used to specify the language of the content within the element. See [Translations](#translations).
-- `experimental` A space-separated list of experimental features to be enabled.
-  See [experimental features](#experimental-features).
 
 #### &lt;hanko-profile&gt;
 
@@ -639,23 +635,6 @@ If you use Hanko Elements the language supplied to the `lang` attribute of any o
 to the Hanko API the language to use for outgoing emails. If you have disabled email delivery through Hanko and
 configured a webhook for the `email.send` event, the value for the `lang` attribute is reflected in the JWT payload of
 the token contained in the webhook request in the `language` claim.
-
-## Experimental Features
-
-### Conditional Mediation / Autofill assisted Requests
-
-```html
-<hanko-auth [...] experimental="conditionalMediation" />
-```
-
-If the browser supports autofill assisted requests, it will hide the "Sign in with passkey" button on the login page and
-instead present the available passkeys via the email input's autocompletion menu. Enabling this feature will currently
-cause the following issues:
-
-- On iOS 16/Safari you may encounter an issue that WebAuthn credential registration is not working the first time you
-  press the button or only after reloading the page.
-
-- Microsoft Edge v. 108 sometimes crashes or is not able to display the credential name properly.
 
 ## Live Demo
 

--- a/frontend/elements/src/Elements.tsx
+++ b/frontend/elements/src/Elements.tsx
@@ -9,7 +9,6 @@ import { defaultTranslations, Translations } from "./i18n/translations";
 import { SessionTokenLocation } from "@teamhanko/hanko-frontend-sdk/dist/lib/client/HttpClient";
 
 export interface HankoAuthAdditionalProps {
-  experimental?: string;
   prefilledEmail?: string;
   prefilledUsername?: string;
 }
@@ -123,7 +122,6 @@ export const register = async (
   const observedAttributes = [
     "api",
     "lang",
-    "experimental",
     "prefilled-email",
     "entry",
   ];

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -49,9 +49,6 @@ import DeviceTrustPage from "../pages/DeviceTrustPage";
 
 import SignalLike = JSXInternal.SignalLike;
 
-type ExperimentalFeature = "conditionalMediation";
-type ExperimentalFeatures = ExperimentalFeature[];
-
 export type ComponentName =
   | "auth"
   | "login"
@@ -85,7 +82,6 @@ interface Context {
   init: (compName: ComponentName) => void;
   componentName: ComponentName;
   setComponentName: StateUpdater<ComponentName>;
-  experimentalFeatures?: ExperimentalFeatures;
   lang: string;
   hidePasskeyButtonOnLogin: boolean;
   prefilledEmail?: string;
@@ -101,7 +97,6 @@ export const AppContext = createContext<Context>(null);
 
 interface Props {
   lang?: string | SignalLike<string>;
-  experimental?: string;
   prefilledEmail?: string;
   prefilledUsername?: string;
   componentName: ComponentName;
@@ -112,7 +107,6 @@ interface Props {
 
 const AppProvider = ({
   lang,
-  experimental = "",
   prefilledEmail,
   prefilledUsername,
   globalOptions,
@@ -155,15 +149,6 @@ const AppProvider = ({
       events: null,
     }),
     [authComponentFlow],
-  );
-
-  const experimentalFeatures = useMemo(
-    () =>
-      experimental
-        .split(" ")
-        .filter((feature) => feature.length)
-        .map((feature) => feature as ExperimentalFeature),
-    [experimental],
   );
 
   const initComponent = useMemo(() => <InitPage />, []);
@@ -396,7 +381,6 @@ const AppProvider = ({
         prefilledUsername,
         componentName,
         setComponentName,
-        experimentalFeatures,
         hidePasskeyButtonOnLogin,
         page,
         setPage,


### PR DESCRIPTION
# Description

Removes the observable attribute `experimentalFeatures`  from `hanko-elements`, that is unused, since "autofill assisted requests" are always enabled.

