### PR TITLE
docs: fix redis config password schema

### DIFF
--- a/backend/config/config_shared.go
+++ b/backend/config/config_shared.go
@@ -1,8 +1,21 @@
 package config
 
+import "github.com/invopop/jsonschema"
+
 type RedisConfig struct {
 	// `address` is the address of the redis instance in the form of `host[:port][/database]`.
 	Address string `yaml:"address" json:"address" koanf:"address"`
 	// `password` is the password for the redis instance.
 	Password string `yaml:"password" json:"password,omitempty" koanf:"password"`
+}
+
+func (t RedisConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
+	password, _ := schema.Properties.Get("password")
+	schema.Properties.Set("password", &jsonschema.Schema{
+		Description: password.Description,
+		AnyOf: []*jsonschema.Schema{
+			{Type: "string"},
+			{Type: "null"},
+		},
+	})
 }

--- a/backend/json_schema/hanko.config.json
+++ b/backend/json_schema/hanko.config.json
@@ -1050,7 +1050,14 @@
           "description": "`address` is the address of the redis instance in the form of `host[:port][/database]`."
         },
         "password": {
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "`password` is the password for the redis instance."
         }
       },


### PR DESCRIPTION
# Description

At least JetBrains IDEs visually complain when the `password` key is set but no value is given.

# Implementation

Add custom schema extension.

#### Before
<img width="388" height="191" alt="Screenshot 2025-11-03 at 16 28 39" src="https://github.com/user-attachments/assets/00a30486-0fd4-47e9-923e-dd7c5e9dc449" />

#### After
<img width="393" height="141" alt="Screenshot 2025-11-03 at 16 29 10" src="https://github.com/user-attachments/assets/2ea3728f-3d6c-482a-b2dc-5e31c95fee88" />



