### PR TITLE
feat: firebase scrypt compatibility

### DIFF
--- a/backend/cmd/user/convert.go
+++ b/backend/cmd/user/convert.go
@@ -1,0 +1,15 @@
+package user
+
+import "github.com/spf13/cobra"
+
+func NewConvertCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert",
+		Short: "Utilities for converting external user data to Hanko import data",
+		Long:  ``,
+	}
+
+	cmd.AddCommand(NewFirebaseCommand())
+
+	return cmd
+}

--- a/backend/cmd/user/firebase.go
+++ b/backend/cmd/user/firebase.go
@@ -401,33 +401,43 @@ func writer(
 
 func convertUser(u FirebaseUser, cfg FirebaseHashConfig) (ImportOrExportEntry, error) {
 
-	createdAt, _ := parseTime(u.CreatedAt)
-	updatedAt, _ := parseTime(u.UpdatedAt)
+	if u.Email == "" && u.PasswordHash != "" {
+		// If both are missing, there is no way to authenticate the user, unless some other credential/factor
+		// is manually added after the firebase -> hanko user conversion. This feels unlikely, so we count this
+		// as a failure.
+		return ImportOrExportEntry{}, fmt.Errorf("email and passwordHash missing for Firebase user with localId '%s'", u.LocalID)
+	}
 
 	fscryptString, err := buildFbscryptString(u, cfg)
 	if err != nil {
 		return ImportOrExportEntry{}, err
 	}
 
-	convertedEntry := ImportOrExportEntry{
-		Emails: []ImportOrExportEmail{
+	convertedEntry := ImportOrExportEntry{}
+
+	if u.Email != "" {
+		convertedEntry.Emails = []ImportOrExportEmail{
 			{
 				Address:    u.Email,
-				IsPrimary:  true, // we assume imported users are new users, so we set it primary
-				IsVerified: u.EmailVerified,
+				IsPrimary:  true,            // we assume imported users are new users, so we set it primary
+				IsVerified: u.EmailVerified, // if not returned by the firebase export we accept that it zeros to false
 			},
-		},
-		Password: &ImportPasswordCredential{
-			Password: fscryptString,
-		},
-		CreatedAt: createdAt,
-		UpdatedAt: updatedAt,
+		}
 	}
 
-	if u.PasswordHash == "" {
+	if u.PasswordHash != "" {
+		convertedEntry.Password = &ImportPasswordCredential{
+			Password: fscryptString,
+		}
+	} else {
 		log.Printf("[WARN] no password given for Firebase user with localId '%s', converting anyway\n", u.LocalID)
-		convertedEntry.Password = nil
 	}
+
+	createdAt, _ := parseTime(u.CreatedAt)
+	updatedAt, _ := parseTime(u.UpdatedAt)
+
+	convertedEntry.CreatedAt = createdAt
+	convertedEntry.UpdatedAt = updatedAt
 
 	err = convertedEntry.validate(v)
 	if err != nil {

--- a/backend/cmd/user/firebase.go
+++ b/backend/cmd/user/firebase.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -35,6 +36,30 @@ type FirebaseHashConfig struct {
 	Base64SaltSeparator string `json:"base64_salt_separator"`
 	Rounds              int    `json:"rounds"`
 	MemCost             int    `json:"mem_cost"`
+}
+
+func (f *FirebaseHashConfig) Validate() error {
+	if f.Algorithm != "SCRYPT" {
+		return errors.New("crypto: invalid algorithm")
+	}
+
+	if f.Base64SignerKey == "" {
+		return errors.New("crypto: invalid base64_signer_key")
+	}
+
+	if f.Base64SaltSeparator == "" {
+		return errors.New("crypto: invalid base64_salt_separator")
+	}
+
+	if f.MemCost <= 0 {
+		return errors.New("crypto: invalid memCost (scrypt 'n') <= 0")
+	}
+
+	if f.Rounds <= 0 {
+		return errors.New("crypto: invalid rounds (scrypt 'r') <= 0")
+	}
+
+	return nil
 }
 
 type result struct {
@@ -104,12 +129,12 @@ func run(opts *options) error {
 
 	cfg, err := loadFirebaseConfig(opts.configFile)
 	if err != nil {
-		return fmt.Errorf("config: %w", err)
+		return fmt.Errorf("firebase hash config: %w", err)
 	}
 
 	inFile, err := os.Open(opts.inputFile)
 	if err != nil {
-		return fmt.Errorf("input: %w", err)
+		return fmt.Errorf("firebase user input: %w", err)
 	}
 	defer inFile.Close()
 
@@ -481,6 +506,16 @@ func loadFirebaseConfig(path string) (FirebaseHashConfig, error) {
 
 	var cfg FirebaseHashConfig
 	err = json.Unmarshal(b, &cfg)
+
+	if err != nil {
+		return FirebaseHashConfig{}, err
+	}
+
+	// Validate and possibly fail early since the config is declared as param in multiple functions
+	if err = cfg.Validate(); err != nil {
+		return FirebaseHashConfig{}, err
+	}
+
 	return cfg, err
 }
 

--- a/backend/cmd/user/firebase.go
+++ b/backend/cmd/user/firebase.go
@@ -409,10 +409,6 @@ func convertUser(u FirebaseUser, cfg FirebaseHashConfig) (ImportOrExportEntry, e
 		return ImportOrExportEntry{}, err
 	}
 
-	if u.PasswordHash == "" {
-		log.Printf("[WARN] no password given for Firebase user with localId '%s', converting anyway\n", u.LocalID)
-	}
-
 	convertedEntry := ImportOrExportEntry{
 		Emails: []ImportOrExportEmail{
 			{
@@ -426,6 +422,11 @@ func convertUser(u FirebaseUser, cfg FirebaseHashConfig) (ImportOrExportEntry, e
 		},
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
+	}
+
+	if u.PasswordHash == "" {
+		log.Printf("[WARN] no password given for Firebase user with localId '%s', converting anyway\n", u.LocalID)
+		convertedEntry.Password = nil
 	}
 
 	err = convertedEntry.validate(v)

--- a/backend/cmd/user/firebase.go
+++ b/backend/cmd/user/firebase.go
@@ -1,0 +1,491 @@
+package user
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/spf13/cobra"
+)
+
+// ======================================================
+// MODELS
+// ======================================================
+
+type FirebaseUser struct {
+	LocalID       string `json:"localId"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"emailVerified"`
+	PasswordHash  string `json:"passwordHash"`
+	Salt          string `json:"salt"`
+	CreatedAt     string `json:"createdAt"`
+	UpdatedAt     string `json:"lastLoginAt"`
+}
+
+type FirebaseHashConfig struct {
+	Algorithm           string `json:"algorithm"`
+	Base64SignerKey     string `json:"base64_signer_key"`
+	Base64SaltSeparator string `json:"base64_salt_separator"`
+	Rounds              int    `json:"rounds"`
+	MemCost             int    `json:"mem_cost"`
+}
+
+type result struct {
+	entry ImportOrExportEntry
+	raw   FirebaseUser
+	err   error
+}
+
+type dlqEntry struct {
+	Error string       `json:"error"`
+	User  FirebaseUser `json:"user"`
+}
+
+type writerReport struct {
+	Written int
+	Failed  int
+}
+
+// ======================================================
+// CLI
+// ======================================================
+
+type options struct {
+	inputFile  string
+	configFile string
+	outputFile string
+	dlqFile    string
+	workers    int
+}
+
+func NewFirebaseCommand() *cobra.Command {
+	opts := &options{
+		outputFile: "hanko-import.json",
+		dlqFile:    "firebase-dlq.jsonl",
+		workers:    runtime.NumCPU(),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "firebase",
+		Short: "Convert user data exported via Firebase CLI to Hanko import data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.inputFile, "input", "", "input file")
+	cmd.Flags().StringVar(&opts.configFile, "config", "", "config file")
+	cmd.Flags().StringVar(&opts.outputFile, "output", opts.outputFile, "output file")
+	cmd.Flags().StringVar(&opts.dlqFile, "dlq", opts.dlqFile, "dlq file")
+	cmd.Flags().IntVar(&opts.workers, "workers", opts.workers, "workers")
+
+	_ = cmd.MarkFlagRequired("input")
+	_ = cmd.MarkFlagRequired("config")
+
+	return cmd
+}
+
+var v = validator.New()
+
+// ======================================================
+// MAIN
+// ======================================================
+
+func run(opts *options) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg, err := loadFirebaseConfig(opts.configFile)
+	if err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+
+	inFile, err := os.Open(opts.inputFile)
+	if err != nil {
+		return fmt.Errorf("input: %w", err)
+	}
+	defer inFile.Close()
+
+	tmpFile, err := os.CreateTemp("", "firebase-*.ndjson")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	tmpWriter := bufio.NewWriter(tmpFile)
+
+	dlqFile, err := os.Create(opts.dlqFile)
+	if err != nil {
+		return fmt.Errorf("dlq: %w", err)
+	}
+	defer dlqFile.Close()
+
+	dlqWriter := bufio.NewWriter(dlqFile)
+
+	jobs := make(chan FirebaseUser, opts.workers*2)
+	results := make(chan result, opts.workers*2)
+
+	// -----------------------------
+	// WORKERS
+	// -----------------------------
+	var wg sync.WaitGroup
+
+	for i := 0; i < opts.workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			worker(ctx, cfg, jobs, results)
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// -----------------------------
+	// STREAM INPUT
+	// -----------------------------
+	streamErr := make(chan error, 1)
+
+	go func() {
+		defer close(jobs)
+		streamErr <- stream(ctx, inFile, jobs)
+	}()
+
+	if err := <-streamErr; err != nil {
+		cancel()
+		return fmt.Errorf("stream: %w", err)
+	}
+
+	// -----------------------------
+	// WRITER
+	// -----------------------------
+	report, err := writer(
+		ctx,
+		tmpWriter,
+		dlqWriter,
+		results,
+	)
+	if err != nil {
+		return fmt.Errorf("writer failed: %w", err)
+	}
+
+	if report.Written == 0 {
+		return fmt.Errorf("could not convert any users, no output file written, number of failed entries that went to DLQ=%d)", report.Failed)
+	}
+
+	// -----------------------------
+	// FINALIZE JSON ARRAY
+	// -----------------------------
+
+	if err := tmpWriter.Flush(); err != nil {
+		return err
+	}
+	if err := dlqWriter.Flush(); err != nil {
+		return err
+	}
+
+	outFile, err := os.Create(opts.outputFile)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	outWriter := bufio.NewWriter(outFile)
+
+	if _, err := outWriter.WriteString("[\n"); err != nil {
+		return err
+	}
+
+	// rewind temp file
+	if _, err := tmpFile.Seek(0, 0); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(tmpFile)
+
+	first := true
+	for scanner.Scan() {
+		if !first {
+			outWriter.WriteString(",\n")
+		}
+		first = false
+
+		outWriter.Write(scanner.Bytes())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	if _, err := outWriter.WriteString("\n]\n"); err != nil {
+		return err
+	}
+
+	if err := outWriter.Flush(); err != nil {
+		return err
+	}
+
+	if report.Failed > 0 {
+		log.Printf("conversion completed with partial failures: written=%d failed=%d\n", report.Written, report.Failed)
+	} else {
+		log.Printf("conversion completed: written=%d failed=%d\n", report.Written, report.Failed)
+	}
+
+	return nil
+}
+
+// ======================================================
+// STREAMING INPUT
+// ======================================================
+
+func stream(ctx context.Context, in *os.File, jobs chan<- FirebaseUser) error {
+	dec := json.NewDecoder(bufio.NewReader(in))
+
+	_, err := dec.Token() // {
+	if err != nil {
+		return err
+	}
+
+	for dec.More() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		t, err := dec.Token()
+		if err != nil {
+			return err
+		}
+
+		if t.(string) != "users" {
+			var discard any
+			_ = dec.Decode(&discard)
+			continue
+		}
+
+		_, err = dec.Token() // [
+		if err != nil {
+			return err
+		}
+
+		for dec.More() {
+			var u FirebaseUser
+			if err := dec.Decode(&u); err != nil {
+				return err
+			}
+
+			jobs <- u
+		}
+
+		_, err = dec.Token() // ]
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = dec.Token() // }
+	return err
+}
+
+// ======================================================
+// WORKER
+// ======================================================
+
+func worker(ctx context.Context, cfg FirebaseHashConfig, jobs <-chan FirebaseUser, results chan<- result) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case u, ok := <-jobs:
+			if !ok {
+				return
+			}
+
+			entry, err := convertUser(u, cfg)
+
+			select {
+			case results <- result{entry: entry, raw: u, err: err}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// ======================================================
+// WRITER
+// ======================================================
+
+func writer(
+	ctx context.Context,
+	w *bufio.Writer,
+	dlq *bufio.Writer,
+	results <-chan result,
+) (writerReport, error) {
+
+	var written, failed int
+
+	for {
+		select {
+
+		case <-ctx.Done():
+			return writerReport{written, failed},
+				ctx.Err()
+
+		case r, ok := <-results:
+			if !ok {
+				if err := w.Flush(); err != nil {
+					return writerReport{written, failed}, err
+				}
+				if err := dlq.Flush(); err != nil {
+					return writerReport{written, failed}, err
+				}
+
+				return writerReport{written, failed}, nil
+			}
+
+			// -------------------------
+			// DLQ FOR FAILED ENTRIES
+			// -------------------------
+			if r.err != nil {
+				failed++
+
+				b, err := json.Marshal(dlqEntry{
+					User:  r.raw,
+					Error: r.err.Error(),
+				})
+				if err != nil {
+					return writerReport{written, failed}, err
+				}
+
+				if _, err := dlq.Write(b); err != nil {
+					return writerReport{written, failed}, err
+				}
+				dlq.WriteByte('\n')
+				continue
+			}
+
+			// -------------------------
+			// SUCCESS → NDJSON
+			// -------------------------
+			written++
+
+			b, err := json.Marshal(r.entry)
+			if err != nil {
+				return writerReport{written, failed}, err
+			}
+
+			if _, err := w.Write(b); err != nil {
+				return writerReport{written, failed}, err
+			}
+			w.WriteByte('\n')
+		}
+	}
+}
+
+// ======================================================
+// TRANSFORM
+// ======================================================
+
+func convertUser(u FirebaseUser, cfg FirebaseHashConfig) (ImportOrExportEntry, error) {
+
+	createdAt, _ := parseTime(u.CreatedAt)
+	updatedAt, _ := parseTime(u.UpdatedAt)
+
+	fscryptString, err := buildFbscryptString(u, cfg)
+	if err != nil {
+		return ImportOrExportEntry{}, err
+	}
+
+	if u.PasswordHash == "" {
+		log.Printf("[WARN] no password given for Firebase user with localId '%s', converting anyway\n", u.LocalID)
+	}
+
+	convertedEntry := ImportOrExportEntry{
+		Emails: []ImportOrExportEmail{
+			{
+				Address:    u.Email,
+				IsPrimary:  true, // we assume imported users are new users, so we set it primary
+				IsVerified: u.EmailVerified,
+			},
+		},
+		Password: &ImportPasswordCredential{
+			Password: fscryptString,
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+
+	err = convertedEntry.validate(v)
+	if err != nil {
+		return ImportOrExportEntry{}, err
+	}
+
+	return convertedEntry, nil
+}
+
+// ======================================================
+// FIREBASE STRING (PARAMETERS INCL. PASSWORD HASH)
+// ======================================================
+
+func buildFbscryptString(u FirebaseUser, cfg FirebaseHashConfig) (string, error) {
+	meta := fmt.Sprintf(
+		"v=1,n=%d,r=%d,p=%d,ss=%s,sk=%s",
+		cfg.MemCost,
+		cfg.Rounds,
+		1,
+		cfg.Base64SaltSeparator,
+		cfg.Base64SignerKey,
+	)
+
+	return fmt.Sprintf(
+		"$fbscrypt$%s$%s$%s",
+		meta,
+		u.Salt,
+		u.PasswordHash,
+	), nil
+}
+
+// ======================================================
+// CONFIG
+// ======================================================
+
+func loadFirebaseConfig(path string) (FirebaseHashConfig, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return FirebaseHashConfig{}, err
+	}
+
+	var cfg FirebaseHashConfig
+	err = json.Unmarshal(b, &cfg)
+	return cfg, err
+}
+
+// ======================================================
+// HELPERS
+// ======================================================
+
+func parseTime(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	t, err := time.Parse(time.RFC3339, s)
+	if err == nil {
+		return &t, nil
+	}
+
+	return nil, nil
+}

--- a/backend/cmd/user/firebase.go
+++ b/backend/cmd/user/firebase.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"runtime"
 	"sync"
@@ -51,8 +52,15 @@ func (f *FirebaseHashConfig) Validate() error {
 		return errors.New("crypto: invalid base64_salt_separator")
 	}
 
-	if f.MemCost <= 0 {
-		return errors.New("crypto: invalid memCost (scrypt 'n') <= 0")
+	// Firebase computes N as 2^memCost; ensure N fits in int, so we can fail early
+	if f.MemCost <= 0 || f.MemCost >= 63 {
+		return errors.New("crypto: invalid memCost, must be between 1 and 62")
+	}
+
+	n64 := uint64(1) << f.MemCost
+
+	if n64 > uint64(math.MaxInt) {
+		return errors.New("crypto: memCost (N) does not fit in int")
 	}
 
 	if f.Rounds <= 0 {

--- a/backend/cmd/user/format.go
+++ b/backend/cmd/user/format.go
@@ -3,10 +3,12 @@ package user
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/gofrs/uuid"
 	"github.com/invopop/jsonschema"
-	"time"
 )
 
 // ImportOrExportEmail The import/export format for a user's email
@@ -62,7 +64,7 @@ type ImportWebauthnCredentials []ImportWebauthnCredential
 
 type ImportPasswordCredential struct {
 	// Password hash of the password in bcrypt format.
-	Password string `json:"password" yaml:"password" validate:"required,startswith=$2a$"`
+	Password string `json:"password" yaml:"password" validate:"required"`
 	// CreatedAt optional timestamp when the password was created. Will be set to the import date if not provided.
 	CreatedAt *time.Time `json:"created_at,omitempty" yaml:"created_at" validate:"omitempty"`
 	// UpdatedAt optional timestamp of the last update to the password. Will be set to the import date if not provided.
@@ -156,6 +158,12 @@ func (entry *ImportOrExportEntry) validate(v *validator.Validate) error {
 
 	if len(entry.Emails) > 0 && primaryEmailAddresses != 1 {
 		return errors.New(fmt.Sprintf("Need exactly one primary email, got %v", primaryEmailAddresses))
+	}
+
+	if entry.Password != nil && entry.Password.Password != "" {
+		if !strings.HasPrefix(entry.Password.Password, "$2a$") && !strings.HasPrefix(entry.Password.Password, "$fbscrypt$") {
+			return errors.New("password must be in bcrypt or firebase scrypt format")
+		}
 	}
 
 	return nil

--- a/backend/cmd/user/format.go
+++ b/backend/cmd/user/format.go
@@ -91,9 +91,9 @@ type ImportOrExportEntry struct {
 	// WebauthnCredentials optional list of WebAuthn credentials of a user. Includes passkeys and MFA credentials.
 	WebauthnCredentials ImportWebauthnCredentials `json:"webauthn_credentials,omitempty" yaml:"webauthn_credentials" validate:"omitempty,unique=ID,dive"`
 	// Password optional password.
-	Password *ImportPasswordCredential `json:"password" yaml:"password" validate:"omitempty"`
+	Password *ImportPasswordCredential `json:"password,omitempty" yaml:"password" validate:"omitempty"`
 	// OTPSecret optional TOTP secret for MFA.
-	OTPSecret *ImportOTPSecret `json:"otp_secret" yaml:"otp_secret" validate:"omitempty"`
+	OTPSecret *ImportOTPSecret `json:"otp_secret,omitempty" yaml:"otp_secret" validate:"omitempty"`
 	// CreatedAt optional timestamp of the users' creation. Will be set to the import date if not provided.
 	CreatedAt *time.Time `json:"created_at,omitempty" yaml:"created_at" validate:"omitempty"`
 	// UpdatedAt optional timestamp of the last update to the user. Will be set to the import date if not provided.

--- a/backend/cmd/user/root.go
+++ b/backend/cmd/user/root.go
@@ -18,4 +18,5 @@ func RegisterCommands(parent *cobra.Command) {
 	command.AddCommand(NewImportCommand())
 	command.AddCommand(NewGenerateCommand())
 	command.AddCommand(NewExportCommand())
+	command.AddCommand(NewConvertCommand())
 }

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -48,7 +48,7 @@ type FirebaseScryptHashInput struct {
 	v             string
 	memory        uint64
 	rounds        uint64
-	threads       uint64
+	parallelism   uint64
 	saltSeparator []byte
 	signerKey     []byte
 	salt          []byte
@@ -200,11 +200,11 @@ func ParseFirebaseScryptHash(hash string) (*FirebaseScryptHashInput, error) {
 		return nil, fmt.Errorf("crypto: invalid r=0")
 	}
 
-	threads, err := strconv.ParseUint(p, 10, 8)
+	parallelism, err := strconv.ParseUint(p, 10, 8)
 	if err != nil {
 		return nil, fmt.Errorf("crypto: invalid p parameter %q: %w", p, err)
 	}
-	if threads == 0 {
+	if parallelism == 0 {
 		return nil, fmt.Errorf("crypto: invalid p=0")
 	}
 
@@ -232,7 +232,7 @@ func ParseFirebaseScryptHash(hash string) (*FirebaseScryptHashInput, error) {
 		v:             v,
 		memory:        memory,
 		rounds:        rounds,
-		threads:       threads,
+		parallelism:   parallelism,
 		salt:          salt,
 		rawHash:       rawHash,
 		saltSeparator: saltSeparator,

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -46,9 +46,9 @@ const (
 
 type FirebaseScryptParameters struct {
 	v             string
-	memCost       uint64
-	rounds        uint64
-	parallelism   uint64
+	memCost       int
+	rounds        int
+	parallelism   int
 	saltSeparator []byte
 	signerKey     []byte
 	salt          []byte
@@ -177,7 +177,8 @@ func ParseFirebaseScryptString(fbscryptString string) (*FirebaseScryptParameters
 		return nil, fmt.Errorf("crypto: unsupported version %q", v)
 	}
 
-	memory, err := strconv.ParseUint(n, 10, 64)
+	memory64, err := strconv.ParseInt(n, 10, 0)
+	memory := int(memory64)
 	if err != nil {
 		return nil, fmt.Errorf("crypto: invalid n parameter %q: %w", n, err)
 	}
@@ -185,7 +186,8 @@ func ParseFirebaseScryptString(fbscryptString string) (*FirebaseScryptParameters
 		return nil, fmt.Errorf("crypto: invalid n=0")
 	}
 
-	rounds, err := strconv.ParseUint(r, 10, 64)
+	rounds64, err := strconv.ParseInt(r, 10, 0)
+	rounds := int(rounds64)
 	if err != nil {
 		return nil, fmt.Errorf("crypto: invalid r parameter %q: %w", r, err)
 	}
@@ -193,7 +195,8 @@ func ParseFirebaseScryptString(fbscryptString string) (*FirebaseScryptParameters
 		return nil, fmt.Errorf("crypto: invalid r=0")
 	}
 
-	parallelism, err := strconv.ParseUint(p, 10, 8)
+	parallelism64, err := strconv.ParseInt(p, 10, 0)
+	parallelism := int(parallelism64)
 	if err != nil {
 		return nil, fmt.Errorf("crypto: invalid p parameter %q: %w", p, err)
 	}

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -133,8 +133,8 @@ func firebaseScrypt(password []byte, parameters FirebaseScryptParameters) ([]byt
 		password,
 		fullSalt,
 		N,
-		int(parameters.rounds),
-		1,
+		parameters.rounds,
+		parameters.parallelism,
 		FirebaseScryptKeyLen,
 	)
 	if err != nil {

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -46,7 +46,7 @@ const (
 
 type FirebaseScryptHashInput struct {
 	v             string
-	memory        uint64
+	memCost       uint64
 	rounds        uint64
 	parallelism   uint64
 	saltSeparator []byte
@@ -109,7 +109,7 @@ func (s password) compareHashAndPasswordFirebaseScrypt(hash, password string) er
 		return fmt.Errorf("could not parse hash data: %w", err)
 	}
 
-	derivedKey, err := firebaseScrypt([]byte(password), input.salt, input.signerKey, input.saltSeparator, input.memory, input.rounds)
+	derivedKey, err := firebaseScrypt([]byte(password), input.salt, input.signerKey, input.saltSeparator, input.memCost, input.rounds)
 	if err != nil {
 		return fmt.Errorf("could not derive key: %w", err)
 	}
@@ -230,7 +230,7 @@ func ParseFirebaseScryptHash(hash string) (*FirebaseScryptHashInput, error) {
 
 	input := &FirebaseScryptHashInput{
 		v:             v,
-		memory:        memory,
+		memCost:       memory,
 		rounds:        rounds,
 		parallelism:   parallelism,
 		salt:          salt,

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -182,8 +182,8 @@ func ParseFirebaseScryptString(fbscryptString string) (*FirebaseScryptParameters
 	if err != nil {
 		return nil, fmt.Errorf("crypto: invalid n parameter %q: %w", n, err)
 	}
-	if memory == 0 {
-		return nil, fmt.Errorf("crypto: invalid n=0")
+	if memory <= 0 {
+		return nil, fmt.Errorf("crypto: invalid n<=0")
 	}
 
 	rounds64, err := strconv.ParseInt(r, 10, 0)
@@ -191,8 +191,8 @@ func ParseFirebaseScryptString(fbscryptString string) (*FirebaseScryptParameters
 	if err != nil {
 		return nil, fmt.Errorf("crypto: invalid r parameter %q: %w", r, err)
 	}
-	if rounds == 0 {
-		return nil, fmt.Errorf("crypto: invalid r=0")
+	if rounds <= 0 {
+		return nil, fmt.Errorf("crypto: invalid r<=0")
 	}
 
 	parallelism64, err := strconv.ParseInt(p, 10, 0)
@@ -200,8 +200,8 @@ func ParseFirebaseScryptString(fbscryptString string) (*FirebaseScryptParameters
 	if err != nil {
 		return nil, fmt.Errorf("crypto: invalid p parameter %q: %w", p, err)
 	}
-	if parallelism == 0 {
-		return nil, fmt.Errorf("crypto: invalid p=0")
+	if parallelism <= 0 {
+		return nil, fmt.Errorf("crypto: invalid p<=0")
 	}
 
 	rawHash, err := base64.StdEncoding.DecodeString(hashB64)

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -37,7 +37,7 @@ type password struct {
 	persister persistence.Persister
 }
 
-var fbscryptHashRegexp = regexp.MustCompile(`^\$fbscrypt\$v=(?P<v>[0-9]+),n=(?P<n>[0-9]+),r=(?P<r>[0-9]+),p=(?P<p>[0-9]+)(?:,ss=(?P<ss>[^,]+))?(?:,sk=(?P<sk>[^$]+))?\$(?P<salt>[^$]+)\$(?P<hash>.+)$`)
+var fbscryptStringRegexp = regexp.MustCompile(`^\$fbscrypt\$v=(?P<v>[0-9]+),n=(?P<n>[0-9]+),r=(?P<r>[0-9]+),p=(?P<p>[0-9]+)(?:,ss=(?P<ss>[^,]+))?(?:,sk=(?P<sk>[^$]+))?\$(?P<salt>[^$]+)\$(?P<hash>.+)$`)
 
 const (
 	FirebaseScryptPrefix = "$fbscrypt"
@@ -104,7 +104,7 @@ func (s password) CompareHashAndPassword(hash, password string) error {
 }
 
 func (s password) compareHashAndPasswordFirebaseScrypt(hash, password string) error {
-	input, err := ParseFirebaseScryptHash(hash)
+	input, err := ParseFirebaseScryptString(hash)
 	if err != nil {
 		return fmt.Errorf("could not parse hash data: %w", err)
 	}
@@ -165,20 +165,20 @@ func firebaseScrypt(
 
 // Format and parsing implementation inspired by Supabase.
 // See: https://github.com/supabase/auth/blob/v2.189.0/internal/crypto/password.go
-func ParseFirebaseScryptHash(hash string) (*FirebaseScryptParameters, error) {
-	submatch := fbscryptHashRegexp.FindStringSubmatchIndex(hash)
+func ParseFirebaseScryptString(fbscryptString string) (*FirebaseScryptParameters, error) {
+	submatch := fbscryptStringRegexp.FindStringSubmatchIndex(fbscryptString)
 	if submatch == nil {
-		return nil, errors.New("crypto: incorrect scrypt hash format")
+		return nil, errors.New("crypto: incorrect scrypt string format")
 	}
 
-	v := string(fbscryptHashRegexp.ExpandString(nil, "$v", hash, submatch))
-	n := string(fbscryptHashRegexp.ExpandString(nil, "$n", hash, submatch))
-	r := string(fbscryptHashRegexp.ExpandString(nil, "$r", hash, submatch))
-	p := string(fbscryptHashRegexp.ExpandString(nil, "$p", hash, submatch))
-	ss := string(fbscryptHashRegexp.ExpandString(nil, "$ss", hash, submatch))
-	sk := string(fbscryptHashRegexp.ExpandString(nil, "$sk", hash, submatch))
-	saltB64 := string(fbscryptHashRegexp.ExpandString(nil, "$salt", hash, submatch))
-	hashB64 := string(fbscryptHashRegexp.ExpandString(nil, "$hash", hash, submatch))
+	v := string(fbscryptStringRegexp.ExpandString(nil, "$v", fbscryptString, submatch))
+	n := string(fbscryptStringRegexp.ExpandString(nil, "$n", fbscryptString, submatch))
+	r := string(fbscryptStringRegexp.ExpandString(nil, "$r", fbscryptString, submatch))
+	p := string(fbscryptStringRegexp.ExpandString(nil, "$p", fbscryptString, submatch))
+	ss := string(fbscryptStringRegexp.ExpandString(nil, "$ss", fbscryptString, submatch))
+	sk := string(fbscryptStringRegexp.ExpandString(nil, "$sk", fbscryptString, submatch))
+	saltB64 := string(fbscryptStringRegexp.ExpandString(nil, "$salt", fbscryptString, submatch))
+	hashB64 := string(fbscryptStringRegexp.ExpandString(nil, "$hash", fbscryptString, submatch))
 
 	if v != "1" {
 		return nil, fmt.Errorf("crypto: unsupported version %q", v)

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"regexp"
@@ -123,9 +124,18 @@ func (s password) compareHashAndPasswordFirebaseScrypt(hash, password string) er
 }
 
 func firebaseScrypt(password []byte, parameters FirebaseScryptParameters) ([]byte, error) {
+	// 1. scrypt step (Firebase computes N as 2^memCost; ensure N fits in int before passing to scrypt.Key)
+	if parameters.memCost < 1 || parameters.memCost >= 63 {
+		return nil, errors.New("invalid memCost")
+	}
 
-	// 1. scrypt step (Firebase uses N = 2^memCost)
-	N := 1 << parameters.memCost
+	n64 := uint64(1) << parameters.memCost
+
+	if n64 > uint64(math.MaxInt) {
+		return nil, errors.New("N does not fit in int")
+	}
+
+	N := int(n64)
 
 	fullSalt := append(parameters.salt, parameters.saltSeparator...)
 

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -1,14 +1,25 @@
 package services
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/subtle"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"time"
+
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 	"github.com/teamhanko/hanko/backend/v2/persistence"
 	"github.com/teamhanko/hanko/backend/v2/persistence/models"
 	"golang.org/x/crypto/bcrypt"
-	"time"
+
+	"golang.org/x/crypto/scrypt"
 )
 
 var (
@@ -24,6 +35,24 @@ type Password interface {
 
 type password struct {
 	persister persistence.Persister
+}
+
+var fbscryptHashRegexp = regexp.MustCompile(`^\$fbscrypt\$v=(?P<v>[0-9]+),n=(?P<n>[0-9]+),r=(?P<r>[0-9]+),p=(?P<p>[0-9]+)(?:,ss=(?P<ss>[^,]+))?(?:,sk=(?P<sk>[^$]+))?\$(?P<salt>[^$]+)\$(?P<hash>.+)$`)
+
+const (
+	FirebaseScryptPrefix = "$fbscrypt"
+	FirebaseScryptKeyLen = 32
+)
+
+type FirebaseScryptHashInput struct {
+	v             string
+	memory        uint64
+	rounds        uint64
+	threads       uint64
+	saltSeparator []byte
+	signerKey     []byte
+	salt          []byte
+	rawHash       []byte
 }
 
 func NewPasswordService(persister persistence.Persister) Password {
@@ -51,11 +80,166 @@ func (s password) VerifyPassword(tx *pop.Connection, userId uuid.UUID, password 
 		return ErrorPasswordInvalid
 	}
 
-	if err = bcrypt.CompareHashAndPassword([]byte(pw.Password), []byte(password)); err != nil {
+	if err = s.CompareHashAndPassword(pw.Password, password); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s password) CompareHashAndPassword(hash, password string) error {
+	if strings.HasPrefix(hash, FirebaseScryptPrefix) {
+		if err := s.compareHashAndPasswordFirebaseScrypt(hash, password); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)); err != nil {
 		return ErrorPasswordInvalid
 	}
 
 	return nil
+}
+
+func (s password) compareHashAndPasswordFirebaseScrypt(hash, password string) error {
+	input, err := ParseFirebaseScryptHash(hash)
+	if err != nil {
+		return fmt.Errorf("could not parse hash data: %w", err)
+	}
+
+	derivedKey, err := firebaseScrypt([]byte(password), input.salt, input.signerKey, input.saltSeparator, input.memory, input.rounds)
+	if err != nil {
+		return fmt.Errorf("could not derive key: %w", err)
+	}
+
+	match := subtle.ConstantTimeCompare(derivedKey, input.rawHash) == 1
+	if !match {
+		return ErrorPasswordInvalid
+	}
+
+	return nil
+}
+
+func firebaseScrypt(
+	password,
+	salt,
+	signerKey,
+	saltSeparator []byte,
+	memCost,
+	rounds uint64,
+) ([]byte, error) {
+
+	// 1. scrypt step (Firebase uses N = 2^memCost)
+	N := 1 << memCost
+
+	fullSalt := append(salt, saltSeparator...)
+
+	dk, err := scrypt.Key(
+		password,
+		fullSalt,
+		N,
+		int(rounds),
+		1,
+		FirebaseScryptKeyLen,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. AES-CTR using dk as key
+	block, err := aes.NewCipher(dk)
+	if err != nil {
+		return nil, err
+	}
+
+	stream := cipher.NewCTR(block, make([]byte, aes.BlockSize))
+
+	// 3. Encrypt signerKey directly
+	derived := make([]byte, len(signerKey))
+	stream.XORKeyStream(derived, signerKey)
+
+	return derived, nil
+}
+
+// Format and parsing implementation inspired by Supabase.
+// See: https://github.com/supabase/auth/blob/v2.189.0/internal/crypto/password.go
+func ParseFirebaseScryptHash(hash string) (*FirebaseScryptHashInput, error) {
+	submatch := fbscryptHashRegexp.FindStringSubmatchIndex(hash)
+	if submatch == nil {
+		return nil, errors.New("crypto: incorrect scrypt hash format")
+	}
+
+	v := string(fbscryptHashRegexp.ExpandString(nil, "$v", hash, submatch))
+	n := string(fbscryptHashRegexp.ExpandString(nil, "$n", hash, submatch))
+	r := string(fbscryptHashRegexp.ExpandString(nil, "$r", hash, submatch))
+	p := string(fbscryptHashRegexp.ExpandString(nil, "$p", hash, submatch))
+	ss := string(fbscryptHashRegexp.ExpandString(nil, "$ss", hash, submatch))
+	sk := string(fbscryptHashRegexp.ExpandString(nil, "$sk", hash, submatch))
+	saltB64 := string(fbscryptHashRegexp.ExpandString(nil, "$salt", hash, submatch))
+	hashB64 := string(fbscryptHashRegexp.ExpandString(nil, "$hash", hash, submatch))
+
+	if v != "1" {
+		return nil, fmt.Errorf("crypto: unsupported version %q", v)
+	}
+
+	memory, err := strconv.ParseUint(n, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: invalid n parameter %q: %w", n, err)
+	}
+	if memory == 0 {
+		return nil, fmt.Errorf("crypto: invalid n=0")
+	}
+
+	rounds, err := strconv.ParseUint(r, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: invalid r parameter %q: %w", r, err)
+	}
+	if rounds == 0 {
+		return nil, fmt.Errorf("crypto: invalid r=0")
+	}
+
+	threads, err := strconv.ParseUint(p, 10, 8)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: invalid p parameter %q: %w", p, err)
+	}
+	if threads == 0 {
+		return nil, fmt.Errorf("crypto: invalid p=0")
+	}
+
+	rawHash, err := base64.StdEncoding.DecodeString(hashB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid hash base64: %w", err)
+	}
+
+	salt, err := base64.StdEncoding.DecodeString(saltB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid salt base64: %w", err)
+	}
+
+	signerKey, err := base64.StdEncoding.DecodeString(sk)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signer key: %w", err)
+	}
+
+	saltSeparator, err := base64.StdEncoding.DecodeString(ss)
+	if err != nil {
+		return nil, fmt.Errorf("invalid salt separator: %w", err)
+	}
+
+	input := &FirebaseScryptHashInput{
+		v:             v,
+		memory:        memory,
+		rounds:        rounds,
+		threads:       threads,
+		salt:          salt,
+		rawHash:       rawHash,
+		saltSeparator: saltSeparator,
+		signerKey:     signerKey,
+	}
+
+	return input, nil
 }
 
 func (s password) RecoverPassword(tx *pop.Connection, userId uuid.UUID, newPassword string) error {

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -104,17 +104,17 @@ func (s password) CompareHashAndPassword(hash, password string) error {
 }
 
 func (s password) compareHashAndPasswordFirebaseScrypt(hash, password string) error {
-	input, err := ParseFirebaseScryptString(hash)
+	parameters, err := ParseFirebaseScryptString(hash)
 	if err != nil {
 		return fmt.Errorf("could not parse hash data: %w", err)
 	}
 
-	derivedKey, err := firebaseScrypt([]byte(password), input.salt, input.signerKey, input.saltSeparator, input.memCost, input.rounds)
+	derivedKey, err := firebaseScrypt([]byte(password), *parameters)
 	if err != nil {
 		return fmt.Errorf("could not derive key: %w", err)
 	}
 
-	match := subtle.ConstantTimeCompare(derivedKey, input.rawHash) == 1
+	match := subtle.ConstantTimeCompare(derivedKey, parameters.rawHash) == 1
 	if !match {
 		return ErrorPasswordInvalid
 	}
@@ -122,25 +122,18 @@ func (s password) compareHashAndPasswordFirebaseScrypt(hash, password string) er
 	return nil
 }
 
-func firebaseScrypt(
-	password,
-	salt,
-	signerKey,
-	saltSeparator []byte,
-	memCost,
-	rounds uint64,
-) ([]byte, error) {
+func firebaseScrypt(password []byte, parameters FirebaseScryptParameters) ([]byte, error) {
 
 	// 1. scrypt step (Firebase uses N = 2^memCost)
-	N := 1 << memCost
+	N := 1 << parameters.memCost
 
-	fullSalt := append(salt, saltSeparator...)
+	fullSalt := append(parameters.salt, parameters.saltSeparator...)
 
 	dk, err := scrypt.Key(
 		password,
 		fullSalt,
 		N,
-		int(rounds),
+		int(parameters.rounds),
 		1,
 		FirebaseScryptKeyLen,
 	)
@@ -157,8 +150,8 @@ func firebaseScrypt(
 	stream := cipher.NewCTR(block, make([]byte, aes.BlockSize))
 
 	// 3. Encrypt signerKey directly
-	derived := make([]byte, len(signerKey))
-	stream.XORKeyStream(derived, signerKey)
+	derived := make([]byte, len(parameters.signerKey))
+	stream.XORKeyStream(derived, parameters.signerKey)
 
 	return derived, nil
 }

--- a/backend/flow_api/services/password.go
+++ b/backend/flow_api/services/password.go
@@ -44,7 +44,7 @@ const (
 	FirebaseScryptKeyLen = 32
 )
 
-type FirebaseScryptHashInput struct {
+type FirebaseScryptParameters struct {
 	v             string
 	memCost       uint64
 	rounds        uint64
@@ -165,7 +165,7 @@ func firebaseScrypt(
 
 // Format and parsing implementation inspired by Supabase.
 // See: https://github.com/supabase/auth/blob/v2.189.0/internal/crypto/password.go
-func ParseFirebaseScryptHash(hash string) (*FirebaseScryptHashInput, error) {
+func ParseFirebaseScryptHash(hash string) (*FirebaseScryptParameters, error) {
 	submatch := fbscryptHashRegexp.FindStringSubmatchIndex(hash)
 	if submatch == nil {
 		return nil, errors.New("crypto: incorrect scrypt hash format")
@@ -228,7 +228,7 @@ func ParseFirebaseScryptHash(hash string) (*FirebaseScryptHashInput, error) {
 		return nil, fmt.Errorf("invalid salt separator: %w", err)
 	}
 
-	input := &FirebaseScryptHashInput{
+	input := &FirebaseScryptParameters{
 		v:             v,
 		memCost:       memory,
 		rounds:        rounds,


### PR DESCRIPTION
# Description

These changes provide Firebase Scryt compatibility. 

# Implementation

- Add command that converts firebase users exported via Firebase CLI to Hanko user import data
    - Passwords are stored in a specific format (inspired by Supabase) that allows recovering the Scrypt parameter/meta data on password verification
- Adjust password service password verification to include Firebase Scrypt
    -  The above mentioned formatted string is parsed, the Firebase specific Scrypt hash is created for a given input password and compared to the existing password hash. 

# How to test

1. Get the Firebase hash config of your Firebase project. Find it in the Firebase console under `Authentication > Users > three dots on the top right of the users table > Password hash parameters`.
2. Copy only the JSON object (don't include the `hash_config` string) and save it to a file.
3. Create one or more Firebase users, set a password.
4. Install the Firebase CLI, [log in](https://firebase.google.com/docs/cli#sign-in-test-cli), and then use the [auth:export](https://firebase.google.com/docs/cli/auth#auth-export) command for your project.
5. In the `backend` directory execute
    ```
    go run main.go user convert firebase --input="./firebase-users.json" --config="./hash-config.json"
    ```

    This will produce an output file (default `hanko-import.json`; can be changed via command option). Failed conversions are written into a "Dead Letter Queue" and saved in a separate output file (default `firebase-dlq.jsonl` where each line contains an error reason and the original firebase user; DLQ output file path can be changed via command option).
6. Run
    ```
    go run main.go user import --inputFile="./hanko-import.json"
    ```
7. Start the backend with a frontend example and try to log in with one of the user's credentials you chose when creating it in the Firebase console. 
