### PR TITLE
fix user deletion when using mysql as DBMS

### DIFF
--- a/backend/handler/user_admin.go
+++ b/backend/handler/user_admin.go
@@ -46,7 +46,9 @@ func (h *UserHandlerAdmin) Delete(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "user not found")
 	}
 
-	err = p.Delete(*user)
+	err = h.persister.Transaction(func(tx *pop.Connection) error {
+		return p.Delete(*user)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to delete user: %w", err)
 	}

--- a/backend/persistence/user_persister.go
+++ b/backend/persistence/user_persister.go
@@ -125,7 +125,18 @@ func (p *userPersister) Update(user models.User) error {
 	return nil
 }
 
+// Delete deletes a user from the database including all information (e.g., emails, username, metadata)
+// It must be called within a transaction otherwise some information might not be rolled back on an error.
 func (p *userPersister) Delete(user models.User) error {
+	primaryEmail := user.Emails.GetPrimary()
+
+	if primaryEmail != nil {
+		err := p.db.Destroy(primaryEmail.PrimaryEmail)
+		if err != nil {
+			return fmt.Errorf("failed to delete primary email: %w", err)
+		}
+	}
+
 	err := p.db.Destroy(&user)
 	if err != nil {
 		return fmt.Errorf("failed to delete user: %w", err)


### PR DESCRIPTION
# Description

When using mysql as DBMS the user can't be deleted due to: 
`failed to delete user: failed to delete user: mysql destroy: Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`hanko`.`primary_emails`, CONSTRAINT `primary_emails_ibfk_1` FOREIGN KEY (`email_id`) REFERENCES `emails` (`id`) ON UPDATE CASCADE)`

The foreign key is set here: https://github.com/teamhanko/hanko/blob/f231ae7e4ad73c5fc1d47c3ca150053ebae7d9bc/backend/persistence/migrations/20221027104800_create_emails.up.fizz#L18

And was introduced to add a protection on database level to prevent deleting an email entry before removing the primary_email entry.

# Implementation

To overcome this the `Delete()` function from the `user_persister` now deletes the primary email entry first before deleting the user entry.
The foreign keys on delete action could be changed to `CASCADE` to fix this error, but then we would loose the protection on database level when an email entry is deleted.

# Tests

Start Hanko with mysql as DBMS and try to delete a user through the [delete user endpoint](https://docs.hanko.io/api-reference/admin/user-management/delete-a-user-by-id).

