### PR TITLE
feat: support nonce for styles

### DIFF
--- a/frontend/elements/src/Elements.tsx
+++ b/frontend/elements/src/Elements.tsx
@@ -84,17 +84,24 @@ const globalOptions: GlobalOptions = {};
 const createHankoComponent = (
   componentName: ComponentName,
   props: Record<string, any>,
-) => (
-  <AppProvider
-    componentName={componentName}
-    globalOptions={globalOptions}
-    createWebauthnAbortSignal={createWebauthnAbortSignal}
-    {...props}
-  />
-);
+) => {
+  props.nonce = document.getElementsByTagName(
+    `hanko-${componentName}`,
+    // @ts-ignore
+  )[0].nonce;
+  return (
+    <AppProvider
+      componentName={componentName}
+      globalOptions={globalOptions}
+      createWebauthnAbortSignal={createWebauthnAbortSignal}
+      {...props}
+    />
+  );
+};
 
-const HankoAuth = (props: HankoAuthElementProps) =>
-  createHankoComponent("auth", props);
+const HankoAuth = (props: HankoAuthElementProps) => {
+  return createHankoComponent("auth", props);
+};
 
 const HankoLogin = (props: HankoAuthElementProps) =>
   createHankoComponent("login", props);

--- a/frontend/elements/src/Elements.tsx
+++ b/frontend/elements/src/Elements.tsx
@@ -85,10 +85,10 @@ const createHankoComponent = (
   componentName: ComponentName,
   props: Record<string, any>,
 ) => {
-  props.nonce = document.getElementsByTagName(
-    `hanko-${componentName}`,
+  props.nonce = document
+    .getElementsByTagName(`hanko-${componentName}`)
     // @ts-ignore
-  )[0].nonce;
+    .item(0)?.nonce;
   return (
     <AppProvider
       componentName={componentName}

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -102,6 +102,7 @@ interface Props {
   prefilledEmail?: string;
   prefilledUsername?: string;
   mode?: HankoAuthMode;
+  nonce?: string;
   componentName: ComponentName;
   globalOptions: GlobalOptions;
   children?: ComponentChildren;
@@ -114,6 +115,7 @@ const AppProvider = ({
   prefilledUsername,
   globalOptions,
   createWebauthnAbortSignal,
+  nonce,
   ...props
 }: Props) => {
   const {
@@ -403,6 +405,7 @@ const AppProvider = ({
             <Fragment>
               {injectStyles ? (
                 <style
+                  nonce={nonce}
                   /* eslint-disable-next-line react/no-danger */
                   dangerouslySetInnerHTML={{
                     __html: window._hankoStyle.innerHTML,


### PR DESCRIPTION
# Description

This PR adds support for the nonce property to allow a more stricter content-security-policy (no need for `unsafe-inline`) when using Hanko. 

Fixes #1983 

# Implementation

The components forward the nonce property from one of the elements (`hanko-auth`, `hanko-login`, `hanko-registration`) to the inline style tag. 

Unfortunately the nonce property is hidden for security reasons ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/nonce)) and can only be accessed through the IDL property (`script['nonce']`). That means that it cannot be accessed through props, e.g. we do with the `lang` property, but has to be done through `document.getElementsByTagName()[0].nonce`. This approach has one disadvantage, when using more than one of the same element on the same page, and both have different nonce values only one value will be used, but that should not break the elements.

# Tests

1. Add a CSP which disallows `unsafe-inline` for styles.
2. Add a nonce to the CSP for `style-src`.
3. Add the nonce to the hanko components (`hanko-auth`, ...)

The inline styles should be applied.

[src.zip](https://github.com/user-attachments/files/21363008/src.zip) contains changed files from the quickstart which can be used to test it.

# Todos

- Add a guide to the docs.
