### PR TITLE
fix: check for SAML before email existence

### DIFF
--- a/backend/flow_api/flow/credential_usage/action_continue_with_login_identifier.go
+++ b/backend/flow_api/flow/credential_usage/action_continue_with_login_identifier.go
@@ -84,6 +84,21 @@ func (a ContinueWithLoginIdentifier) Execute(c flowpilot.ExecutionContext) error
 	if treatIdentifierAsEmail {
 		// User has submitted an email address.
 
+		if deps.Cfg.Saml.Enabled {
+			domain := strings.Split(identifierInputValue, "@")[1]
+			if provider, err := deps.SamlService.GetProviderByDomain(domain); err == nil && provider != nil {
+				authUrl, err := deps.SamlService.GetAuthUrl(provider, deps.Cfg.Saml.DefaultRedirectUrl, true)
+
+				if err != nil {
+					return fmt.Errorf("failed to get auth url: %w", err)
+				}
+
+				_ = c.Payload().Set("redirect_url", authUrl)
+
+				return c.Continue(shared.StateThirdParty)
+			}
+		}
+
 		var err error
 
 		userModel, err = deps.Persister.GetUserPersister().GetByEmailAddress(identifierInputValue)
@@ -122,21 +137,6 @@ func (a ContinueWithLoginIdentifier) Execute(c flowpilot.ExecutionContext) error
 				if err != nil {
 					return fmt.Errorf("failed to set user_id to the stash: %w", err)
 				}
-			}
-		}
-
-		if deps.Cfg.Saml.Enabled {
-			domain := strings.Split(identifierInputValue, "@")[1]
-			if provider, err := deps.SamlService.GetProviderByDomain(domain); err == nil && provider != nil {
-				authUrl, err := deps.SamlService.GetAuthUrl(provider, deps.Cfg.Saml.DefaultRedirectUrl, true)
-
-				if err != nil {
-					return fmt.Errorf("failed to get auth url: %w", err)
-				}
-
-				_ = c.Payload().Set("redirect_url", authUrl)
-
-				return c.Continue(shared.StateThirdParty)
 			}
 		}
 	} else {


### PR DESCRIPTION
# Description

Check if the domain is registered for a SAML provider before checking if the email already exists, otherwise the user could get an error that the user does not exists.
