### PR TITLE
feat: make elements use PKCE flow per default

### DIFF
--- a/frontend/frontend-sdk/src/index.ts
+++ b/frontend/frontend-sdk/src/index.ts
@@ -22,8 +22,20 @@ export { Relay };
 // Utils
 
 import { WebauthnSupport } from "./lib/WebauthnSupport";
+import {
+  generateCodeVerifier,
+  setStoredCodeVerifier,
+  getStoredCodeVerifier,
+  clearStoredCodeVerifier,
+} from "./lib/Pkce";
 
-export { WebauthnSupport };
+export {
+  WebauthnSupport,
+  generateCodeVerifier,
+  setStoredCodeVerifier,
+  getStoredCodeVerifier,
+  clearStoredCodeVerifier,
+};
 
 // DTO
 

--- a/frontend/frontend-sdk/src/lib/Pkce.ts
+++ b/frontend/frontend-sdk/src/lib/Pkce.ts
@@ -1,0 +1,57 @@
+const PKCE_STORAGE_KEY = "hanko_pkce_code_verifier";
+
+/**
+ * Generates a high-entropy, cryptographically strong random string for use as a PKCE code verifier.
+ * It uses rejection sampling to eliminate modulo bias, ensuring a perfectly uniform distribution
+ * across the character set recommended by RFC 7636.
+ *
+ * @returns {string} A 64-character URL-safe random string.
+ */
+export const generateCodeVerifier = (): string => {
+  const charset =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+  const n = charset.length;
+  const maxValidByte = 256 - (256 % n);
+  let result = "";
+  const requiredLength = 64;
+  const tempArray = new Uint8Array(1);
+
+  while (result.length < requiredLength) {
+    window.crypto.getRandomValues(tempArray);
+    const byte = tempArray[0];
+    if (byte < maxValidByte) {
+      result += charset.charAt(byte % n);
+    }
+  }
+  return result;
+};
+
+/**
+ * Stores the PKCE code verifier in sessionStorage.
+ * @param {string} verifier - The verifier to store.
+ */
+export const setStoredCodeVerifier = (verifier: string) => {
+  if (typeof window !== "undefined" && window.sessionStorage) {
+    window.sessionStorage.setItem(PKCE_STORAGE_KEY, verifier);
+  }
+};
+
+/**
+ * Retrieves the PKCE code verifier from sessionStorage.
+ * @returns {string | null}
+ */
+export const getStoredCodeVerifier = (): string | null => {
+  if (typeof window !== "undefined" && window.sessionStorage) {
+    return window.sessionStorage.getItem(PKCE_STORAGE_KEY);
+  }
+  return null;
+};
+
+/**
+ * Removes the PKCE code verifier from sessionStorage.
+ */
+export const clearStoredCodeVerifier = () => {
+  if (typeof window !== "undefined" && window.sessionStorage) {
+    window.sessionStorage.removeItem(PKCE_STORAGE_KEY);
+  }
+};

--- a/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
@@ -2,6 +2,7 @@ import { AutoSteps } from "./types/flow";
 import { WebauthnSupport } from "../WebauthnSupport";
 import WebauthnManager from "./WebauthnManager";
 import { CredentialCreationOptionsJSON } from "@github/webauthn-json";
+import { clearStoredCodeVerifier, getStoredCodeVerifier } from "../Pkce";
 
 // Helper function to handle WebAuthn credential creation and error handling
 // eslint-disable-next-line require-jsdoc
@@ -90,7 +91,16 @@ export const autoSteps: AutoSteps = {
 
     if (token?.length > 0) {
       updateUrl(["hanko_token"]);
-      return await state.actions.exchange_token.run({ token });
+      const verifier = getStoredCodeVerifier();
+
+      try {
+        return await state.actions.exchange_token.run({
+          token,
+          code_verifier: verifier || undefined,
+        });
+      } finally {
+        clearStoredCodeVerifier();
+      }
     }
 
     if (error?.length > 0) {


### PR DESCRIPTION
# Description:
Initiates PKCE (Proof Key for Code Exchange) by default for all third-party OAuth and token exchange actions.

# Implementation

The PR makes the following changes:

## Frontend SDK:
- Adds a PKCE utility for generating and storing code verifier.
- Updates `auto-steps.ts` to automatically retrieve and include the `code_verifier` during token exchange.

## Elements:
- Updates Login, Registration, and Profile components to generate and store a `code_verifier` before initiating OAuth redirects.
- Strict cleanup of the stored verifier in both success (after exchange) and error paths.