### PR TITLE
fix: don't show the divider on login

### DIFF
--- a/frontend/elements/src/pages/LoginInitPage.tsx
+++ b/frontend/elements/src/pages/LoginInitPage.tsx
@@ -129,8 +129,9 @@ const LoginInitPage = (props: Props) => {
 
   const showDivider = useMemo(
     () =>
-      !!flowState.actions.webauthn_generate_request_options.enabled ||
-      !!flowState.actions.thirdparty_oauth.enabled,
+      (!!flowState.actions.webauthn_generate_request_options.enabled ||
+        !!flowState.actions.thirdparty_oauth.enabled) &&
+      flowState.actions.continue_with_login_identifier.enabled,
     [flowState.actions],
   );
 

--- a/frontend/elements/src/pages/RegistrationInitPage.tsx
+++ b/frontend/elements/src/pages/RegistrationInitPage.tsx
@@ -98,7 +98,9 @@ const RegistrationInitPage = (props: Props) => {
   };
 
   const showDivider = useMemo(
-    () => !!flowState.actions.thirdparty_oauth.enabled,
+    () =>
+      !!flowState.actions.thirdparty_oauth.enabled &&
+      flowState.actions.register_login_identifier.enabled,
     [flowState.actions],
   );
 


### PR DESCRIPTION
# Description

Don't show the `or` divider on login and registration page when email and username are disabled.


# Tests

Set in the config:
```
email:
  enabled: false
username:
  enabled: false
```
and have at least one OAuth provider configured and enabled.

Check that the `or` divider is not shown anymore when no username or email input are shown.

# Additional context

How it currently looks:
<img width="459" height="398" alt="Screenshot 2025-10-17 at 11 20 45" src="https://github.com/user-attachments/assets/e5df4482-e046-4bdf-84f8-6ac1ad366b80" />

How it looks after the change:
<img width="433" height="372" alt="Screenshot 2025-10-17 at 11 18 45" src="https://github.com/user-attachments/assets/a5e0b757-70c6-4b41-8ab3-0b29c501b5fc" />


