### PR TITLE
fix: take privacy setting into account when adding an email

### DIFF
--- a/backend/flow_api/flow/profile/action_email_create.go
+++ b/backend/flow_api/flow/profile/action_email_create.go
@@ -54,7 +54,7 @@ func (a EmailCreate) Execute(c flowpilot.ExecutionContext) error {
 	}
 
 	if existingEmailModel != nil {
-		if (existingEmailModel.UserID != nil && existingEmailModel.UserID.String() == userModel.ID.String()) || !deps.Cfg.Email.RequireVerification {
+		if (existingEmailModel.UserID != nil && existingEmailModel.UserID.String() == userModel.ID.String()) || !deps.Cfg.Email.RequireVerification || deps.Cfg.Privacy.ShowAccountExistenceHints {
 			c.Input().SetError("email", shared.ErrorEmailAlreadyExists)
 			return c.Error(flowpilot.ErrorFormDataInvalid)
 		} else {


### PR DESCRIPTION
# Description

When adding an email in the profile, check the `show_account_existence_hints` setting in order to decide if an error should be returned or if the passcode input should be shown.

# Implementation

Check the `show_account_existence_hints` setting.

# Tests

Set `privacy.show_account_existence_hints: true` and create an email in the profile with an email address that already belongs to a different user.

# Additional context

Fixes #2206 
