### PR TITLE
fix: add all user properties to session

### DIFF
--- a/backend/handler/session_admin.go
+++ b/backend/handler/session_admin.go
@@ -57,15 +57,7 @@ func (h *SessionAdminHandler) Generate(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "user not found")
 	}
 
-	var emailDTO *dto.EmailJWT
-	if email := user.Emails.GetPrimary(); email != nil {
-		emailDTO = dto.EmailJWTFromEmailModel(email)
-	}
-
-	encodedToken, rawToken, err := h.sessionManger.GenerateJWT(dto.UserJWT{
-		UserID: userID.String(),
-		Email:  emailDTO,
-	})
+	encodedToken, rawToken, err := h.sessionManger.GenerateJWT(dto.UserJWTFromUserModel(user))
 	if err != nil {
 		return fmt.Errorf("failed to generate JWT: %w", err)
 	}


### PR DESCRIPTION
# Description

Add missing user properties to the session JWT created by the create session endpoint in the admin API, including the username and the user metadata.

# Implementation

Use the existing `UserJWTFromUserModel()` function to pass all user properties correctly to the `GenerateJWT()` method.

# Tests

- Add a metadata to a user
- Add a session JWT customization in the config that uses the metadata
- Create a session using the admin endpoint

