### PR TITLE
feat(mfa): support multiple users per device for device trust

### DIFF
--- a/backend/config/config_default.go
+++ b/backend/config/config_default.go
@@ -193,13 +193,14 @@ func DefaultConfig() *Config {
 			MaxLength:             32,
 		},
 		MFA: MFA{
-			AcquireOnLogin:        false,
-			AcquireOnRegistration: true,
-			DeviceTrustCookieName: "hanko-device-token",
-			DeviceTrustDuration:   30 * 24 * time.Hour, // 30 days
-			DeviceTrustPolicy:     "prompt",
-			Enabled:               true,
-			Optional:              true,
+			AcquireOnLogin:               false,
+			AcquireOnRegistration:        true,
+			DeviceTrustCookieName:        "hanko-device-token",
+			DeviceTrustDuration:          30 * 24 * time.Hour, // 30 days
+			DeviceTrustMaxUsersPerDevice: 20,
+			DeviceTrustPolicy:            "prompt",
+			Enabled:                      true,
+			Optional:                     true,
 			SecurityKeys: SecurityKeys{
 				AttestationPreference:   "direct",
 				AuthenticatorAttachment: "cross-platform",

--- a/backend/config/config_mfa.go
+++ b/backend/config/config_mfa.go
@@ -38,6 +38,10 @@ type MFA struct {
 	// `device_trust_duration` configures the duration a device remains trusted after authentication; once expired, the
 	// user must reauthenticate with MFA.
 	DeviceTrustDuration time.Duration `yaml:"device_trust_duration" json:"device_trust_duration" koanf:"device_trust_duration" jsonschema:"default=720h,type=string"`
+	// `device_trust_max_users_per_device` limits how many users can have device trust on a single device/browser.
+	// Oldest entries are removed when the limit is exceeded. This allows multiple users to trust the same device
+	// without overwriting each other's trust tokens.
+	DeviceTrustMaxUsersPerDevice int `yaml:"device_trust_max_users_per_device" json:"device_trust_max_users_per_device,omitempty" koanf:"device_trust_max_users_per_device" jsonschema:"default=20"`
 	// `device_trust_policy` determines the conditions under which a device or browser is considered trusted, allowing
 	// MFA to be skipped for subsequent logins.
 	DeviceTrustPolicy string `yaml:"device_trust_policy" json:"device_trust_policy,omitempty" koanf:"device_trust_policy" split_words:"true" jsonschema:"default=prompt,enum=always,enum=prompt,enum=never"`

--- a/backend/flow_api/services/device_trust.go
+++ b/backend/flow_api/services/device_trust.go
@@ -4,12 +4,27 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"strings"
+
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"github.com/teamhanko/hanko/backend/v2/persistence"
 	"github.com/teamhanko/hanko/backend/v2/persistence/models"
 	"time"
+)
+
+// DeviceTrustEntry represents a single user's device trust token entry
+type DeviceTrustEntry struct {
+	UserID      uuid.UUID
+	DeviceToken string
+}
+
+const (
+	// entrySeparator separates multiple user entries in the cookie
+	entrySeparator = "|"
+	// fieldSeparator separates user ID from token within an entry
+	fieldSeparator = ":"
 )
 
 type DeviceTrustService struct {
@@ -42,17 +57,38 @@ func (s DeviceTrustService) CreateTrustedDevice(userID uuid.UUID, deviceToken st
 }
 
 func (s DeviceTrustService) CheckDeviceTrust(userID uuid.UUID) bool {
-	if !userID.IsNil() && s.Cfg.MFA.DeviceTrustPolicy != "never" {
-		cookieName := s.Cfg.MFA.DeviceTrustCookieName
-		cookie, _ := s.HttpContext.Cookie(cookieName)
+	if userID.IsNil() || s.Cfg.MFA.DeviceTrustPolicy == "never" {
+		return false
+	}
 
-		if cookie != nil {
-			deviceToken := cookie.Value
-			trustedDeviceModel, err := s.Persister.FindByDeviceToken(deviceToken)
+	cookieName := s.Cfg.MFA.DeviceTrustCookieName
+	cookie, _ := s.HttpContext.Cookie(cookieName)
 
-			if err == nil && trustedDeviceModel != nil &&
-				time.Now().UTC().Before(trustedDeviceModel.ExpiresAt.UTC()) &&
-				trustedDeviceModel.UserID.String() == userID.String() {
+	if cookie == nil {
+		return false
+	}
+
+	entries := s.ParseDeviceTrustCookie(cookie.Value)
+
+	// Handle legacy format (single token without user ID)
+	if entries == nil && cookie.Value != "" {
+		// Legacy: look up token in DB to check if it belongs to this user
+		trustedDevice, err := s.Persister.FindByDeviceToken(cookie.Value)
+		if err == nil && trustedDevice != nil &&
+			time.Now().UTC().Before(trustedDevice.ExpiresAt.UTC()) &&
+			trustedDevice.UserID.String() == userID.String() {
+			return true
+		}
+		return false
+	}
+
+	// New format: find entry for this user
+	for _, entry := range entries {
+		if entry.UserID.String() == userID.String() {
+			trustedDevice, err := s.Persister.FindByDeviceToken(entry.DeviceToken)
+			if err == nil && trustedDevice != nil &&
+				time.Now().UTC().Before(trustedDevice.ExpiresAt.UTC()) &&
+				trustedDevice.UserID.String() == userID.String() {
 				return true
 			}
 		}
@@ -68,4 +104,55 @@ func (s DeviceTrustService) GenerateRandomToken(length int) (string, error) {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(bytes), nil
+}
+
+// ParseDeviceTrustCookie parses a composite device trust cookie value into individual entries.
+// Returns nil if the cookie is empty or in legacy format (single token without user ID).
+// Legacy format detection: no separators means it's a single token.
+func (s DeviceTrustService) ParseDeviceTrustCookie(cookieValue string) []DeviceTrustEntry {
+	if cookieValue == "" {
+		return nil
+	}
+
+	// Legacy format detection (no separators = single token)
+	if !strings.Contains(cookieValue, entrySeparator) && !strings.Contains(cookieValue, fieldSeparator) {
+		return nil // Caller handles legacy migration
+	}
+
+	var entries []DeviceTrustEntry
+	parts := strings.Split(cookieValue, entrySeparator)
+
+	for _, part := range parts {
+		fields := strings.SplitN(part, fieldSeparator, 2)
+		if len(fields) != 2 {
+			continue // Skip malformed entries
+		}
+
+		userID, err := uuid.FromString(fields[0])
+		if err != nil {
+			continue // Skip invalid user IDs
+		}
+
+		entries = append(entries, DeviceTrustEntry{
+			UserID:      userID,
+			DeviceToken: fields[1],
+		})
+	}
+
+	return entries
+}
+
+// SerializeDeviceTrustCookie serializes device trust entries into a composite cookie value.
+// Format: <user_id_1>:<token_1>|<user_id_2>:<token_2>|...
+func (s DeviceTrustService) SerializeDeviceTrustCookie(entries []DeviceTrustEntry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+
+	parts := make([]string, len(entries))
+	for i, entry := range entries {
+		parts[i] = entry.UserID.String() + fieldSeparator + entry.DeviceToken
+	}
+
+	return strings.Join(parts, entrySeparator)
 }

--- a/deploy/docker-compose/config.yaml
+++ b/deploy/docker-compose/config.yaml
@@ -21,6 +21,20 @@ webauthn:
 session:
   cookie:
     secure: false # is needed for safari, because safari does not store secure cookies on localhost
+# MFA configuration with multi-user device trust support
+mfa:
+  enabled: true
+  optional: true
+  acquire_on_login: false
+  acquire_on_registration: true
+  device_trust_policy: "prompt"
+  device_trust_duration: "720h"
+  device_trust_cookie_name: "hanko-device-token"
+  device_trust_max_users_per_device: 20
+  totp:
+    enabled: true
+  security_keys:
+    enabled: false
 server:
   public:
     cors:


### PR DESCRIPTION
## Problem

When multiple users trust the same device/browser, the device trust cookie (`hanko-device-token`) gets overwritten with each new trust action. This causes previous users to lose their device trust status and be required to re-enter their TOTP code on every login. It's an improvement from initial PR about trust-device implementation (https://github.com/teamhanko/hanko/pull/1982)

**Reproduction steps:**
1. User A logs in → sets up TOTP → trusts device → cookie set to `tokenA`
2. User B logs in → sets up TOTP → trusts device → cookie overwritten to `tokenB`
3. User A logs in again → cookie contains `tokenB` → MFA required (trust lost)

This is a common scenario in shared environments (family computers, shared workstations, demo environments, etc.) where multiple users need to authenticate from the same browser.

## Solution

This PR introduces a **composite cookie format** that stores multiple user tokens in a single cookie, allowing each user to maintain their own device trust independently.

**New cookie format:**
```
<user_id_1>:<token_1>|<user_id_2>:<token_2>|...
```

**Example:**
```
a1b2c3d4-e5f6-7890-abcd-ef1234567890:dGVzdHRva2VuMQ==|e5f6g7h8-i9j0-1234-klmn-op5678901234:dGVzdHRva2VuMg==
```

Fixes the device trust overwrite issue for multi-user scenarios.

# Implementation

## Changes Overview

| File | Purpose |
|------|---------|
| `backend/config/config_mfa.go` | Added `DeviceTrustMaxUsersPerDevice` config field |
| `backend/config/config_default.go` | Set default value to 20 users per device |
| `backend/flow_api/services/device_trust.go` | Core parsing/serialization logic + updated trust check |
| `backend/flow_api/flow/device_trust/hook_issue_trust_device_cookie.go` | Multi-user cookie management on trust action |
| `deploy/docker-compose/config.yaml` | Added example MFA configuration |

## Key Design Decisions

### 1. Composite Token Format
Chose `<user_id>:<token>|<user_id>:<token>` format because:
- Simple to parse with standard string operations
- Graceful degradation (malformed entries are skipped, not fatal)
- No external dependencies (vs JSON parsing)
- Human-readable for debugging

### 2. Backward Compatibility
The implementation detects and handles legacy single-token cookies:
```go
// Legacy format detection (no separators = single token)
if !strings.Contains(cookieValue, entrySeparator) && !strings.Contains(cookieValue, fieldSeparator) {
    return nil // Caller handles legacy migration
}
```

When a legacy cookie is detected:
1. The token is validated against the database as before
2. On the user's next trust action, the cookie is automatically migrated to the new format

### 3. Entry Management
- **Most recent first**: New entries are prepended to maintain recency order
- **Duplicate prevention**: Existing entries for the same user are removed before adding new one
- **Limit enforcement**: Oldest entries (at the end) are trimmed when exceeding `DeviceTrustMaxUsersPerDevice`

### 4. Configuration
New config option with sensible default:
```yaml
mfa:
  device_trust_max_users_per_device: 20  # ~100 bytes per user, 4KB cookie limit supports ~40 users
```

## Code Flow

### When checking device trust (`CheckDeviceTrust`):
```
1. Read cookie value
2. Parse into entries (or detect legacy format)
3. If legacy: validate single token against DB
4. If new format: find entry matching current user ID → validate token against DB
5. Return true if valid, unexpired token found for user
```

### When issuing trust cookie (`IssueTrustDeviceCookie`):
```
1. Generate new token for current user
2. Store token in database
3. Read existing cookie entries
4. Filter out any existing entry for current user
5. Prepend new entry
6. Enforce max users limit (trim from end)
7. Serialize and set cookie
```

# Tests

## Manual Testing Steps

### Setup
```bash
# Start Hanko with MFA enabled
docker compose -f deploy/docker-compose/quickstart.yaml -p "hanko-quickstart" up --build
```

### Test Case 1: Multi-User Device Trust
1. **User A**: Register/login → Set up TOTP → Enter code → Choose "Trust this device"
2. **User B**: Register/login → Set up TOTP → Enter code → Choose "Trust this device"
3. **User A**: Login again → Should **skip MFA** (device still trusted)
4. **User B**: Login again → Should **skip MFA** (device still trusted)
5. **Verify cookie**: Open DevTools → Application → Cookies → `hanko-device-token` should contain composite format with both user IDs

### Test Case 2: Legacy Cookie Migration
1. Manually set a legacy cookie: `hanko-device-token=<single_token_value>`
2. Login as user with that token → Should validate successfully
3. Trust device again → Cookie should migrate to new composite format

### Test Case 3: Max Users Limit
1. Set `device_trust_max_users_per_device: 2` in config
2. User A trusts device
3. User B trusts device
4. User C trusts device
5. **Verify**: User A's entry should be removed (oldest), Users B and C remain

### Test Case 4: Malformed Cookie Handling
1. Manually set malformed cookie: `hanko-device-token=invalid|data|here`
2. Login → Should gracefully handle (no crash), require MFA
3. Trust device → Should set valid new cookie


# Additional Context

## Security Considerations

| Aspect | Status |
|--------|--------|
| **Token Isolation** | ✅ Each user has their own token - cannot reuse another user's token |
| **Cookie Security** | ✅ Existing `HttpOnly`, `Secure`, `SameSite` protections unchanged |
| **User ID Exposure** | ✅ User IDs in cookie are UUIDs, already exposed in JWT |
| **Cookie Size** | ✅ ~100 bytes per user entry, 4KB browser limit supports ~40 users |
| **Malformed Data** | ✅ Invalid entries are skipped gracefully without affecting others |

## Cookie Size Analysis

```
Entry format: <UUID>:<base64_token>
UUID length: 36 characters
Token length: ~86 characters (64 bytes base64 encoded)
Separator: 1 character
Total per entry: ~124 characters

4KB cookie limit / 124 chars ≈ 32 users (conservative estimate)
Default limit of 20 provides comfortable margin
```

## Browser Compatibility

The composite cookie format uses only standard ASCII characters (alphanumeric, `-`, `=`, `|`, `:`) and is compatible with all modern browsers' cookie handling.
