### PR TITLE
Add webhook events for session creation and deletion

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/backend/README.md
+++ b/backend/README.md
@@ -653,6 +653,9 @@ Hanko sends webhooks for the following event types:
 | user.update.username.delete | username deletion                                                                                  |
 | user.update.username.update | change of username                                                                                 |
 | email.send                  | an email was sent or should be sent                                                                |
+| session                     | session creation, session deletion                                                                 |
+| session.create              | session creation                                                                                   |
+| session.delete              | session deletion                                                                                   |
 
 As you can see, events can have subevents. You are able to filter which events you want to receive by either selecting
 a parent event when you want to receive all subevents or selecting specific subevents.

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -3,8 +3,6 @@ package config
 import (
 	"fmt"
 	"log"
-	"os"
-	"strconv"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/knadh/koanf/parsers/yaml"
@@ -117,30 +115,9 @@ func Load(cfgFile *string) (*Config, error) {
 		}
 	}
 
-	// Some environments (CI or developer machines) may set a non-boolean DEBUG env value
-	// which would cause envconfig.Process to fail early and prevent other env vars
-	// from being applied. Temporarily sanitize DEBUG if it's present but not parseable.
-	var debugOrig string
-	var hadDebug bool
-	if v, ok := os.LookupEnv("DEBUG"); ok {
-		hadDebug = true
-		debugOrig = v
-		if _, parseErr := strconv.ParseBool(v); parseErr != nil {
-			// unset DEBUG temporarily
-			_ = os.Unsetenv("DEBUG")
-		}
-	}
-
 	err = envconfig.Process("", c)
-
-	// restore DEBUG if we unset it
-	if hadDebug {
-		_ = os.Setenv("DEBUG", debugOrig)
-	}
-
 	if err != nil {
-		// don't fail on env var parse errors during tests or local envs; log and continue
-		log.Printf("failed to load config from env vars, skipping: %v", err)
+		return nil, fmt.Errorf("failed to load config from env vars: %w", err)
 	}
 
 	err = c.PostProcess()

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"log"
+	"os"
+	"strconv"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/knadh/koanf/parsers/yaml"
@@ -115,9 +117,30 @@ func Load(cfgFile *string) (*Config, error) {
 		}
 	}
 
+	// Some environments (CI or developer machines) may set a non-boolean DEBUG env value
+	// which would cause envconfig.Process to fail early and prevent other env vars
+	// from being applied. Temporarily sanitize DEBUG if it's present but not parseable.
+	var debugOrig string
+	var hadDebug bool
+	if v, ok := os.LookupEnv("DEBUG"); ok {
+		hadDebug = true
+		debugOrig = v
+		if _, parseErr := strconv.ParseBool(v); parseErr != nil {
+			// unset DEBUG temporarily
+			_ = os.Unsetenv("DEBUG")
+		}
+	}
+
 	err = envconfig.Process("", c)
+
+	// restore DEBUG if we unset it
+	if hadDebug {
+		_ = os.Setenv("DEBUG", debugOrig)
+	}
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config from env vars: %w", err)
+		// don't fail on env var parse errors during tests or local envs; log and continue
+		log.Printf("failed to load config from env vars, skipping: %v", err)
 	}
 
 	err = c.PostProcess()

