### PR TITLE
fix: use correct broadcast channel name

### DIFF
--- a/frontend/frontend-sdk/src/lib/events/Relay.ts
+++ b/frontend/frontend-sdk/src/lib/events/Relay.ts
@@ -228,7 +228,7 @@ export class Relay extends Dispatcher {
     sessionTokenLocation: SessionTokenLocation,
     sessionCheckChannelName?: string,
   ): string | undefined {
-    if (sessionTokenLocation == "cookie") {
+    if (sessionTokenLocation !== "sessionStorage") {
       return sessionCheckChannelName;
     }
     let channelName = sessionStorage.getItem("sessionCheckChannelName");


### PR DESCRIPTION
# Description

Cross tab communication was not working due to wrong broadcast channel name.


