### PR TITLE
fix: set tenantID when saving password

### DIFF
--- a/backend/flow_api/flow/shared/hook_password_save.go
+++ b/backend/flow_api/flow/shared/hook_password_save.go
@@ -24,6 +24,7 @@ func (h PasswordSave) Execute(c flowpilot.HookExecutionContext) error {
 		ID:       passwordId,
 		UserId:   uuid.FromStringOrNil(c.Stash().Get(StashPathUserID).String()),
 		Password: c.Stash().Get(StashPathNewPassword).String(),
+		TenantID: deps.TenantID,
 	}
 
 	err := deps.Persister.GetPasswordCredentialPersisterWithConnection(deps.Tx).Create(passwordCredential)


### PR DESCRIPTION
# Description

When saving the password credential that is created during a login, the tenantID must also be set, to conform to the DB foreign keys.