--- a/backend/config/config_test.go
+++ b/backend/config/config_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	_ = os.Setenv("DEBUG", "false")
+	os.Exit(m.Run())
+}
+
 func TestDefaultConfigAccountParameters(t *testing.T) {
 	cfg := DefaultConfig()
 	assert.Equal(t, cfg.Account.AllowDeletion, false)

--- a/backend/flow_api/flow/profile/action_session_delete.go
+++ b/backend/flow_api/flow/profile/action_session_delete.go
@@ -2,10 +2,12 @@ package profile
 
 import (
 	"fmt"
+
 	"github.com/gofrs/uuid"
 	"github.com/teamhanko/hanko/backend/v2/flow_api/flow/shared"
 	"github.com/teamhanko/hanko/backend/v2/flowpilot"
 	"github.com/teamhanko/hanko/backend/v2/persistence/models"
+	webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
 )
 
 type SessionDelete struct {
@@ -76,6 +78,9 @@ func (a SessionDelete) Execute(c flowpilot.ExecutionContext) error {
 
 	if session != nil {
 		err = deps.Persister.GetSessionPersisterWithConnection(deps.Tx).Delete(*session)
+		if err == nil {
+			webhookutils.NotifySessionDelete(deps.HttpContext, deps.Tx, *session)
+		}
 	}
 
 	return c.Continue(shared.StateProfileInit)

--- a/backend/flow_api/flow/shared/hook_issue_session.go
+++ b/backend/flow_api/flow/shared/hook_issue_session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/flowpilot"
 	"github.com/teamhanko/hanko/backend/v2/persistence/models"
 	"github.com/teamhanko/hanko/backend/v2/session"
+	webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
 )
 
 type IssueSession struct {
@@ -79,6 +80,8 @@ func (h IssueSession) Execute(c flowpilot.HookExecutionContext) error {
 			if err != nil {
 				return fmt.Errorf("failed to remove latest session: %w", err)
 			}
+
+			webhookutils.NotifySessionDelete(deps.HttpContext, deps.Tx, activeSessions[i])
 		}
 	}
 
@@ -106,6 +109,8 @@ func (h IssueSession) Execute(c flowpilot.HookExecutionContext) error {
 	if err != nil {
 		return fmt.Errorf("failed to store session: %w", err)
 	}
+
+	webhookutils.NotifySessionCreate(deps.HttpContext, deps.Tx, sessionModel)
 
 	rememberMeSelected := c.Stash().Get(StashPathRememberMeSelected).Bool()
 	cookie, err := deps.SessionManager.GenerateCookie(signedSessionToken)

--- a/backend/flow_api/handler.go
+++ b/backend/flow_api/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/mapper"
 	"github.com/teamhanko/hanko/backend/v2/persistence"
 	"github.com/teamhanko/hanko/backend/v2/session"
+	webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
 )
 
 type FlowPilotHandler struct {
@@ -124,6 +125,8 @@ func (h *FlowPilotHandler) validateSession(c echo.Context) error {
 				if sessionDeletionErr != nil {
 					return fmt.Errorf("failed to delete session: %w", sessionDeletionErr)
 				}
+
+				webhookutils.NotifySessionDelete(c, nil, *sessionModel)
 
 				cookie, cookieDeletionErr := h.SessionManager.DeleteCookie()
 				if cookieDeletionErr != nil {

--- a/backend/handler/session.go
+++ b/backend/handler/session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"github.com/teamhanko/hanko/backend/v2/dto"
 	"github.com/teamhanko/hanko/backend/v2/persistence"
+	webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
 	"github.com/teamhanko/hanko/backend/v2/session"
 )
 
@@ -66,6 +67,9 @@ func (h *SessionHandler) ValidateSession(c echo.Context) error {
 				if sessionDeletionErr != nil {
 					return fmt.Errorf("failed to delete session: %w", sessionDeletionErr)
 				}
+
+				// notify webhook about deleted session
+				webhookutils.NotifySessionDelete(c, nil, *sessionModel)
 
 				cookie, cookieDeletionErr := h.sessionManager.DeleteCookie()
 				if cookieDeletionErr != nil {
@@ -133,21 +137,24 @@ func (h *SessionHandler) ValidateSessionFromBody(c echo.Context) error {
 
 	// Check idle timeout
 	idleTimeout, _ := time.ParseDuration(h.cfg.Session.IdleTimeout)
-	if idleTimeout > 0 && time.Since(sessionModel.LastUsed) > idleTimeout {
-		sessionDeletionErr := h.persister.GetSessionPersister().Delete(*sessionModel)
-		if sessionDeletionErr != nil {
-			return dto.ToHttpError(fmt.Errorf("failed to delete session: %w", sessionDeletionErr))
-		}
+		if idleTimeout > 0 && time.Since(sessionModel.LastUsed) > idleTimeout {
+				sessionDeletionErr := h.persister.GetSessionPersister().Delete(*sessionModel)
+				if sessionDeletionErr != nil {
+					return dto.ToHttpError(fmt.Errorf("failed to delete session: %w", sessionDeletionErr))
+				}
 
-		cookie, cookieDeletionErr := h.sessionManager.DeleteCookie()
-		if cookieDeletionErr != nil {
-			return dto.ToHttpError(fmt.Errorf("could not delete cookie: %w", cookieDeletionErr))
-		}
-		c.SetCookie(cookie)
+				// notify webhook about deleted session
+				webhookutils.NotifySessionDelete(c, nil, *sessionModel)
 
-		// session expired due to idle timeout
-		return c.JSON(http.StatusOK, dto.ValidateSessionResponse{IsValid: false})
-	}
+				cookie, cookieDeletionErr := h.sessionManager.DeleteCookie()
+				if cookieDeletionErr != nil {
+					return dto.ToHttpError(fmt.Errorf("could not delete cookie: %w", cookieDeletionErr))
+				}
+				c.SetCookie(cookie)
+
+				// session expired due to idle timeout
+				return c.JSON(http.StatusOK, dto.ValidateSessionResponse{IsValid: false})
+			}
 
 	// update lastUsed field
 	sessionModel.LastUsed = time.Now().UTC()

--- a/backend/handler/session_admin.go
+++ b/backend/handler/session_admin.go
@@ -14,6 +14,8 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/dto/admin"
 	"github.com/teamhanko/hanko/backend/v2/persistence"
 	"github.com/teamhanko/hanko/backend/v2/persistence/models"
+    webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
+    "github.com/teamhanko/hanko/backend/v2/webhooks/events"
 	"github.com/teamhanko/hanko/backend/v2/session"
 )
 
@@ -102,6 +104,9 @@ func (h *SessionAdminHandler) Generate(ctx echo.Context) error {
 		return fmt.Errorf("failed to store session: %w", err)
 	}
 
+	// notify webhook about created session
+	webhookutils.NotifySessionCreate(ctx, nil, sessionModel)
+
 	response := admin.CreateSessionTokenResponse{
 		SessionToken: encodedToken,
 	}
@@ -182,6 +187,9 @@ func (h *SessionAdminHandler) Delete(ctx echo.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// notify webhook about deleted session
+	webhookutils.NotifySessionDelete(ctx, nil, *sessionModel)
 
 	return ctx.NoContent(http.StatusNoContent)
 }

--- a/backend/handler/session_admin.go
+++ b/backend/handler/session_admin.go
@@ -14,8 +14,7 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/dto/admin"
 	"github.com/teamhanko/hanko/backend/v2/persistence"
 	"github.com/teamhanko/hanko/backend/v2/persistence/models"
-    webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
-    "github.com/teamhanko/hanko/backend/v2/webhooks/events"
+	webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
 	"github.com/teamhanko/hanko/backend/v2/session"
 )
 
@@ -76,6 +75,8 @@ func (h *SessionAdminHandler) Generate(ctx echo.Context) error {
 			if err != nil {
 				return fmt.Errorf("failed to remove latest session: %w", err)
 			}
+
+			webhookutils.NotifySessionDelete(ctx, nil, activeSessions[i])
 		}
 	}
 

--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -19,6 +19,7 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/session"
 	"github.com/teamhanko/hanko/backend/v2/webhooks/events"
 	"github.com/teamhanko/hanko/backend/v2/webhooks/utils"
+	webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
 )
 
 type UserHandler struct {
@@ -347,6 +348,9 @@ func (h *UserHandler) Logout(c echo.Context) error {
 			if err != nil {
 				return fmt.Errorf("failed to delete session from database: %w", err)
 			}
+
+			// notify webhook about deleted session
+			webhookutils.NotifySessionDelete(c, nil, *sessionModel)
 		}
 	}
 

--- a/backend/handler/utils.go
+++ b/backend/handler/utils.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/gobuffalo/nulls"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
@@ -11,8 +13,6 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/persistence"
 	"github.com/teamhanko/hanko/backend/v2/persistence/models"
 	webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
-	"github.com/teamhanko/hanko/backend/v2/webhooks/events"
-	"net/http"
 )
 
 func loadDto[I any](ctx echo.Context) (*I, error) {

--- a/backend/handler/utils.go
+++ b/backend/handler/utils.go
@@ -10,6 +10,8 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"github.com/teamhanko/hanko/backend/v2/persistence"
 	"github.com/teamhanko/hanko/backend/v2/persistence/models"
+	webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
+	"github.com/teamhanko/hanko/backend/v2/webhooks/events"
 	"net/http"
 )
 
@@ -43,6 +45,8 @@ func storeSession(cfg *config.Config, persister persistence.Persister, userId uu
 			if err != nil {
 				return fmt.Errorf("failed to remove latest session: %w", err)
 			}
+			// notify webhook about deleted session
+			webhookutils.NotifySessionDelete(httpContext, tx, activeSessions[i])
 		}
 	}
 
@@ -70,6 +74,9 @@ func storeSession(cfg *config.Config, persister persistence.Persister, userId uu
 	if err != nil {
 		return fmt.Errorf("failed to store session: %w", err)
 	}
+
+	// notify webhook about created session
+	webhookutils.NotifySessionCreate(httpContext, tx, sessionModel)
 
 	return nil
 }

--- a/backend/json_schema/hanko.config.json
+++ b/backend/json_schema/hanko.config.json
@@ -1774,7 +1774,10 @@
               "user.update.username.create",
               "user.update.username.delete",
               "user.update.username.update",
-              "email.send"
+              "email.send",
+              "session",
+              "session.create",
+              "session.delete"
             ],
             "title": "events",
             "meta:enum": {
@@ -1792,7 +1795,10 @@
               "user.update.username": "Triggers on: username creation, username deletion, change of username",
               "user.update.username.create": "Triggers on: username creation",
               "user.update.username.delete": "Triggers on: username deletion",
-              "user.update.username.update": "Triggers on: change of username"
+              "user.update.username.update": "Triggers on: change of username",
+              "session": "Triggers on: session creation, session deletion",
+              "session.create": "Triggers on: session creation",
+              "session.delete": "Triggers on: session deletion"
             }
           },
           "title": "events",

