### PR TITLE
fix: add missing validation to the pw recovery action

### DIFF
--- a/backend/flow_api/flow/credential_usage/action_password_recovery.go
+++ b/backend/flow_api/flow/credential_usage/action_password_recovery.go
@@ -30,7 +30,8 @@ func (a PasswordRecovery) Initialize(c flowpilot.InitializationContext) {
 
 	c.AddInputs(flowpilot.PasswordInput("new_password").
 		Required(true).
-		MinLength(deps.Cfg.Password.MinLength),
+		MinLength(deps.Cfg.Password.MinLength).
+		MaxLength(72),
 	)
 
 	if !deps.Cfg.Password.Enabled {
@@ -40,6 +41,10 @@ func (a PasswordRecovery) Initialize(c flowpilot.InitializationContext) {
 
 func (a PasswordRecovery) Execute(c flowpilot.ExecutionContext) error {
 	deps := a.GetDeps(c)
+
+	if valid := c.ValidateInputData(); !valid {
+		return c.Error(flowpilot.ErrorFormDataInvalid)
+	}
 
 	newPassword := c.Input().Get("new_password").String()
 


### PR DESCRIPTION
# Description

Adds missing validation to the recovery action, so that the API returns an appropriate error.