### PR TITLE
ci: make workflows ready for trusted publishing

### DIFF
--- a/.github/workflows/release-frontend-sdk.yml
+++ b/.github/workflows/release-frontend-sdk.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     working-directory: frontend/frontend-sdk
 
+permissions:
+  id-token: write  # Required for OIDC
+
 jobs:
   check-matching-versions:
     runs-on: ubuntu-latest
@@ -38,15 +41,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.16.0
+          node-version: 24.11.1
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
       - run: npm test
       - name: publish frontend-sdk
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_SECRET }}
 
   generate-docs:
     needs: build-and-publish
@@ -57,7 +58,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.16.0
+          node-version: 24.11.1
       - name: Install dependencies
         run: npm ci
       - name: Generate docs

--- a/.github/workflows/release-hanko-elements.yml
+++ b/.github/workflows/release-hanko-elements.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     working-directory: frontend/elements
 
+permissions:
+  id-token: write  # Required for OIDC
+
 jobs:
   check-matching-versions:
     runs-on: ubuntu-latest
@@ -38,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24.11.1
           registry-url: https://registry.npmjs.org/
       - name: build-frontend-sdk
         run: |
@@ -51,5 +54,3 @@ jobs:
           npm run build
       - name: publish-elements
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_SECRET }}


### PR DESCRIPTION
# Description

See https://docs.npmjs.com/trusted-publishers#limitations-and-future-improvements

# Notes

- The workflow uses the current LTS version ([v24.11.1](https://nodejs.org/en/download/archive/v24.11.1)) of node, which includes an `npm` version of `v11.6.2`, so a workflow step for updating `npm` as shown in the above documentation should not be necessary.
