### PR TITLE
fix: remove duplicate key in webpack config

### DIFF
--- a/frontend/elements/webpack.config.cjs
+++ b/frontend/elements/webpack.config.cjs
@@ -40,7 +40,7 @@ module.exports = {
         type: "module",
       },
     },
-    it: {
+    nl: {
       filename: "i18n/nl.js",
       import: "./src/i18n/nl.ts",
       library: {


### PR DESCRIPTION
# Description

There's a duplicate key in `elements`' webpack config. Because of this, the Italian translation is not part of the build output. These changes match the correct key with the given files.
