### PR TITLE
fix: saml provider sync

### DIFF
--- a/backend/saml/sync.go
+++ b/backend/saml/sync.go
@@ -54,12 +54,6 @@ func SyncProviderConfigToDatabase(cfg *config.Config, persister persistence.Pers
 	log.Printf("[SAML Migration] Syncing %d identity providers from config to database...", len(cfg.Saml.IdentityProviders))
 
 	for _, idpConfig := range cfg.Saml.IdentityProviders {
-		// Skip disabled providers
-		if !idpConfig.Enabled {
-			log.Printf("[SAML Migration] Skipping disabled provider: %s (domain: %s)", idpConfig.Name, idpConfig.Domain)
-			continue
-		}
-
 		log.Printf("[SAML Migration] Syncing provider: %s (domain: %s, metadata: %s)",
 			idpConfig.Name, idpConfig.Domain, idpConfig.MetadataUrl)
 


### PR DESCRIPTION
# Description

In single-tenant mode, if a SAML provider is enabled and then disabled via config and the application restarts, the provider is not synced as a disabled provider and this skipping step retains the provider as enabled. That does not make sense, so this removes the skip check based on the enabled status.