### PR TITLE
fix: user can do saml check

### DIFF
--- a/backend/flow_api/services/user.go
+++ b/backend/flow_api/services/user.go
@@ -18,8 +18,10 @@ func UserCanDoThirdParty(cfg config.Config, identities models.Identities) bool {
 }
 
 func UserCanDoSaml(cfg config.Config, identities models.Identities) bool {
-	for _, identity := range identities {
-		return cfg.Saml.Enabled && identity.SamlIdentity.SamlProvider.Enabled
+	if cfg.Saml.Enabled {
+		for _, identity := range identities {
+			return identity.SamlIdentity != nil && identity.SamlIdentity.SamlProvider.Enabled
+		}
 	}
 
 	return false


### PR DESCRIPTION
# Description

When no custom or built in OAuth/OIDC provider is enabled the UserCanDoSaml() check does not check if an identity is actually a SAML identity by also checking for the presence of a SamlIdentity struct. If it iterates over all identities and hits a non SAML identity then there is a nil dereference because it attempts to read the SamlProvider fields.
