### PR TITLE
feat: highlight email address when logging in

### DIFF
--- a/frontend/elements/src/i18n/bn.ts
+++ b/frontend/elements/src/i18n/bn.ts
@@ -50,7 +50,7 @@ export const bn: Translation = {
     trustDevice: "এই ব্রাউজারটি বিশ্বাস করবেন?",
   },
   texts: {
-    enterPasscode: 'যে পাসকোডটি পাঠানো হয়েছিল "{emailAddress}" এ তা লিখুন.',
+    enterPasscode: "আপনার ইমেইল ঠিকানায় পাঠানো পাসকোডটি প্রবেশ করান।",
     enterPasscodeNoEmail:
       "আপনার প্রাথমিক ইমেল ঠিকানায় প্রেরিত পাসকোডটি লিখুন।",
     setupPasskey:

--- a/frontend/elements/src/i18n/de.ts
+++ b/frontend/elements/src/i18n/de.ts
@@ -51,7 +51,7 @@ export const de: Translation = {
   },
   texts: {
     enterPasscode:
-      'Geben Sie den Passcode ein, der an die E-Mail-Adresse "{emailAddress}" gesendet wurde.',
+      "Geben Sie den Passcode ein, der an Ihre E-Mail-Adresse gesendet wurde.",
     enterPasscodeNoEmail:
       "Geben Sie den Passcode ein, der an Ihre primäre E-Mail-Adresse gesendet wurde.",
     setupPasskey:

--- a/frontend/elements/src/i18n/en.ts
+++ b/frontend/elements/src/i18n/en.ts
@@ -50,7 +50,7 @@ export const en: Translation = {
     trustDevice: "Trust this browser?",
   },
   texts: {
-    enterPasscode: 'Enter the passcode that was sent to "{emailAddress}".',
+    enterPasscode: "Enter the passcode sent to your email address.",
     enterPasscodeNoEmail:
       "Enter the passcode that was sent to your primary email address.",
     setupPasskey:

--- a/frontend/elements/src/i18n/fr.ts
+++ b/frontend/elements/src/i18n/fr.ts
@@ -51,8 +51,7 @@ export const fr: Translation = {
     trustDevice: "Faire confiance à ce navigateur ?",
   },
   texts: {
-    enterPasscode:
-      'Saisissez le code d\'accès qui a été envoyé à "{emailAddress}".',
+    enterPasscode: "Saisissez le code d'accès envoyé à votre adresse e-mail.",
     enterPasscodeNoEmail:
       "Entrez le code envoyé à votre adresse e-mail principale.",
     setupPasskey:

--- a/frontend/elements/src/i18n/it.ts
+++ b/frontend/elements/src/i18n/it.ts
@@ -50,7 +50,7 @@ export const it: Translation = {
     trustDevice: "Fidarsi di questo browser?",
   },
   texts: {
-    enterPasscode: 'Inserisci il codice di accesso inviato a "{emailAddress}".',
+    enterPasscode: "Inserisci il codice di accesso inviato al tuo indirizzo email.",
     enterPasscodeNoEmail:
       "Inserisci il codice inviato al tuo indirizzo email principale.",
     setupPasskey:

--- a/frontend/elements/src/i18n/pt-BR.ts
+++ b/frontend/elements/src/i18n/pt-BR.ts
@@ -52,7 +52,7 @@ export const ptBR: Translation = {
   },
   texts: {
     enterPasscode:
-      'Digite o código de acesso que foi enviado para "{emailAddress}".',
+      "Digite o código de acesso enviado para o seu endereço de email.",
     enterPasscodeNoEmail:
       "Digite o código enviado para o seu endereço de e-mail principal.",
     setupPasskey:

--- a/frontend/elements/src/i18n/zh.ts
+++ b/frontend/elements/src/i18n/zh.ts
@@ -50,7 +50,7 @@ export const zh: Translation = {
     trustDevice: "信任此浏览器？",
   },
   texts: {
-    enterPasscode: "输入发送到“{emailAddress}”的验证码。",
+    enterPasscode: "请输入发送到您邮箱地址的验证码。",
     enterPasscodeNoEmail: "输入发送到您的主要电子邮件地址的验证码。",
     setupPasskey:
       "使用密钥轻松安全地登录您的账户。注意：您的生物识别数据仅存储在您的设备上，永远不会与任何人共享。",

--- a/frontend/elements/src/pages/PasscodePage.tsx
+++ b/frontend/elements/src/pages/PasscodePage.tsx
@@ -96,8 +96,11 @@ const PasscodePage = (props: Props) => {
         <ErrorBox state={flowState} />
         <Paragraph>
           {uiState.email
-            ? t("texts.enterPasscode", { emailAddress: uiState.email })
+            ? t("texts.enterPasscode")
             : t("texts.enterPasscodeNoEmail")}
+        </Paragraph>
+        <Paragraph hidden={!uiState.email}>
+           <b>{uiState.email}</b>
         </Paragraph>
         <Form
           flowAction={flowState.actions.verify_passcode}


### PR DESCRIPTION
# Description

Highlight the email address when logging in with an email address through making the text bold.

# Implementation

The email address is always shown in the PasscodePage and not a part of the translation text anymore. The email address is set in a different `Paragraph` so that a small margin between the text and the email address exist.

The address is only shown when the user entered it himself, this behaviour didn't change.

Also the translation texts are changed to reflect the change.

# Tests

- Login with an email address and check that the address is bold.
- Login with an username and check that the email address is not shown.

