### PR TITLE
feat: add acr values to custom thridparty provider

### DIFF
--- a/backend/config/config_third_party.go
+++ b/backend/config/config_third_party.go
@@ -220,6 +220,9 @@ func (p *CustomThirdPartyProviders) Validate() error {
 }
 
 type CustomThirdPartyProvider struct {
+	// `acr_values` is a list of strings that specifies the Authentication Context Class Reference values that the
+	// Authorization Server is being requested to use for processing this Authentication Request.
+	AcrValues []string `yaml:"acr_values" json:"acr_values,omitempty" koanf:"acr_values"`
 	// `allow_linking` indicates whether existing accounts can be automatically linked with this provider.
 	//
 	// Linking is based on matching one of the email addresses of an existing user account with the (primary)

--- a/backend/thirdparty/provider_custom.go
+++ b/backend/thirdparty/provider_custom.go
@@ -3,6 +3,7 @@ package thirdparty
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/mitchellh/mapstructure"
@@ -59,6 +60,9 @@ func (p customProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption)
 
 	if prompt := p.config.Prompt; prompt != "" {
 		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
+	if acrValues := p.config.AcrValues; len(acrValues) > 0 {
+		opts = append(opts, oauth2.SetAuthURLParam("acr_values", strings.Join(acrValues, " ")))
 	}
 
 	return p.oauthConfig.AuthCodeURL(state, opts...)


### PR DESCRIPTION
# Description

Add a config parameter to the `CustomThirdPartyProvider` to configure `acr_values`. Currently these are only added to the authentication request url but are not validated in the response.
