### PR TITLE
fix: oauth third party authentication with case insensitive email

### DIFF
--- a/backend/config/config_webauthn.go
+++ b/backend/config/config_webauthn.go
@@ -2,11 +2,12 @@ package config
 
 import (
 	"fmt"
-	"github.com/go-webauthn/webauthn/protocol"
-	webauthnLib "github.com/go-webauthn/webauthn/webauthn"
-	"golang.org/x/exp/slices"
+	"slices"
 	"strings"
 	"time"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	webauthnLib "github.com/go-webauthn/webauthn/webauthn"
 )
 
 // WebauthnSettings defines the settings for the webauthn authentication mechanism

--- a/backend/flow_api/flow/shared/action_thirdparty_oauth.go
+++ b/backend/flow_api/flow/shared/action_thirdparty_oauth.go
@@ -1,14 +1,16 @@
 package shared
 
 import (
+	"cmp"
 	"fmt"
+	"net/http"
+	"slices"
+
 	"github.com/teamhanko/hanko/backend/config"
 	"github.com/teamhanko/hanko/backend/flowpilot"
 	"github.com/teamhanko/hanko/backend/thirdparty"
 	"github.com/teamhanko/hanko/backend/utils"
-	"golang.org/x/exp/slices"
 	"golang.org/x/oauth2"
-	"net/http"
 )
 
 type ThirdPartyOAuth struct {
@@ -41,9 +43,8 @@ func (a ThirdPartyOAuth) Initialize(c flowpilot.InitializationContext) {
 	for _, provider := range enabledThirdPartyProviders {
 		providerInput.AllowedValue(provider.DisplayName, provider.ID)
 	}
-
-	slices.SortFunc(enabledCustomThirdPartyProviders, func(a, b config.CustomThirdPartyProvider) bool {
-		return a.DisplayName < b.DisplayName
+	slices.SortFunc(enabledCustomThirdPartyProviders, func(a, b config.CustomThirdPartyProvider) int {
+		return cmp.Compare(a.DisplayName, b.DisplayName)
 	})
 
 	for _, provider := range enabledCustomThirdPartyProviders {
@@ -84,11 +85,11 @@ func (a ThirdPartyOAuth) Execute(c flowpilot.ExecutionContext) error {
 
 	authCodeUrl := provider.AuthCodeURL(string(state), oauth2.SetAuthURLParam("prompt", "consent"))
 
-	//cookie := utils.GenerateStateCookie(&deps.Cfg, utils.HankoThirdpartyStateCookie, string(state), utils.CookieOptions{
+	// cookie := utils.GenerateStateCookie(&deps.Cfg, utils.HankoThirdpartyStateCookie, string(state), utils.CookieOptions{
 	//	MaxAge:   300,
 	//	Path:     "/",
 	//	SameSite: http.SameSiteLaxMode,
-	//})
+	// })
 
 	cookie := &http.Cookie{
 		Name:     utils.HankoThirdpartyStateCookie,

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/tidwall/sjson v1.2.5
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	golang.org/x/crypto v0.36.0
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/oauth2 v0.28.0
 	golang.org/x/text v0.23.0
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -504,8 +504,6 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=

--- a/backend/handler/user_test.go
+++ b/backend/handler/user_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/teamhanko/hanko/backend/dto"
 	"github.com/teamhanko/hanko/backend/persistence/models"
 	"github.com/teamhanko/hanko/backend/test"
-	"golang.org/x/exp/slices"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 )

--- a/backend/persistence/models/email.go
+++ b/backend/persistence/models/email.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
-	"golang.org/x/exp/slices"
+	"slices"
 	"time"
 )
 

--- a/backend/persistence/models/user.go
+++ b/backend/persistence/models/user.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // User is used by pop to map your users database table to your go code.

--- a/backend/thirdparty/linking.go
+++ b/backend/thirdparty/linking.go
@@ -2,14 +2,15 @@ package thirdparty
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 	"github.com/teamhanko/hanko/backend/config"
 	"github.com/teamhanko/hanko/backend/persistence"
 	"github.com/teamhanko/hanko/backend/persistence/models"
 	"github.com/teamhanko/hanko/backend/webhooks/events"
-	"strings"
-	"time"
 )
 
 type AccountLinkingResult struct {
@@ -25,6 +26,14 @@ func LinkAccount(tx *pop.Connection, cfg *config.Config, p persistence.Persister
 			return nil, ErrorUnverifiedProviderEmail("third party provider email must be verified")
 		}
 	}
+
+	// Validate userData
+	if userData == nil {
+		return nil, ErrorInvalidRequest("user data must be set")
+	}
+
+	// Ensure the email is lowercase to avoid case sensitivity issues
+	userData.Metadata.Email = strings.ToLower(userData.Metadata.Email)
 
 	identity, err := p.GetIdentityPersister().Get(userData.Metadata.Subject, providerID)
 	if err != nil {


### PR DESCRIPTION
# Description

Implement a case insensitive account linking functionality for third-party authentication.

Fixes #2193

# Implementation

Lowercase payload of userData.Metadata.Email
Refactored `golang.org/x/exp/slices` to use `slices` instead.

# Tests

Register with any email. Try your Microsoft account for login, which might have an uppercase email configured and it should link the account correctly.

# Todos

Maybe prepare a migration for persisted emails which are not yet lowercased.
