### PR TITLE
feat: change flow switch UI

### DIFF
--- a/frontend/elements/src/components/paragraph/Paragraph.tsx
+++ b/frontend/elements/src/components/paragraph/Paragraph.tsx
@@ -1,15 +1,24 @@
 import { ComponentChildren } from "preact";
 
 import styles from "./styles.sass";
+import cx from "classnames";
 
 type Props = {
   hidden?: boolean;
   children: ComponentChildren;
+  center?: boolean;
 };
 
-const Paragraph = ({ children, hidden }: Props) => {
+const Paragraph = ({ children, hidden, center }: Props) => {
   return !hidden ? (
-    <p part={"paragraph"} className={styles.paragraph}>
+    <p
+      part={"paragraph"}
+      className={cx(
+        styles.paragraph,
+        center && styles.center,
+        center && styles.column,
+      )}
+    >
       {children}
     </p>
   ) : null;

--- a/frontend/elements/src/components/paragraph/styles.sass
+++ b/frontend/elements/src/components/paragraph/styles.sass
@@ -10,3 +10,10 @@
   text-align: left
   word-break: break-word
 
+  &.center
+    align-items: center
+
+  &.column
+    display: flex
+    flex-direction: column
+    width: 100%

--- a/frontend/elements/src/pages/LoginInitPage.tsx
+++ b/frontend/elements/src/pages/LoginInitPage.tsx
@@ -26,6 +26,7 @@ import Link from "../components/link/Link";
 import Footer from "../components/wrapper/Footer";
 import Checkbox from "../components/form/Checkbox";
 import Spacer from "../components/spacer/Spacer";
+import Paragraph from "../components/paragraph/Paragraph";
 
 interface Props {
   state: State<"login_init">;
@@ -252,14 +253,16 @@ const LoginInitPage = (props: Props) => {
         )}
       </Content>
       <Footer hidden={initialComponentName !== "auth"}>
-        <span hidden />
-        <Link
-          onClick={onRegisterClick}
-          loadingSpinnerPosition={"left"}
-          isLoading={isFlowSwitchLoading}
-        >
-          {t("labels.dontHaveAnAccount")}
-        </Link>
+        <Paragraph center>
+          <span>{t("labels.dontHaveAnAccount")}</span>
+          <Link
+            onClick={onRegisterClick}
+            loadingSpinnerPosition={"left"}
+            isLoading={isFlowSwitchLoading}
+          >
+            {t("labels.signUp")}
+          </Link>
+        </Paragraph>
       </Footer>
     </Fragment>
   );

--- a/frontend/elements/src/pages/RegistrationInitPage.tsx
+++ b/frontend/elements/src/pages/RegistrationInitPage.tsx
@@ -18,6 +18,7 @@ import { HankoError } from "@teamhanko/hanko-frontend-sdk";
 import Divider from "../components/spacer/Divider";
 import Checkbox from "../components/form/Checkbox";
 import Spacer from "../components/spacer/Spacer";
+import Paragraph from "../components/paragraph/Paragraph";
 
 interface Props {
   state: State<"registration_init">;
@@ -185,14 +186,16 @@ const RegistrationInitPage = (props: Props) => {
         )}
       </Content>
       <Footer hidden={initialComponentName !== "auth"}>
-        <span hidden />
-        <Link
-          onClick={onLoginClick}
-          loadingSpinnerPosition={"left"}
-          isLoading={isFlowSwitchLoading}
-        >
-          {t("labels.alreadyHaveAnAccount")}
-        </Link>
+        <Paragraph center>
+          <span>{t("labels.alreadyHaveAnAccount")}</span>
+          <Link
+            onClick={onLoginClick}
+            loadingSpinnerPosition={"left"}
+            isLoading={isFlowSwitchLoading}
+          >
+            {t("labels.signIn")}
+          </Link>
+        </Paragraph>
       </Footer>
     </Fragment>
   );


### PR DESCRIPTION
# Description

Change the flow switch appearance on the registration and login pages in `<hanko-auth>` element. The complete text is not a link anymore, only the action it self is. This should make the action more visible to the user.