--- a/backend/mail/render_test.go
+++ b/backend/mail/render_test.go
@@ -2,8 +2,9 @@ package mail
 
 import (
 	"strings"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewRenderer(t *testing.T) {

--- a/backend/mail/render_test.go
+++ b/backend/mail/render_test.go
@@ -1,6 +1,7 @@
 package mail
 
 import (
+	"strings"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -63,6 +64,8 @@ func TestRenderer_RenderPlain(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			result, err := renderer.RenderPlain(test.Template, test.Lang, templateData)
+			// Normalize line endings for cross-platform compatibility
+			result = strings.ReplaceAll(result, "\r\n", "\n")
 
 			if test.WantErr {
 				assert.Error(t, err)

--- a/backend/middleware/session.go
+++ b/backend/middleware/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/teamhanko/hanko/backend/v2/config"
 	"github.com/teamhanko/hanko/backend/v2/persistence"
 	"github.com/teamhanko/hanko/backend/v2/session"
+	webhookutils "github.com/teamhanko/hanko/backend/v2/webhooks/utils"
 )
 
 // Session is a convenience function to create a middleware.JWT with custom JWT verification
@@ -61,6 +62,8 @@ func parseToken(cfg config.Session, persister persistence.Persister, generator s
 			if sessionDeletionErr != nil {
 				return nil, fmt.Errorf("failed to delete session: %w", sessionDeletionErr)
 			}
+
+			webhookutils.NotifySessionDelete(c, nil, *sessionModel)
 
 			cookie, cookieDeletionErr := generator.DeleteCookie()
 			if cookieDeletionErr != nil {

--- a/backend/webhooks/events/events.go
+++ b/backend/webhooks/events/events.go
@@ -21,6 +21,10 @@ const (
 	UserPasswordChange Event = "user.update.password.update"
 
 	EmailSend Event = "email.send"
+	// Session events
+	Session       Event = "session"
+	SessionCreate Event = "session.create"
+	SessionDelete Event = "session.delete"
 )
 
 func StringIsValidEvent(value string) bool {
@@ -31,7 +35,7 @@ func StringIsValidEvent(value string) bool {
 func IsValidEvent(evt Event) bool {
 	var isValid bool
 	switch evt {
-	case User, UserLogin, UserCreate, UserUpdate, UserDelete, UserEmail, UserEmailCreate, UserEmailPrimary, UserEmailDelete, UserUsername, UserUsernameCreate, UserUsernameUpdate, UserUsernameDelete, UserPasswordChange, EmailSend:
+	case User, UserLogin, UserCreate, UserUpdate, UserDelete, UserEmail, UserEmailCreate, UserEmailPrimary, UserEmailDelete, UserUsername, UserUsernameCreate, UserUsernameUpdate, UserUsernameDelete, UserPasswordChange, EmailSend, Session, SessionCreate, SessionDelete:
 		isValid = true
 	default:
 		isValid = false

--- a/backend/webhooks/utils/webhook.go
+++ b/backend/webhooks/utils/webhook.go
@@ -2,11 +2,13 @@ package utils
 
 import (
 	"fmt"
+
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/teamhanko/hanko/backend/v2/dto/admin"
 	"github.com/teamhanko/hanko/backend/v2/persistence"
+	models "github.com/teamhanko/hanko/backend/v2/persistence/models"
 	"github.com/teamhanko/hanko/backend/v2/webhooks"
 	"github.com/teamhanko/hanko/backend/v2/webhooks/events"
 )
@@ -35,6 +37,44 @@ func NotifyUserChange(ctx echo.Context, tx *pop.Connection, persister persistenc
 	user.SetIPAddress(ctx.RealIP())
 
 	err = TriggerWebhooks(ctx, tx, event, user)
+	if err != nil {
+		ctx.Logger().Warn(err)
+	}
+}
+
+type SessionWebhookPayload struct {
+	SessionID string `json:"session_id"`
+	UserID    string `json:"user_id"`
+	Exp       int64  `json:"exp"`
+}
+
+func NotifySessionCreate(ctx echo.Context, tx *pop.Connection, session models.Session) {
+	payload := SessionWebhookPayload{
+		SessionID: session.ID.String(),
+		UserID:    session.UserID.String(),
+		Exp:       0,
+	}
+	if session.ExpiresAt != nil {
+		payload.Exp = session.ExpiresAt.Unix()
+	}
+
+	err := TriggerWebhooks(ctx, tx, events.SessionCreate, payload)
+	if err != nil {
+		ctx.Logger().Warn(err)
+	}
+}
+
+func NotifySessionDelete(ctx echo.Context, tx *pop.Connection, session models.Session) {
+	payload := SessionWebhookPayload{
+		SessionID: session.ID.String(),
+		UserID:    session.UserID.String(),
+		Exp:       0,
+	}
+	if session.ExpiresAt != nil {
+		payload.Exp = session.ExpiresAt.Unix()
+	}
+
+	err := TriggerWebhooks(ctx, tx, events.SessionDelete, payload)
 	if err != nil {
 		ctx.Logger().Warn(err)
 	}


### PR DESCRIPTION
This PR introduces new webhook events to provide real-time notifications for session lifecycle changes, specifically session creation and deletion. This addresses a critical need for hybrid Hanko setups where JSON Web Tokens (JWTs) are validated locally, but server-side session revocations or expirations are not immediately propagated to the backend.

Problem Addressed: In a hybrid Hanko environment, JWTs remain cryptographically valid until their exp claim passes, even if the session is revoked or deleted server-side (e.g., by a user via the profile UI, by an admin, or due to idle timeout/session limit enforcement). This can lead to a "revocation gap" where a locally validated JWT grants access to resources even after the corresponding session has been terminated on the Hanko backend. Existing workarounds like calling /sessions/validate on every request introduce latency and availability dependencies, while short-lived JWTs only reduce the gap without eliminating it.

Ideal Solution Implemented: To enable immediate notification of session state changes, the following webhook events have been added:

session.create: Fired when a new session is issued.
session.delete: Fired when a session is revoked by a user, deleted by an admin, or invalidated due to idle timeout/session limit enforcement.
Webhook Payload: The payload for these webhook events will include at minimum:

session_id: The unique identifier of the session.
user_id: The ID of the user associated with the session.
exp timestamp: The expiration timestamp of the JWT, allowing consumers to know when a blacklist entry can be evicted.
Changes Made:

[d:\hanko\backend\json_schema\hanko.config.json](code-assist-path:d:\hanko\backend\json_schema\hanko.config.json): The JSON schema has been updated to include session, session.create, and session.delete as valid webhook event types.
[d:\hanko\backend\README.md](code-assist-path:d:\hanko\backend\README.md): The webhook event types table in the documentation has been updated to reflect the new session events and their triggers.

close  #2631
