### PR TITLE
feat: move metric endpoint to management router

### DIFF
--- a/backend/handler/admin_router.go
+++ b/backend/handler/admin_router.go
@@ -30,7 +30,9 @@ func NewAdminRouter(cfg *config.Config, persister persistence.Persister, prometh
 
 	if prometheus != nil {
 		e.Use(prometheus)
-		e.GET("/metrics", echoprometheus.NewHandler())
+		if !cfg.MultiTenancy.Enabled {
+			e.GET("/metrics", echoprometheus.NewHandler())
+		}
 	}
 
 	statusHandler := NewStatusHandler(persister)

--- a/backend/handler/management_router.go
+++ b/backend/handler/management_router.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/teamhanko/hanko/backend/v2/config"
@@ -19,6 +20,8 @@ func NewManagementRouter(cfg *config.Config, persister persistence.Persister) *e
 	e.Use(hankoMiddleware.GetLoggerMiddleware())
 
 	e.Validator = dto.NewCustomValidator()
+
+	e.GET("/metrics", echoprometheus.NewHandler())
 
 	statusHandler := NewStatusHandler(persister)
 	e.GET("/", statusHandler.Status)


### PR DESCRIPTION
# Description

When multi-tenancy is enabled, the metrics can be obtained from the management router. When multi-tenancy is disabled, the metrics can be obtained from the admin router.


