### PR TITLE
fix: prevent TOTP code replay 

### DIFF
--- a/backend/flow_api/flow/mfa_creation/action_otp_code_verify.go
+++ b/backend/flow_api/flow/mfa_creation/action_otp_code_verify.go
@@ -1,10 +1,12 @@
 package mfa_creation
 
 import (
+	"errors"
 	"fmt"
+	"time"
 
+	"github.com/gobuffalo/nulls"
 	"github.com/gofrs/uuid"
-	"github.com/pquerna/otp/totp"
 	auditlog "github.com/teamhanko/hanko/backend/v3/audit_log"
 	"github.com/teamhanko/hanko/backend/v3/flow_api/flow/shared"
 	"github.com/teamhanko/hanko/backend/v3/flow_api/services"
@@ -40,9 +42,18 @@ func (a OTPCodeVerify) Execute(c flowpilot.ExecutionContext) error {
 	code := c.Input().Get("otp_code").String()
 	secret := c.Stash().Get(shared.StashPathOTPSecret).String()
 
-	if !totp.Validate(code, secret) {
-		c.Input().SetError("otp_code", shared.ErrorPasscodeInvalid)
-		return c.Error(flowpilot.ErrorFormDataInvalid)
+	matchedStep, err := deps.TOTPService.ValidateCode(code, &models.OTPSecret{Secret: secret}, time.Now().UTC())
+	if err != nil {
+		if errors.Is(err, services.ErrTOTPCodeInvalid) {
+			c.Input().SetError("otp_code", shared.ErrorPasscodeInvalid)
+			return c.Error(flowpilot.ErrorFormDataInvalid)
+		}
+		return fmt.Errorf("totp validation error: %w", err)
+	}
+
+	// Stash the matched step so hook_create_user can set it on the OTPSecret during registration.
+	if err := c.Stash().Set(shared.StashPathOTPLastValidatedStep, matchedStep); err != nil {
+		return fmt.Errorf("failed to stash otp last validated step: %w", err)
 	}
 
 	_ = c.Stash().Set(shared.StashPathUserHasOTPSecret, true)
@@ -62,6 +73,11 @@ func (a OTPCodeVerify) Execute(c flowpilot.ExecutionContext) error {
 		}
 
 		otpSecretModel := models.NewOTPSecret(userID, secret, deps.TenantID)
+		// Set LastValidatedStep to the step just consumed during setup verification.
+		// This prevents the setup code from being replayed as the first MFA login
+		// code (RFC 6238 §5.2): the persisted secret already has that step consumed,
+		// so the replay check in TOTPService.ValidateCode will reject it.
+		otpSecretModel.LastValidatedStep = nulls.NewInt64(matchedStep)
 
 		err := deps.Persister.GetOTPSecretPersisterWithConnection(deps.Tx).Create(*otpSecretModel)
 		if err != nil {

--- a/backend/flow_api/flow/mfa_usage/action_otp_code_validate.go
+++ b/backend/flow_api/flow/mfa_usage/action_otp_code_validate.go
@@ -3,10 +3,12 @@ package mfa_usage
 import (
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/gobuffalo/nulls"
 	"github.com/gofrs/uuid"
-	"github.com/pquerna/otp/totp"
 	"github.com/teamhanko/hanko/backend/v3/flow_api/flow/shared"
+	"github.com/teamhanko/hanko/backend/v3/flow_api/services"
 	"github.com/teamhanko/hanko/backend/v3/flowpilot"
 	"github.com/teamhanko/hanko/backend/v3/rate_limiter"
 )
@@ -63,9 +65,24 @@ func (a OTPCodeValidate) Execute(c flowpilot.ExecutionContext) error {
 
 	code := c.Input().Get("otp_code").String()
 
-	if !totp.Validate(code, userModel.OTPSecret.Secret) {
-		c.Input().SetError("otp_code", shared.ErrorPasscodeInvalid)
-		return c.Error(flowpilot.ErrorFormDataInvalid)
+	matchedStep, err := deps.TOTPService.ValidateCode(code, userModel.OTPSecret, time.Now().UTC())
+	if err != nil {
+		if errors.Is(err, services.ErrTOTPCodeAlreadyUsed) {
+			deps.HttpContext.Logger().Warn(fmt.Errorf("totp replay attempt for user %s: %w", userID, err))
+			c.Input().SetError("otp_code", shared.ErrorOTPCodeAlreadyUsed)
+			return c.Error(flowpilot.ErrorFormDataInvalid)
+		}
+		if errors.Is(err, services.ErrTOTPCodeInvalid) {
+			c.Input().SetError("otp_code", shared.ErrorOTPCodeInvalid)
+			return c.Error(flowpilot.ErrorFormDataInvalid)
+		}
+		return fmt.Errorf("totp validation error: %w", err)
+	}
+
+	// Persist the consumed step atomically within deps.Tx (same transaction as session creation).
+	userModel.OTPSecret.LastValidatedStep = nulls.NewInt64(matchedStep)
+	if err := deps.Persister.GetOTPSecretPersisterWithConnection(deps.Tx).Update(userModel.OTPSecret); err != nil {
+		return fmt.Errorf("failed to update otp secret last validated step: %w", err)
 	}
 
 	err = c.Stash().Set(shared.StashPathMFAUsageMethod, "totp")

--- a/backend/flow_api/flow/registration/hook_create_user.go
+++ b/backend/flow_api/flow/registration/hook_create_user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gobuffalo/nulls"
 	"github.com/gofrs/uuid"
 	auditlog "github.com/teamhanko/hanko/backend/v3/audit_log"
 	"github.com/teamhanko/hanko/backend/v3/flow_api/flow/shared"
@@ -44,6 +45,11 @@ func (h CreateUser) Execute(c flowpilot.HookExecutionContext) error {
 		}
 	}
 
+	otpLastValidatedStep := nulls.Int64{}
+	if stashedStep := c.Stash().Get(shared.StashPathOTPLastValidatedStep); stashedStep.Exists() {
+		otpLastValidatedStep = nulls.NewInt64(stashedStep.Int())
+	}
+
 	err = h.createUser(
 		c,
 		userId,
@@ -53,6 +59,7 @@ func (h CreateUser) Execute(c flowpilot.HookExecutionContext) error {
 		c.Stash().Get(shared.StashPathWebauthnCredentials).Array(),
 		c.Stash().Get(shared.StashPathNewPassword).String(),
 		c.Stash().Get(shared.StashPathOTPSecret).String(),
+		otpLastValidatedStep,
 		deps.TenantID,
 	)
 	if err != nil {
@@ -64,7 +71,7 @@ func (h CreateUser) Execute(c flowpilot.HookExecutionContext) error {
 	return nil
 }
 
-func (h CreateUser) createUser(c flowpilot.HookExecutionContext, id uuid.UUID, email string, emailVerified bool, username string, webauthnCredentials []gjson.Result, password, otpSecret string, tenantID uuid.UUID) error {
+func (h CreateUser) createUser(c flowpilot.HookExecutionContext, id uuid.UUID, email string, emailVerified bool, username string, webauthnCredentials []gjson.Result, password, otpSecret string, otpLastValidatedStep nulls.Int64, tenantID uuid.UUID) error {
 	deps := h.GetDeps(c)
 
 	now := time.Now().UTC()
@@ -135,6 +142,7 @@ func (h CreateUser) createUser(c flowpilot.HookExecutionContext, id uuid.UUID, e
 
 	if otpSecret != "" {
 		otpSecretModel := models.NewOTPSecret(id, otpSecret, tenantID)
+		otpSecretModel.LastValidatedStep = otpLastValidatedStep
 		err = deps.Persister.GetOTPSecretPersisterWithConnection(deps.Tx).Create(*otpSecretModel)
 		if err != nil {
 			return err

--- a/backend/flow_api/flow/shared/const_stash_paths.go
+++ b/backend/flow_api/flow/shared/const_stash_paths.go
@@ -22,6 +22,7 @@ const (
 	StashPathCreateMFAOnlyCredential                = "create_mfa_only_credential"
 	StashPathNewPassword                            = "new_password"
 	StashPathOTPSecret                              = "otp_secret"
+	StashPathOTPLastValidatedStep                   = "otp_last_validated_step"
 	StashPathOTPImageSource                         = "otp_image_src"
 	StashPathPasscodeEmail                          = "sticky.passcode_email"
 	StashPathPasscodeID                             = "sticky.passcode_id"

--- a/backend/flow_api/flow/shared/errors.go
+++ b/backend/flow_api/flow/shared/errors.go
@@ -22,5 +22,7 @@ var (
 	ErrorUnknownEmail          = flowpilot.NewInputError("unknown_email_error", "The email address is unknown.")
 	ErrorInvalidUsername       = flowpilot.NewInputError("invalid_username_error", "The username is invalid.")
 	ErrorPasscodeInvalid       = flowpilot.NewInputError("passcode_invalid", "The passcode is invalid.")
+	ErrorOTPCodeInvalid        = flowpilot.NewInputError("otp_code_invalid", "The OTP code is invalid.")
+	ErrorOTPCodeAlreadyUsed    = flowpilot.NewInputError("otp_code_already_used", "The OTP code has already been used.")
 	ErrorInvalidMetadata       = flowpilot.NewInputError("invalid_metadata_error", "The metadata is invalid.")
 )

--- a/backend/flow_api/flow/shared/flow.go
+++ b/backend/flow_api/flow/shared/flow.go
@@ -21,6 +21,7 @@ type Dependencies struct {
 	SecurityNotificationService services.SecurityNotification
 	PasscodeService             services.Passcode
 	PasswordService             services.Password
+	TOTPService                 services.TOTP
 	WebauthnService             services.WebauthnService
 	SamlService                 saml.SamlProviderService
 	Persister                   persistence.Persister

--- a/backend/flow_api/handler.go
+++ b/backend/flow_api/handler.go
@@ -38,6 +38,7 @@ type FlowPilotHandler struct {
 	SecurityNotificationService services.SecurityNotification
 	PasscodeService             services.Passcode
 	PasswordService             services.Password
+	TOTPService                 services.TOTP
 	WebauthnService             services.WebauthnService
 	SamlService                 saml.SamlProviderService
 	SessionManager              session.Manager
@@ -65,6 +66,7 @@ func NewFlowAPIHandler(cfg config.Config, persister persistence.Persister, audit
 	emailService, _ := services.NewEmailService()
 	passcodeService := services.NewPasscodeService(*emailService, persister)
 	passwordService := services.NewPasswordService(persister)
+	totpService := services.NewTOTPService(services.DefaultTOTPOptions())
 	webauthnService := services.NewWebauthnService(persister)
 	securityNotificationService := services.NewSecurityNotificationService(*emailService, persister, auditLogger)
 	samlService := saml.NewSamlProviderService(persister)
@@ -80,6 +82,7 @@ func NewFlowAPIHandler(cfg config.Config, persister persistence.Persister, audit
 		SecurityNotificationService: securityNotificationService,
 		PasscodeService:             passcodeService,
 		PasswordService:             passwordService,
+		TOTPService:                 totpService,
 		WebauthnService:             webauthnService,
 		SamlService:                 samlService,
 		SessionManager:              nil, // Populated in executeFlow() from session manager middleware
@@ -287,6 +290,7 @@ func (h *FlowPilotHandler) executeFlow(c echo.Context, flow flowpilot.Flow) erro
 			SecurityNotificationService: h.SecurityNotificationService,
 			PasscodeService:             h.PasscodeService,
 			PasswordService:             h.PasswordService,
+			TOTPService:                 h.TOTPService,
 			WebauthnService:             h.WebauthnService,
 			SamlService:                 h.SamlService,
 			AuthenticatorMetadata:       h.AuthenticatorMetadata, // does not need to be tenant-specific

--- a/backend/flow_api/services/totp.go
+++ b/backend/flow_api/services/totp.go
@@ -1,0 +1,112 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/hotp"
+	"github.com/teamhanko/hanko/backend/v3/persistence/models"
+)
+
+// ErrTOTPCodeInvalid is returned by TOTP.ValidateCode when the code does not
+// match the secret within the acceptance window.
+var ErrTOTPCodeInvalid = errors.New("totp code invalid")
+
+// ErrTOTPCodeAlreadyUsed is returned by TOTP.ValidateCode when the code's time
+// step has already been consumed (RFC 6238 §5.2 replay protection).
+var ErrTOTPCodeAlreadyUsed = errors.New("totp code already used")
+
+// TOTPOptions configures the TOTP service. Zero values are replaced with
+// defaults in NewTOTPService, matching the totp.Validate baseline.
+type TOTPOptions struct {
+	Period    uint          // seconds per step; default 30
+	Skew      uint          // accepted steps either side of now; default 1
+	Digits    otp.Digits    // code length; default otp.DigitsSix
+	Algorithm otp.Algorithm // HMAC algorithm; default otp.AlgorithmSHA1
+}
+
+// DefaultTOTPOptions returns options compatible with Google Authenticator and
+// most TOTP clients (RFC 6238 defaults).
+func DefaultTOTPOptions() TOTPOptions {
+	return TOTPOptions{
+		Period:    30,
+		Skew:      1,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	}
+}
+
+// TOTP validates time-based one-time codes.
+type TOTP interface {
+	// ValidateCode checks code against otpSecret at time t, including RFC 6238
+	// §5.2 replay detection. Returns the matched step on success so the caller
+	// can persist it. Returns ErrTOTPCodeInvalid or ErrTOTPCodeAlreadyUsed on
+	// rejection. When otpSecret.LastValidatedStep is NULL (initial setup), the
+	// replay check is skipped.
+	ValidateCode(code string, otpSecret *models.OTPSecret, t time.Time) (int64, error)
+}
+
+type totpService struct {
+	opts TOTPOptions
+}
+
+// NewTOTPService creates a TOTP service. Zero fields in opts are replaced with
+// DefaultTOTPOptions values. Note: Skew=0 is a valid strict mode (no drift
+// tolerance) and is not overridden; use DefaultTOTPOptions() to get Skew=1.
+func NewTOTPService(opts TOTPOptions) TOTP {
+	defaults := DefaultTOTPOptions()
+	if opts.Period == 0 {
+		opts.Period = defaults.Period
+	}
+	if opts.Digits == 0 {
+		opts.Digits = defaults.Digits
+	}
+	if opts.Algorithm == 0 {
+		opts.Algorithm = defaults.Algorithm
+	}
+	return &totpService{opts: opts}
+}
+
+func (s *totpService) ValidateCode(code string, otpSecret *models.OTPSecret, t time.Time) (int64, error) {
+	step, ok, err := s.validate(code, otpSecret.Secret, t)
+	if err != nil {
+		return 0, fmt.Errorf("totp: crypto validation failed: %w", err)
+	}
+	if !ok {
+		return 0, ErrTOTPCodeInvalid
+	}
+	if otpSecret.LastValidatedStep.Valid && step <= otpSecret.LastValidatedStep.Int64 {
+		return 0, ErrTOTPCodeAlreadyUsed
+	}
+	return step, nil
+}
+
+func (s *totpService) validate(code, secret string, t time.Time) (int64, bool, error) {
+	currentStep := int64(math.Floor(float64(t.UTC().Unix()) / float64(s.opts.Period)))
+
+	// Mirror the counter order used by the pquerna library: T, T+1, T-1, ...
+	stepsToCheck := []int64{currentStep}
+	for i := 1; i <= int(s.opts.Skew); i++ {
+		stepsToCheck = append(stepsToCheck, currentStep+int64(i), currentStep-int64(i))
+	}
+
+	for _, step := range stepsToCheck {
+		if step < 0 {
+			continue
+		}
+		valid, err := hotp.ValidateCustom(code, uint64(step), secret, hotp.ValidateOpts{
+			Digits:    s.opts.Digits,
+			Algorithm: s.opts.Algorithm,
+		})
+		if err != nil {
+			return 0, false, fmt.Errorf("totp: hotp validation failed: %w", err)
+		}
+		if valid {
+			return step, true, nil
+		}
+	}
+	return 0, false, nil
+}

--- a/backend/flow_api/services/totp_test.go
+++ b/backend/flow_api/services/totp_test.go
@@ -1,0 +1,197 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/nulls"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/teamhanko/hanko/backend/v3/persistence/models"
+)
+
+var svc = NewTOTPService(DefaultTOTPOptions())
+
+func newTestSecret(t *testing.T) string {
+	t.Helper()
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      "test",
+		AccountName: "user@test.com",
+	})
+	require.NoError(t, err)
+	return key.Secret()
+}
+
+// freshSecret returns an OTPSecret with no history (LastValidatedStep NULL),
+// as used during initial TOTP setup.
+func freshSecret(secret string) *models.OTPSecret {
+	return &models.OTPSecret{Secret: secret}
+}
+
+func TestValidateTOTPCode_CurrentStepAccepted(t *testing.T) {
+	secret := newTestSecret(t)
+	now := time.Now().UTC()
+	code, err := totp.GenerateCode(secret, now)
+	require.NoError(t, err)
+
+	step, err := svc.ValidateCode(code, freshSecret(secret), now)
+	require.NoError(t, err)
+	assert.Equal(t, now.Unix()/30, step)
+}
+
+func TestValidateTOTPCode_WrongDigitsRejected(t *testing.T) {
+	secret := newTestSecret(t)
+	_, err := svc.ValidateCode("000000", freshSecret(secret), time.Now().UTC())
+	require.ErrorIs(t, err, ErrTOTPCodeInvalid)
+}
+
+func TestValidateTOTPCode_WrongSecret(t *testing.T) {
+	secret1 := newTestSecret(t)
+	secret2 := newTestSecret(t)
+	now := time.Now().UTC()
+	code, err := totp.GenerateCode(secret1, now)
+	require.NoError(t, err)
+
+	_, err = svc.ValidateCode(code, freshSecret(secret2), now)
+	require.ErrorIs(t, err, ErrTOTPCodeInvalid)
+}
+
+func TestValidateTOTPCode_PreviousStepAccepted(t *testing.T) {
+	// A code generated one period in the past (T-1) must be accepted.
+	secret := newTestSecret(t)
+	const period = 30
+	now := time.Now().UTC()
+	past := now.Add(-period * time.Second)
+	code, err := totp.GenerateCode(secret, past)
+	require.NoError(t, err)
+
+	step, err := svc.ValidateCode(code, freshSecret(secret), now)
+	require.NoError(t, err)
+	assert.Equal(t, past.Unix()/period, step, "must return the T-1 step, not T")
+}
+
+func TestValidateTOTPCode_NextStepAccepted(t *testing.T) {
+	// A code generated one period in the future (T+1) must be accepted.
+	secret := newTestSecret(t)
+	const period = 30
+	now := time.Now().UTC()
+	future := now.Add(period * time.Second)
+	code, err := totp.GenerateCode(secret, future)
+	require.NoError(t, err)
+
+	step, err := svc.ValidateCode(code, freshSecret(secret), now)
+	require.NoError(t, err)
+	assert.Equal(t, future.Unix()/period, step, "must return the T+1 step, not T")
+}
+
+func TestValidateTOTPCode_TwoPeriodsOldRejected(t *testing.T) {
+	// A code from two periods ago must be rejected (outside Skew=1).
+	secret := newTestSecret(t)
+	const period = 30
+	now := time.Now().UTC()
+	twoBack := now.Add(-2 * period * time.Second)
+	code, err := totp.GenerateCode(secret, twoBack)
+	require.NoError(t, err)
+
+	_, err = svc.ValidateCode(code, freshSecret(secret), now)
+	require.ErrorIs(t, err, ErrTOTPCodeInvalid)
+}
+
+func TestValidateTOTPCode_FirstUseAllowed(t *testing.T) {
+	// NULL LastValidatedStep (never used) must allow any valid step.
+	secret := newTestSecret(t)
+	now := time.Now().UTC()
+	code, err := totp.GenerateCode(secret, now)
+	require.NoError(t, err)
+
+	_, err = svc.ValidateCode(code, freshSecret(secret), now)
+	require.NoError(t, err)
+}
+
+func TestValidateTOTPCode_ReplayRejected(t *testing.T) {
+	secret := newTestSecret(t)
+	now := time.Now().UTC()
+	code, err := totp.GenerateCode(secret, now)
+	require.NoError(t, err)
+
+	step := now.Unix() / 30
+	otpSecret := &models.OTPSecret{
+		Secret:            secret,
+		LastValidatedStep: nulls.NewInt64(step), // already consumed
+	}
+	_, err = svc.ValidateCode(code, otpSecret, now)
+	require.ErrorIs(t, err, ErrTOTPCodeAlreadyUsed)
+}
+
+func TestValidateTOTPCode_OlderSkewStepRejectedAfterAdvancement(t *testing.T) {
+	// After step T is consumed, a T-1 code (within the skew window for a fresh
+	// secret) must still be rejected because step T-1 <= LastValidatedStep T
+	// (forward-only progression rule).
+	secret := newTestSecret(t)
+	const period = 30
+	now := time.Now().UTC()
+	tMinus1 := now.Add(-period * time.Second)
+
+	code, err := totp.GenerateCode(secret, tMinus1)
+	require.NoError(t, err)
+
+	currentStep := now.Unix() / period
+	otpSecret := &models.OTPSecret{
+		Secret:            secret,
+		LastValidatedStep: nulls.NewInt64(currentStep), // T already consumed
+	}
+
+	_, err = svc.ValidateCode(code, otpSecret, now)
+	require.ErrorIs(t, err, ErrTOTPCodeAlreadyUsed,
+		"T-1 code must be rejected once T has been consumed (forward-only progression)")
+}
+
+func TestValidateTOTPCode_NextStepAcceptedAfterPreviousValidation(t *testing.T) {
+	// After step T is consumed, a code for T+1 must be accepted (T+1 > T).
+	// This verifies that normal continued usage works after the first authentication.
+	secret := newTestSecret(t)
+	const period = 30
+	now := time.Now().UTC()
+	future := now.Add(period * time.Second) // T+1
+
+	code, err := totp.GenerateCode(secret, future)
+	require.NoError(t, err)
+
+	currentStep := now.Unix() / period
+	otpSecret := &models.OTPSecret{
+		Secret:            secret,
+		LastValidatedStep: nulls.NewInt64(currentStep), // T already consumed
+	}
+
+	step, err := svc.ValidateCode(code, otpSecret, now)
+	require.NoError(t, err)
+	assert.Equal(t, future.Unix()/period, step, "must return T+1 step")
+}
+
+// TestValidateTOTPCode_SetupCodeRejectedOnFirstLogin ensures that a code used
+// to verify TOTP during setup cannot be replayed as the first MFA login code.
+// During setup, action_otp_code_verify persists LastValidatedStep = matchedStep,
+// so the persisted secret already has that step consumed when login begins.
+func TestValidateTOTPCode_SetupValidatedStepCannotBeReusedForLogin(t *testing.T) {
+	secret := newTestSecret(t)
+	now := time.Now().UTC()
+	code, err := totp.GenerateCode(secret, now)
+	require.NoError(t, err)
+
+	// Simulate what action_otp_code_verify does: validate with a fresh secret,
+	// then store the returned step as LastValidatedStep before persisting.
+	setupStep, err := svc.ValidateCode(code, freshSecret(secret), now)
+	require.NoError(t, err)
+
+	// Simulate the OTPSecret as it exists in the DB after setup.
+	persistedSecret := &models.OTPSecret{
+		Secret:            secret,
+		LastValidatedStep: nulls.NewInt64(setupStep),
+	}
+
+	// The same code must be rejected when used for the first MFA login.
+	_, err = svc.ValidateCode(code, persistedSecret, now)
+	require.ErrorIs(t, err, ErrTOTPCodeAlreadyUsed,
+		"setup verification code must not be reusable as the first MFA login code")
+}

--- a/backend/persistence/migrations/20260629120000_add_last_validated_step_to_otp_secrets.down.fizz
+++ b/backend/persistence/migrations/20260629120000_add_last_validated_step_to_otp_secrets.down.fizz
@@ -1,0 +1,1 @@
+drop_column("otp_secrets", "last_validated_step")

--- a/backend/persistence/migrations/20260629120000_add_last_validated_step_to_otp_secrets.up.fizz
+++ b/backend/persistence/migrations/20260629120000_add_last_validated_step_to_otp_secrets.up.fizz
@@ -1,0 +1,1 @@
+add_column("otp_secrets", "last_validated_step", "integer", {"null": true})

--- a/backend/persistence/models/otp_secret.go
+++ b/backend/persistence/models/otp_secret.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"github.com/gobuffalo/nulls"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
@@ -10,12 +11,13 @@ import (
 )
 
 type OTPSecret struct {
-	ID        uuid.UUID `db:"id"`
-	UserID    uuid.UUID `db:"user_id"`
-	TenantID  uuid.UUID `db:"tenant_id"`
-	Secret    string    `db:"secret"`
-	CreatedAt time.Time `db:"created_at"`
-	UpdatedAt time.Time `db:"updated_at"`
+	ID                uuid.UUID   `db:"id"`
+	UserID            uuid.UUID   `db:"user_id"`
+	TenantID          uuid.UUID   `db:"tenant_id"`
+	Secret            string      `db:"secret"`
+	LastValidatedStep nulls.Int64 `db:"last_validated_step"`
+	CreatedAt         time.Time   `db:"created_at"`
+	UpdatedAt         time.Time   `db:"updated_at"`
 }
 
 func (otpSecret OTPSecret) TableName() string {

--- a/frontend/elements/src/i18n/bn.ts
+++ b/frontend/elements/src/i18n/bn.ts
@@ -191,6 +191,8 @@ export const bn: Translation = {
     flow_expired_error:
       "সেশনটি মেয়াদ উত্তীর্ণ হয়েছে, দয়া করে পুনরায় শুরু করতে বাটনটি ক্লিক করুন।",
     value_invalid_error: "প্রবেশিত মান অবৈধ।",
+    otp_code_invalid: "প্রদত্ত OTP কোড সঠিক নয়।",
+    otp_code_already_used: "OTP কোডটি ইতিমধ্যে ব্যবহৃত হয়েছে।",
     passcode_invalid: "প্রদত্ত পাসকোড সঠিক নয়।",
     passkey_invalid: "এই পাসকী আর ব্যবহার করা যাবে না",
     passcode_max_attempts_reached:

--- a/frontend/elements/src/i18n/de.ts
+++ b/frontend/elements/src/i18n/de.ts
@@ -201,6 +201,8 @@ export const de: Translation = {
     flow_expired_error:
       "Die Sitzung ist abgelaufen, bitte klicken Sie auf die Schaltfläche, um neu zu starten.",
     value_invalid_error: "Der eingegebene Wert ist ungültig.",
+    otp_code_invalid: "Der angegebene OTP-Code war nicht korrekt.",
+    otp_code_already_used: "Der angegebene OTP-Code wurde bereits verwendet.",
     passcode_invalid: "Der angegebene Passcode war nicht korrekt.",
     passkey_invalid: "Dieser Passkey kann nicht mehr verwendet werden.",
     passcode_max_attempts_reached:

--- a/frontend/elements/src/i18n/en.ts
+++ b/frontend/elements/src/i18n/en.ts
@@ -191,6 +191,8 @@ export const en: Translation = {
     flow_expired_error:
       "The session has expired, please click the button to restart.",
     value_invalid_error: "The entered value is invalid.",
+    otp_code_invalid: "The OTP code provided was not correct.",
+    otp_code_already_used: "The OTP code has already been used.",
     passcode_invalid: "The passcode provided was not correct.",
     passkey_invalid: "This passkey cannot be used anymore.",
     passcode_max_attempts_reached:

--- a/frontend/elements/src/i18n/fr.ts
+++ b/frontend/elements/src/i18n/fr.ts
@@ -199,6 +199,8 @@ export const fr: Translation = {
     flow_expired_error:
       "La session a expiré, veuillez cliquer sur le bouton pour redémarrer.",
     value_invalid_error: "La valeur saisie est invalide.",
+    otp_code_invalid: "Le code OTP fourni n'était pas correct.",
+    otp_code_already_used: "Le code OTP a déjà été utilisé.",
     passcode_invalid: "Le code fourni n'était pas correct.",
     passkey_invalid: "Cette clé de passe ne peut plus être utilisée.",
     passcode_max_attempts_reached:

--- a/frontend/elements/src/i18n/it.ts
+++ b/frontend/elements/src/i18n/it.ts
@@ -193,6 +193,8 @@ export const it: Translation = {
     flow_expired_error:
       "La sessione è scaduta, clicca sul pulsante per riavviare.",
     value_invalid_error: "Il valore inserito non è valido.",
+    otp_code_invalid: "Il codice OTP inserito non è corretto.",
+    otp_code_already_used: "Il codice OTP è già stato utilizzato.",
     passcode_invalid: "Il codice inserito non è corretto.",
     passkey_invalid: "Questa chiave di accesso non può più essere utilizzata.",
     passcode_max_attempts_reached:

--- a/frontend/elements/src/i18n/ko.ts
+++ b/frontend/elements/src/i18n/ko.ts
@@ -191,6 +191,8 @@ export const ko: Translation = {
     flow_expired_error:
       "세션이 만료되었습니다. 버튼을 클릭하여 다시 시작해 주세요.",
     value_invalid_error: "입력한 값이 올바르지 않습니다.",
+    otp_code_invalid: "입력한 OTP 코드가 올바르지 않습니다.",
+    otp_code_already_used: "해당 OTP 코드는 이미 사용되었습니다.",
     passcode_invalid: "입력한 패스코드가 올바르지 않습니다.",
     passkey_invalid: "이 패스키는 더 이상 사용할 수 없습니다.",
     passcode_max_attempts_reached:

--- a/frontend/elements/src/i18n/nl.ts
+++ b/frontend/elements/src/i18n/nl.ts
@@ -191,6 +191,8 @@ export const nl: Translation = {
     flow_expired_error:
       "De sessie is verlopen, klik op de knop om opnieuw te starten.",
     value_invalid_error: "De ingevoerde waarde is ongeldig.",
+    otp_code_invalid: "De ingevoerde OTP-code was niet correct.",
+    otp_code_already_used: "De OTP-code is al gebruikt.",
     passcode_invalid: "De ingevoerde toegangscode was niet correct.",
     passkey_invalid: "Deze passkey kan niet meer worden gebruikt.",
     passcode_max_attempts_reached:

--- a/frontend/elements/src/i18n/pt-BR.ts
+++ b/frontend/elements/src/i18n/pt-BR.ts
@@ -197,6 +197,8 @@ export const ptBR: Translation = {
     flow_expired_error:
       "A sessão expirou, por favor, clique no botão para reiniciar.",
     value_invalid_error: "O valor inserido é inválido.",
+    otp_code_invalid: "O código OTP fornecido não estava correto.",
+    otp_code_already_used: "O código OTP já foi utilizado.",
     passcode_invalid: "O código fornecido não estava correto.",
     passkey_invalid: "Esta chave de acesso não pode mais ser utilizada.",
     passcode_max_attempts_reached:

--- a/frontend/elements/src/i18n/translations.ts
+++ b/frontend/elements/src/i18n/translations.ts
@@ -169,6 +169,8 @@ export interface Translation {
     technical_error: string;
     flow_expired_error: string;
     value_invalid_error: string;
+    otp_code_invalid: string;
+    otp_code_already_used: string;
     passcode_invalid: string;
     passkey_invalid: string;
     passcode_max_attempts_reached: string;

--- a/frontend/elements/src/i18n/zh.ts
+++ b/frontend/elements/src/i18n/zh.ts
@@ -182,6 +182,8 @@ export const zh: Translation = {
     technical_error: "发生技术错误。请稍后再试。",
     flow_expired_error: "会话已过期，请点击按钮重新启动。",
     value_invalid_error: "输入的值无效。",
+    otp_code_invalid: "提供的OTP码不正确。",
+    otp_code_already_used: "该OTP码已被使用。",
     passcode_invalid: "提供的密码不正确。",
     passkey_invalid: "此密码无法再使用。",
     passcode_max_attempts_reached:


### PR DESCRIPTION
## Description

TOTP codes are not protected against replay attacks. A valid code can be submitted multiple times within its 30-second validity window. Additionally, the code used to verify TOTP during setup can be reused immediately as the
first MFA login code.

## Implementation

Adds a `last_validated_step` column to `otp_secrets` to track the highest consumed time-step. `ValidateCode` rejects any code whose matched step satisfies `step <= last_validated_step` (forward-only progression per
RFC 6238 §5.2).

**Mitigates:**
- Replay of a valid code within its 30-second window → `otp_code_already_used`
- Reuse of the TOTP setup verification code as the first MFA login code

The consumed step is persisted in the same transaction as session creation. During setup, `last_validated_step` is set before the secret is written to the DB, so the setup code is already consumed when the first login attempt arrives.

## Tests

### Unit

The new `totp` service has accompanying tests.

### Manual

Compare with and without these changes: advance 2 flows to an OTP verification and try to reuse the same OTP code. It should fail with the changes in this PR.