### PR TITLE
fix: ensure WebAuthn session data expires time is in UTC

### DIFF
--- a/backend/persistence/models/webauthn_session_data.go
+++ b/backend/persistence/models/webauthn_session_data.go
@@ -86,7 +86,7 @@ func NewWebauthnSessionDataFrom(sessionData *webauthn.SessionData, operation Ope
 		UpdatedAt:          now,
 		Operation:          operation,
 		AllowedCredentials: allowedCredentials,
-		ExpiresAt:          nulls.NewTime(sessionData.Expires),
+		ExpiresAt:          nulls.NewTime(sessionData.Expires.UTC()),
 	}
 
 	return sessionDataModel, nil


### PR DESCRIPTION
# Description

Always convert the webauthn session data expiration date to UTC before storing it to prevent issues when the servers timezone is not set to UTC.

# Additional context

Fixes #2258 
