### PR TITLE
fix: remove code_verifier for linkedin

### DIFF
--- a/backend/handler/thirdparty.go
+++ b/backend/handler/thirdparty.go
@@ -146,7 +146,7 @@ func (h *ThirdPartyHandler) Callback(c echo.Context) error {
 		}
 
 		opts := []oauth2.AuthCodeOption{}
-		if state.CodeVerifier != "" {
+		if state.CodeVerifier != "" && provider.ID() != "linkedin" {
 			opts = append(opts, oauth2.VerifierOption(state.CodeVerifier))
 		}
 		oAuthToken, terr := provider.GetOAuthToken(callback.AuthCode, opts...)


### PR DESCRIPTION
# Description

Remove the `code_verifier` parameter on oauth code exchange for LinkedIn, because LinkedIN does not support PKCE on the OIDC http flows and returns an error when the `code_verifier is set.

