### PR TITLE
fix: use 400 Bad Request for expired passcode instead of 408

### DIFF
--- a/backend/handler/passcode.go
+++ b/backend/handler/passcode.go
@@ -309,7 +309,7 @@ func (h *PasscodeHandler) Finish(c echo.Context) error {
 			if err != nil {
 				return fmt.Errorf("failed to create audit log: %w", err)
 			}
-			businessError = echo.NewHTTPError(http.StatusRequestTimeout, "passcode request timed out").SetInternal(errors.New(fmt.Sprintf("createdAt: %s -> lastVerificationTime: %s", passcode.CreatedAt, lastVerificationTime))) // TODO: maybe we should use BadRequest, because RequestTimeout might be to technical and can refer to different error
+			businessError = echo.NewHTTPError(http.StatusBadRequest, "passcode has expired").SetInternal(errors.New(fmt.Sprintf("createdAt: %s -> lastVerificationTime: %s", passcode.CreatedAt, lastVerificationTime)))
 			return nil
 		}
 


### PR DESCRIPTION
Resolves #2398

## Summary
Changed HTTP status code from 408 (Request Timeout) to 400 (Bad Request) for expired passcodes.

## Changes
- Status: `http.StatusRequestTimeout` → `http.StatusBadRequest`
- Message: "passcode request timed out" → "passcode has expired"
- Removed TODO comment

## Why?
HTTP 408 is for network/client timeouts, not application validation failures. Using 400 prevents clients from auto-retrying and correctly indicates a client error.

## Impact
- ✅ Better HTTP semantics (aligns with RFC 7231)
- ✅ No automatic retries from HTTP clients
- ✅ Clearer error handling