### PR TITLE
fix: add timeout to webhook trigger requests

### DIFF
--- a/backend/webhooks/webhook.go
+++ b/backend/webhooks/webhook.go
@@ -30,6 +30,7 @@ type BaseWebhook struct {
 	Logger   echo.Logger
 	Callback string
 	Events   events.Events
+	Timeout  time.Duration
 }
 
 func (bh *BaseWebhook) HasEvent(evt events.Event) bool {
@@ -57,12 +58,26 @@ func (bh *BaseWebhook) Trigger(data JobData) error {
 	}
 	request.Header.Set("Content-Type", "application/json")
 
-	client := http.Client{}
+	timeout := bh.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+
+	client := http.Client{
+		Timeout: timeout,
+	}
+
 	response, err := client.Do(request)
 	if err != nil {
 		bh.Logger.Error(fmt.Errorf("unable to execute webhook request: %w", err))
 		return err
 	}
+
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			bh.Logger.Error(fmt.Errorf("failed to close webhook response body: %w", err))
+		}
+	}()
 
 	if response.StatusCode >= http.StatusBadRequest {
 		err := fmt.Errorf("request failed due to status code: %d", response.StatusCode)

--- a/backend/webhooks/webhook_test.go
+++ b/backend/webhooks/webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/labstack/gommon/log"
 	"github.com/stretchr/testify/require"
 	"github.com/teamhanko/hanko/backend/v2/webhooks/events"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -144,4 +145,32 @@ func TestBaseWebhook_TriggerWithBadServer(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "EOF")
+}
+
+func TestBaseWebhook_TriggerTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	baseHook := BaseWebhook{
+		Logger:   log.New("test"),
+		Callback: server.URL,
+		Events:   events.Events{events.UserCreate},
+		Timeout:  20 * time.Millisecond,
+	}
+
+	data := JobData{
+		Token: "test-token",
+		Event: "user",
+	}
+
+	err := baseHook.Trigger(data)
+
+	var netErr net.Error
+
+	require.Error(t, err)
+	require.ErrorAs(t, err, &netErr)
+	require.True(t, netErr.Timeout())
 }


### PR DESCRIPTION
# Description

When an event is triggered, the webhook dispatcher sends an HTTP request using a default http.Client instance without a configured timeout.


Because the HTTP client lacks a timeout, an attacker-controlled webhook endpoint can keep the connection open indefinitely.

Each triggered webhook creates a goroutine that blocks permanently, eventually leading to:

- Goroutine exhaustion
- Memory growth
- Potential Out-of-Memory crashes

# Implementation

- Configure a `Timeout` on the client (default to 10 seconds)
- Add field to `BaseWebhook` to make it testable (we do not want tests to run for the default 10 seconds)
