### PR TITLE
fix: replace context.TODO with proper timeouts in AWS KMS adapter

### DIFF
--- a/backend/crypto/jwk/aws_kms/manager.go
+++ b/backend/crypto/jwk/aws_kms/manager.go
@@ -1,7 +1,9 @@
 package aws_kms
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -17,7 +19,10 @@ type AWSKMSManager struct {
 }
 
 func NewAWSKMSManager(cfg config.KeyManagement) (*AWSKMSManager, error) {
-	adapter, err := NewAWSKMSAdapter(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	adapter, err := NewAWSKMSAdapter(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AWS KMS adapter: %w", err)
 	}


### PR DESCRIPTION
Resolves #2399

## Summary
Replaced `context.TODO()` with proper context handling in the AWS KMS adapter. Operations now have 30-second timeouts, enabling cancellation and preventing indefinite hangs.

## Changes
- `NewAWSKMSAdapter` now accepts `context.Context` parameter
- `Public()` and `Sign()` use `context.WithTimeout` internally (30s)
- `NewAWSKMSManager` creates timeout context before initialization

## Why?
`context.TODO()` is a development placeholder and shouldn't be in production:
- ❌ Operations can hang indefinitely if AWS has issues
- ❌ No cancellation support
- ❌ Breaks distributed tracing

## Impact
All AWS KMS operations now timeout after 30 seconds instead of hanging forever. The `crypto.Signer` interface is maintained for backward compatibility.

## Testing
✅ Maintains interface compatibility
✅ 30-second timeout prevents indefinite blocking