### PR TITLE
feat: add 'mode' attribute to hanko-auth

### DIFF
--- a/frontend/elements/README.md
+++ b/frontend/elements/README.md
@@ -188,6 +188,7 @@ Dedicated UI for the registration:
 - `prefilled-email` Used to prefill the email input field.
 - `prefilled-username` Used to prefill the username input field.
 - `lang` Used to specify the language of the content within the element. See [Translations](#translations).
+- `mode` Accepts either "login" or "registration" to initialize the `<hanko-auth>` component with a login or registration flow, respectively.
 
 #### &lt;hanko-profile&gt;
 

--- a/frontend/elements/src/Elements.tsx
+++ b/frontend/elements/src/Elements.tsx
@@ -3,6 +3,7 @@ import registerCustomElement from "@teamhanko/preact-custom-element";
 import AppProvider, {
   ComponentName,
   GlobalOptions,
+  HankoAuthMode,
 } from "./contexts/AppProvider";
 import { CookieSameSite, Hanko } from "@teamhanko/hanko-frontend-sdk";
 import { defaultTranslations, Translations } from "./i18n/translations";
@@ -11,6 +12,7 @@ import { SessionTokenLocation } from "@teamhanko/hanko-frontend-sdk/dist/lib/cli
 export interface HankoAuthAdditionalProps {
   prefilledEmail?: string;
   prefilledUsername?: string;
+  mode?: HankoAuthMode;
 }
 
 export declare interface HankoAuthElementProps
@@ -124,6 +126,7 @@ export const register = async (
     "lang",
     "prefilled-email",
     "entry",
+    "mode",
   ];
 
   options = {

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -56,6 +56,8 @@ export type ComponentName =
   | "profile"
   | "events";
 
+export type HankoAuthMode = "registration" | "login";
+
 export interface GlobalOptions {
   hanko?: Hanko;
   injectStyles?: boolean;
@@ -99,6 +101,7 @@ interface Props {
   lang?: string | SignalLike<string>;
   prefilledEmail?: string;
   prefilledUsername?: string;
+  mode?: HankoAuthMode;
   componentName: ComponentName;
   globalOptions: GlobalOptions;
   children?: ComponentChildren;
@@ -138,7 +141,9 @@ const AppProvider = ({
     props.componentName,
   );
 
-  const [authComponentFlow, setAuthComponentFlow] = useState<FlowName>("login");
+  const [authComponentFlow, setAuthComponentFlow] = useState<FlowName>(
+    props.mode ?? "login",
+  );
 
   const componentFlowNameMap = useMemo<Record<ComponentName, FlowName>>(
     () => ({


### PR DESCRIPTION
# Description

This PR adds a mode attribute to `<hanko-auth>`, allowing to specify whether the component initializes the "login" or "registration" flow. 

