### PR TITLE
Feat oauth prompt

### DIFF
--- a/backend/config/config_third_party.go
+++ b/backend/config/config_third_party.go
@@ -268,6 +268,14 @@ type CustomThirdPartyProvider struct {
 	DisplayName string `yaml:"display_name" json:"display_name,omitempty" koanf:"display_name"`
 	// `enabled` indicates if the provider is enabled or disabled.
 	Enabled bool `yaml:"enabled" json:"enabled,omitempty" koanf:"enabled" jsonschema:"default=false"`
+	// `prompt` specifies whether the Authorization Server prompts the End-User for reauthentication and consent.
+	// Possible values are:
+	// - login
+	// - none
+	// - consent
+	// - select_account
+	// Please note that not all providers support all values. Check the corresponding docs of the provider for supported values.
+	Prompt string `yaml:"prompt" json:"prompt,omitempty" koanf:"prompt" jsonschema:"default=consent"`
 	// `scopes` is a list of scopes requested from the provider that specify the level of access an application has to
 	// a user's resources on a server, defining what actions the app can perform on behalf of the user.
 	//
@@ -442,6 +450,14 @@ type ThirdPartyProvider struct {
 	DisplayName string `jsonschema:"-" yaml:"-" json:"-" koanf:"-"`
 	// `enabled` determines whether this provider is enabled.
 	Enabled bool `yaml:"enabled" json:"enabled,omitempty" koanf:"enabled" jsonschema:"default=false"`
+	// `prompt` specifies whether the Authorization Server prompts the End-User for reauthentication and consent.
+	// Possible values are:
+	// - login
+	// - none
+	// - consent
+	// - select_account
+	// Please note that not all providers support all values. Check the corresponding docs of the provider for supported values.
+	Prompt string `yaml:"prompt" json:"prompt,omitempty" koanf:"prompt" jsonschema:"default=consent"`
 	// `secret` is the client secret for the OAuth/OIDC client. Must be obtained from the provider.
 	//
 	// Required if the provider is `enabled`.

--- a/backend/flow_api/flow/shared/action_thirdparty_oauth.go
+++ b/backend/flow_api/flow/shared/action_thirdparty_oauth.go
@@ -83,7 +83,7 @@ func (a ThirdPartyOAuth) Execute(c flowpilot.ExecutionContext) error {
 		return c.Error(flowpilot.ErrorTechnical.Wrap(err))
 	}
 
-	authCodeUrl := provider.AuthCodeURL(string(state), oauth2.SetAuthURLParam("prompt", "consent"))
+	authCodeUrl := provider.AuthCodeURL(string(state), oauth2.SetAuthURLParam("prompt", provider.GetPromptParam()))
 
 	// cookie := utils.GenerateStateCookie(&deps.Cfg, utils.HankoThirdpartyStateCookie, string(state), utils.CookieOptions{
 	//	MaxAge:   300,

--- a/backend/handler/thirdparty.go
+++ b/backend/handler/thirdparty.go
@@ -66,7 +66,7 @@ func (h *ThirdPartyHandler) Auth(c echo.Context) error {
 		return h.redirectError(c, thirdparty.ErrorServer("could not generate state").WithCause(err), errorRedirectTo)
 	}
 
-	authCodeUrl := provider.AuthCodeURL(string(state), oauth2.SetAuthURLParam("prompt", "consent"))
+	authCodeUrl := provider.AuthCodeURL(string(state), oauth2.SetAuthURLParam("prompt", provider.GetPromptParam()))
 
 	cookie := utils.GenerateStateCookie(h.cfg, utils.HankoThirdpartyStateCookie, string(state), utils.CookieOptions{
 		MaxAge:   300,

--- a/backend/thirdparty/provider.go
+++ b/backend/thirdparty/provider.go
@@ -86,6 +86,7 @@ type OAuthProvider interface {
 	GetUserData(*oauth2.Token) (*UserData, error)
 	GetOAuthToken(string) (*oauth2.Token, error)
 	ID() string
+	GetPromptParam() string
 }
 
 func GetProvider(config config.ThirdParty, id string) (OAuthProvider, error) {

--- a/backend/thirdparty/provider_apple.go
+++ b/backend/thirdparty/provider_apple.go
@@ -126,3 +126,10 @@ func (a appleProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 func (a appleProvider) ID() string {
 	return a.config.ID
 }
+
+func (a appleProvider) GetPromptParam() string {
+	if a.config.Prompt != "" {
+		return a.config.Prompt
+	}
+	return "consent"
+}

--- a/backend/thirdparty/provider_custom.go
+++ b/backend/thirdparty/provider_custom.go
@@ -103,3 +103,10 @@ func (p customProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 func (p customProvider) ID() string {
 	return p.config.ID
 }
+
+func (p customProvider) GetPromptParam() string {
+	if p.config.Prompt != "" {
+		return p.config.Prompt
+	}
+	return "consent"
+}

--- a/backend/thirdparty/provider_discord.go
+++ b/backend/thirdparty/provider_discord.go
@@ -107,3 +107,10 @@ func (g discordProvider) buildAvatarURL(userID string, avatarHash string) string
 func (g discordProvider) ID() string {
 	return g.config.ID
 }
+
+func (g discordProvider) GetPromptParam() string {
+	if g.config.Prompt != "" {
+		return g.config.Prompt
+	}
+	return "consent"
+}

--- a/backend/thirdparty/provider_facebook.go
+++ b/backend/thirdparty/provider_facebook.go
@@ -127,3 +127,10 @@ func (f facebookProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 func (f facebookProvider) ID() string {
 	return f.config.ID
 }
+
+func (f facebookProvider) GetPromptParam() string {
+	if f.config.Prompt != "" {
+		return f.config.Prompt
+	}
+	return "consent"
+}

--- a/backend/thirdparty/provider_github.go
+++ b/backend/thirdparty/provider_github.go
@@ -117,3 +117,10 @@ func (g githubProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 func (g githubProvider) ID() string {
 	return g.config.ID
 }
+
+func (g githubProvider) GetPromptParam() string {
+	if g.config.Prompt != "" {
+		return g.config.Prompt
+	}
+	return "consent"
+}

--- a/backend/thirdparty/provider_google.go
+++ b/backend/thirdparty/provider_google.go
@@ -96,3 +96,10 @@ func (g googleProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 func (g googleProvider) ID() string {
 	return g.config.ID
 }
+
+func (g googleProvider) GetPromptParam() string {
+	if g.config.Prompt != "" {
+		return g.config.Prompt
+	}
+	return "consent"
+}

--- a/backend/thirdparty/provider_linkedin.go
+++ b/backend/thirdparty/provider_linkedin.go
@@ -110,3 +110,10 @@ func (g linkedInProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 func (g linkedInProvider) ID() string {
 	return g.config.ID
 }
+
+func (g linkedInProvider) GetPromptParam() string {
+	if g.config.Prompt != "" {
+		return g.config.Prompt
+	}
+	return "consent"
+}

--- a/backend/thirdparty/provider_microsoft.go
+++ b/backend/thirdparty/provider_microsoft.go
@@ -163,6 +163,13 @@ func (p microsoftProvider) ID() string {
 	return p.config.ID
 }
 
+func (p microsoftProvider) GetPromptParam() string {
+	if p.config.Prompt != "" {
+		return p.config.Prompt
+	}
+	return "consent"
+}
+
 func (p microsoftProvider) issuerValidator() jwt.ValidatorFunc {
 	var microsoftIssuerRegexp = regexp.MustCompile("^https://login[.]microsoftonline[.]com/([^/]+)/v2[.]0/?$")
 	validator := jwt.ValidatorFunc(func(_ context.Context, t jwt.Token) jwt.ValidationError {


### PR DESCRIPTION
# Description

Add the option to configure the prompt value for a oauth provider. By default it is set to `consent`.

# Implementation

Add a config option per provider and set the prompt parameter according to the config.

# Tests

Add a thirdparty oauth provider and change the prompt option, then login with the configured provider and check that the flow changes.


