### PR TITLE
fix: email creation security notification

### DIFF
--- a/backend/flow_api/flow/shared/hook_email_persist_verified_status.go
+++ b/backend/flow_api/flow/shared/hook_email_persist_verified_status.go
@@ -113,22 +113,22 @@ func (h EmailPersistVerifiedStatus) Execute(c flowpilot.HookExecutionContext) er
 		}
 	}
 
-	if deps.Cfg.SecurityNotifications.Notifications.EmailCreate.Enabled {
-		deps.SecurityNotificationService.SendNotification(deps.Tx, services.SendSecurityNotificationParams{
-			EmailAddress: user.Emails.GetPrimary().Address,
-			Template:     "email_create",
-			HttpContext:  deps.HttpContext,
-			BodyData: map[string]interface{}{
-				"NewEmailAddress": emailAddressToVerify,
-			},
-			Data: &webhook.SecurityNotificationData{
-				NewEmailAddress: emailAddressToVerify,
-			},
-			UserContext: *user,
-		})
-	}
-
 	if emailCreated {
+		if deps.Cfg.SecurityNotifications.Notifications.EmailCreate.Enabled {
+			deps.SecurityNotificationService.SendNotification(deps.Tx, services.SendSecurityNotificationParams{
+				EmailAddress: user.Emails.GetPrimary().Address,
+				Template:     "email_create",
+				HttpContext:  deps.HttpContext,
+				BodyData: map[string]interface{}{
+					"NewEmailAddress": emailAddressToVerify,
+				},
+				Data: &webhook.SecurityNotificationData{
+					NewEmailAddress: emailAddressToVerify,
+				},
+				UserContext: *user,
+			})
+		}
+
 		err = deps.AuditLogger.CreateWithConnection(
 			deps.Tx,
 			deps.HttpContext,


### PR DESCRIPTION
# Description

The modified hook runs after a passcode confirmation in flows where it is applied, but a security notification informing of the creation of an email is sent regardless of whether an email was actually created, e.g. on a simple login with passcode.

# Implementation

Relocate the `SendNotification` call to where we know an email was created.

# Additional context

Fixes only the issue from the description but I noticed errors from the `SendNotification` call are ignored and also potential nil dereferences from getting the primary email address in the changed code. Maybe we should discuss what failures for security notifications mean (error vs. log & continue vs. ?). 
