### PR TITLE
fix: set passcode charset to numeric by default

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -239,5 +239,10 @@ func (c *Config) PostProcess() error {
 		return fmt.Errorf("failed to post process saml settings: %w", err)
 	}
 
+	err = c.Email.PostProcess()
+	if err != nil {
+		return fmt.Errorf("failed to post process email settings: %w", err)
+	}
+
 	return nil
 }

--- a/backend/config/config_email.go
+++ b/backend/config/config_email.go
@@ -47,3 +47,11 @@ func (e *Email) Validate() error {
 	}
 	return fmt.Errorf("invalid passcode_characters: %s (allowed: 'numeric', 'alphanumeric')", e.PasscodeCharset)
 }
+
+func (e *Email) PostProcess() error {
+	if e.PasscodeCharset == "" {
+		e.PasscodeCharset = PasscodeCharsetNumeric
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

When the passcode_charset config setting is set to an empty string, it should fall back to numeric passcodes.

