### PR TITLE
feat: change default thirdparty prompt parameter behaviour

### DIFF
--- a/backend/config/config_third_party.go
+++ b/backend/config/config_third_party.go
@@ -275,7 +275,7 @@ type CustomThirdPartyProvider struct {
 	// - consent
 	// - select_account
 	// Please note that not all providers support all values. Check the corresponding docs of the provider for supported values.
-	Prompt string `yaml:"prompt" json:"prompt,omitempty" koanf:"prompt" jsonschema:"default=consent"`
+	Prompt string `yaml:"prompt" json:"prompt,omitempty" koanf:"prompt"`
 	// `scopes` is a list of scopes requested from the provider that specify the level of access an application has to
 	// a user's resources on a server, defining what actions the app can perform on behalf of the user.
 	//
@@ -457,7 +457,7 @@ type ThirdPartyProvider struct {
 	// - consent
 	// - select_account
 	// Please note that not all providers support all values. Check the corresponding docs of the provider for supported values.
-	Prompt string `yaml:"prompt" json:"prompt,omitempty" koanf:"prompt" jsonschema:"default=consent"`
+	Prompt string `yaml:"prompt" json:"prompt,omitempty" koanf:"prompt"`
 	// `secret` is the client secret for the OAuth/OIDC client. Must be obtained from the provider.
 	//
 	// Required if the provider is `enabled`.

--- a/backend/flow_api/flow/shared/action_thirdparty_oauth.go
+++ b/backend/flow_api/flow/shared/action_thirdparty_oauth.go
@@ -3,9 +3,10 @@ package shared
 import (
 	"cmp"
 	"fmt"
-	"github.com/teamhanko/hanko/backend/v2/utils"
 	"net/http"
 	"slices"
+
+	"github.com/teamhanko/hanko/backend/v2/utils"
 
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"github.com/teamhanko/hanko/backend/v2/flowpilot"
@@ -88,10 +89,7 @@ func (a ThirdPartyOAuth) Execute(c flowpilot.ExecutionContext) error {
 		return c.Error(flowpilot.ErrorTechnical.Wrap(err))
 	}
 
-	opts := []oauth2.AuthCodeOption{
-		oauth2.SetAuthURLParam("prompt", provider.GetPromptParam()),
-	}
-
+	var opts []oauth2.AuthCodeOption
 	if codeVerifier.Exists() {
 		opts = append(opts, oauth2.S256ChallengeOption(codeVerifier.String()))
 	}

--- a/backend/handler/thirdparty.go
+++ b/backend/handler/thirdparty.go
@@ -3,6 +3,9 @@ package handler
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+
 	"github.com/gobuffalo/pop/v6"
 	"github.com/labstack/echo/v4"
 	auditlog "github.com/teamhanko/hanko/backend/v2/audit_log"
@@ -16,8 +19,6 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/utils"
 	webhookUtils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
 	"golang.org/x/oauth2"
-	"net/http"
-	"net/url"
 )
 
 type ThirdPartyHandler struct {
@@ -67,7 +68,7 @@ func (h *ThirdPartyHandler) Auth(c echo.Context) error {
 		return h.redirectError(c, thirdparty.ErrorServer("could not generate state").WithCause(err), errorRedirectTo)
 	}
 
-	authCodeUrl := provider.AuthCodeURL(string(state), oauth2.SetAuthURLParam("prompt", provider.GetPromptParam()))
+	authCodeUrl := provider.AuthCodeURL(string(state))
 
 	cookie := utils.GenerateStateCookie(h.cfg, utils.HankoThirdpartyStateCookie, string(state), utils.CookieOptions{
 		MaxAge:   300,

--- a/backend/json_schema/hanko.config.json
+++ b/backend/json_schema/hanko.config.json
@@ -440,8 +440,7 @@
         },
         "prompt": {
           "type": "string",
-          "description": "`prompt` specifies whether the Authorization Server prompts the End-User for reauthentication and consent.\nPossible values are:\n- login\n- none\n- consent\n- select_account\nPlease note that not all providers support all values. Check the corresponding docs of the provider for supported values.",
-          "default": "consent"
+          "description": "`prompt` specifies whether the Authorization Server prompts the End-User for reauthentication and consent.\nPossible values are:\n- login\n- none\n- consent\n- select_account\nPlease note that not all providers support all values. Check the corresponding docs of the provider for supported values."
         },
         "scopes": {
           "items": {
@@ -1478,8 +1477,7 @@
         },
         "prompt": {
           "type": "string",
-          "description": "`prompt` specifies whether the Authorization Server prompts the End-User for reauthentication and consent.\nPossible values are:\n- login\n- none\n- consent\n- select_account\nPlease note that not all providers support all values. Check the corresponding docs of the provider for supported values.",
-          "default": "consent"
+          "description": "`prompt` specifies whether the Authorization Server prompts the End-User for reauthentication and consent.\nPossible values are:\n- login\n- none\n- consent\n- select_account\nPlease note that not all providers support all values. Check the corresponding docs of the provider for supported values."
         },
         "secret": {
           "type": "string",

--- a/backend/thirdparty/provider.go
+++ b/backend/thirdparty/provider.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"golang.org/x/oauth2"
@@ -86,7 +87,6 @@ type OAuthProvider interface {
 	GetUserData(*oauth2.Token) (*UserData, error)
 	GetOAuthToken(string, ...oauth2.AuthCodeOption) (*oauth2.Token, error)
 	ID() string
-	GetPromptParam() string
 }
 
 func GetProvider(config config.ThirdParty, id string) (OAuthProvider, error) {

--- a/backend/thirdparty/provider_custom.go
+++ b/backend/thirdparty/provider_custom.go
@@ -3,6 +3,7 @@ package thirdparty
 import (
 	"context"
 	"fmt"
+
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/mitchellh/mapstructure"
 	"github.com/teamhanko/hanko/backend/v2/config"
@@ -55,6 +56,11 @@ func NewCustomThirdPartyProvider(config *config.CustomThirdPartyProvider, redire
 }
 
 func (p customProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+
+	if prompt := p.config.Prompt; prompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
+
 	return p.oauthConfig.AuthCodeURL(state, opts...)
 }
 
@@ -102,11 +108,4 @@ func (p customProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 
 func (p customProvider) ID() string {
 	return p.config.ID
-}
-
-func (p customProvider) GetPromptParam() string {
-	if p.config.Prompt != "" {
-		return p.config.Prompt
-	}
-	return "consent"
 }

--- a/backend/thirdparty/provider_discord.go
+++ b/backend/thirdparty/provider_discord.go
@@ -57,6 +57,11 @@ func NewDiscordProvider(config config.ThirdPartyProvider, redirectURL string) (O
 }
 
 func (p discordProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+
+	if prompt := p.config.Prompt; prompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
+
 	return p.oauthConfig.AuthCodeURL(state, opts...)
 }
 
@@ -106,11 +111,4 @@ func (g discordProvider) buildAvatarURL(userID string, avatarHash string) string
 
 func (g discordProvider) ID() string {
 	return g.config.ID
-}
-
-func (g discordProvider) GetPromptParam() string {
-	if g.config.Prompt != "" {
-		return g.config.Prompt
-	}
-	return "consent"
 }

--- a/backend/thirdparty/provider_facebook.go
+++ b/backend/thirdparty/provider_facebook.go
@@ -6,9 +6,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"net/url"
+
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"golang.org/x/oauth2"
-	"net/url"
 )
 
 const (
@@ -64,6 +65,11 @@ func NewFacebookProvider(config config.ThirdPartyProvider, redirectURL string) (
 }
 
 func (f facebookProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+
+	if prompt := f.config.Prompt; prompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
+
 	return f.oauthConfig.AuthCodeURL(state, opts...)
 }
 
@@ -126,11 +132,4 @@ func (f facebookProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 
 func (f facebookProvider) ID() string {
 	return f.config.ID
-}
-
-func (f facebookProvider) GetPromptParam() string {
-	if f.config.Prompt != "" {
-		return f.config.Prompt
-	}
-	return "consent"
 }

--- a/backend/thirdparty/provider_github.go
+++ b/backend/thirdparty/provider_github.go
@@ -3,9 +3,10 @@ package thirdparty
 import (
 	"context"
 	"errors"
+	"strconv"
+
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"golang.org/x/oauth2"
-	"strconv"
 )
 
 const (
@@ -63,6 +64,11 @@ func NewGithubProvider(config config.ThirdPartyProvider, redirectURL string) (OA
 }
 
 func (g githubProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+
+	if prompt := g.config.Prompt; prompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
+
 	return g.oauthConfig.AuthCodeURL(state, opts...)
 }
 
@@ -116,11 +122,4 @@ func (g githubProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 
 func (g githubProvider) ID() string {
 	return g.config.ID
-}
-
-func (g githubProvider) GetPromptParam() string {
-	if g.config.Prompt != "" {
-		return g.config.Prompt
-	}
-	return "consent"
 }

--- a/backend/thirdparty/provider_google.go
+++ b/backend/thirdparty/provider_google.go
@@ -3,6 +3,7 @@ package thirdparty
 import (
 	"context"
 	"errors"
+
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"golang.org/x/oauth2"
 )
@@ -54,6 +55,11 @@ func NewGoogleProvider(config config.ThirdPartyProvider, redirectURL string) (OA
 }
 
 func (g googleProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+
+	if prompt := g.config.Prompt; prompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
+
 	return g.oauthConfig.AuthCodeURL(state, opts...)
 }
 
@@ -95,11 +101,4 @@ func (g googleProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 
 func (g googleProvider) ID() string {
 	return g.config.ID
-}
-
-func (g googleProvider) GetPromptParam() string {
-	if g.config.Prompt != "" {
-		return g.config.Prompt
-	}
-	return "consent"
 }

--- a/backend/thirdparty/provider_linkedin.go
+++ b/backend/thirdparty/provider_linkedin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"golang.org/x/oauth2"
@@ -65,6 +66,11 @@ func NewLinkedInProvider(config config.ThirdPartyProvider, redirectURL string) (
 }
 
 func (g linkedInProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+
+	if prompt := g.config.Prompt; prompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
+
 	return g.oauthConfig.AuthCodeURL(state, opts...)
 }
 
@@ -109,11 +115,4 @@ func (g linkedInProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 
 func (g linkedInProvider) ID() string {
 	return g.config.ID
-}
-
-func (g linkedInProvider) GetPromptParam() string {
-	if g.config.Prompt != "" {
-		return g.config.Prompt
-	}
-	return "consent"
 }

--- a/backend/thirdparty/provider_microsoft.go
+++ b/backend/thirdparty/provider_microsoft.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/mail"
+	"regexp"
+
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/mitchellh/mapstructure"
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"golang.org/x/oauth2"
-	"net/mail"
-	"regexp"
 )
 
 const (
@@ -62,6 +63,11 @@ func NewMicrosoftProvider(config config.ThirdPartyProvider, redirectURL string) 
 }
 
 func (p microsoftProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+
+	if prompt := p.config.Prompt; prompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
+
 	return p.oauthConfig.AuthCodeURL(state, opts...)
 }
 
@@ -161,13 +167,6 @@ func (p microsoftProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 
 func (p microsoftProvider) ID() string {
 	return p.config.ID
-}
-
-func (p microsoftProvider) GetPromptParam() string {
-	if p.config.Prompt != "" {
-		return p.config.Prompt
-	}
-	return "consent"
 }
 
 func (p microsoftProvider) issuerValidator() jwt.ValidatorFunc {


### PR DESCRIPTION
# Description

Some providers (e.g. Google) have a default/"special" behaviour when the `prompt` parameter is omitted. For example for Google the consent will only be shown on the very first use, and not for subsequent login requests. Some may want to use this default behaviour, which unfortunately cannot be triggered as soon as the `prompt` parameter is set to any value.

# Implementation

Removes the default "consent" value. If prompt is not given it is not added to the auth code URL (i.e. we rely on provider default behaviour).


