### PR TITLE
fix: user verification on passkey creation

### DIFF
--- a/backend/flow_api/services/webauthn.go
+++ b/backend/flow_api/services/webauthn.go
@@ -302,7 +302,7 @@ func (s *webauthnService) GenerateCreationOptionsPasskey(p GenerateCreationOptio
 	authenticatorSelection := protocol.AuthenticatorSelection{
 		RequireResidentKey: &requireResidentKey,
 		ResidentKey:        protocol.ResidentKeyRequirementRequired,
-		UserVerification:   protocol.VerificationRequired,
+		UserVerification:   protocol.UserVerificationRequirement(s.cfg.Passkey.UserVerification),
 	}
 
 	attestationPreference := protocol.ConveyancePreference(s.cfg.Passkey.AttestationPreference)


### PR DESCRIPTION
# Description

The UV value on passkey creation was hardcoded, but is now read from the configuration.

FIxes #2237