### PR TITLE
refactor(thirdparty): propagate context and fix duplicate defer in oauth providers

### DIFF
--- a/backend/handler/thirdparty.go
+++ b/backend/handler/thirdparty.go
@@ -116,12 +116,12 @@ func (h *ThirdPartyHandler) Callback(c echo.Context) error {
 		if state.CodeVerifier != "" && provider.ID() != "linkedin" {
 			opts = append(opts, oauth2.VerifierOption(state.CodeVerifier))
 		}
-		oAuthToken, terr := provider.GetOAuthToken(callback.AuthCode, opts...)
+		oAuthToken, terr := provider.GetOAuthToken(c.Request().Context(), callback.AuthCode, opts...)
 		if terr != nil {
 			return thirdparty.ErrorInvalidRequest("could not exchange authorization code for access token").WithCause(terr)
 		}
 
-		userData, terr := provider.GetUserData(oAuthToken)
+		userData, terr := provider.GetUserData(c.Request().Context(), oAuthToken)
 		if terr != nil {
 			return thirdparty.ErrorInvalidRequest("could not retrieve user data from provider").WithCause(terr)
 		}

--- a/backend/thirdparty/provider.go
+++ b/backend/thirdparty/provider.go
@@ -43,8 +43,8 @@ type Email struct {
 
 type OAuthProvider interface {
 	AuthCodeURL(string, ...oauth2.AuthCodeOption) string
-	GetUserData(*oauth2.Token) (*UserData, error)
-	GetOAuthToken(string, ...oauth2.AuthCodeOption) (*oauth2.Token, error)
+	GetUserData(context.Context, *oauth2.Token) (*UserData, error)
+	GetOAuthToken(context.Context, string, ...oauth2.AuthCodeOption) (*oauth2.Token, error)
 	ID() string
 }
 
@@ -92,24 +92,29 @@ func getThirdPartyProvider(config config.ThirdParty, id string) (OAuthProvider, 
 	}
 }
 
-func makeRequest(token *oauth2.Token, config *oauth2.Config, url string, dst interface{}) error {
-	client := config.Client(context.Background(), token)
+func makeRequest(ctx context.Context, token *oauth2.Token, config *oauth2.Config, url string, dst interface{}) error {
+	client := config.Client(ctx, token)
 	client.Timeout = time.Second * 10
-	res, err := client.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	res, err := client.Do(req)
 	if err != nil {
 		return err
 	}
 	defer res.Body.Close()
 
-	bodyBytes, _ := io.ReadAll(res.Body)
-	defer res.Body.Close()
-	res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
 
 	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		return errors.New(string(bodyBytes))
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(dst); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(dst); err != nil {
 		return err
 	}
 

--- a/backend/thirdparty/provider_apple.go
+++ b/backend/thirdparty/provider_apple.go
@@ -65,17 +65,17 @@ func (a appleProvider) AuthCodeURL(state string, args ...oauth2.AuthCodeOption) 
 	return authURL
 }
 
-func (a appleProvider) GetOAuthToken(code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return a.oauthConfig.Exchange(context.Background(), code, opts...)
+func (a appleProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return a.oauthConfig.Exchange(ctx, code, opts...)
 }
 
-func (a appleProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
+func (a appleProvider) GetUserData(ctx context.Context, token *oauth2.Token) (*UserData, error) {
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
 		return nil, errors.New("id_token missing")
 	}
 
-	set, err := jwk.Fetch(context.Background(), AppleKeysEndpoint)
+	set, err := jwk.Fetch(ctx, AppleKeysEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/thirdparty/provider_custom.go
+++ b/backend/thirdparty/provider_custom.go
@@ -68,14 +68,14 @@ func (p customProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption)
 	return p.oauthConfig.AuthCodeURL(state, opts...)
 }
 
-func (p customProvider) GetOAuthToken(code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return p.oauthConfig.Exchange(context.Background(), code, opts...)
+func (p customProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return p.oauthConfig.Exchange(ctx, code, opts...)
 }
 
-func (p customProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
-	tokenSource := p.oauthConfig.TokenSource(context.Background(), token)
+func (p customProvider) GetUserData(ctx context.Context, token *oauth2.Token) (*UserData, error) {
+	tokenSource := p.oauthConfig.TokenSource(ctx, token)
 
-	userInfo, err := p.oidcProvider.UserInfo(context.Background(), tokenSource)
+	userInfo, err := p.oidcProvider.UserInfo(ctx, tokenSource)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/thirdparty/provider_discord.go
+++ b/backend/thirdparty/provider_discord.go
@@ -65,13 +65,13 @@ func (p discordProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption
 	return p.oauthConfig.AuthCodeURL(state, opts...)
 }
 
-func (g discordProvider) GetOAuthToken(code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return g.oauthConfig.Exchange(context.Background(), code, opts...)
+func (g discordProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return g.oauthConfig.Exchange(ctx, code, opts...)
 }
 
-func (g discordProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
+func (g discordProvider) GetUserData(ctx context.Context, token *oauth2.Token) (*UserData, error) {
 	var user DiscordUser
-	if err := makeRequest(token, g.oauthConfig, DiscordUserInfoEndpoint, &user); err != nil {
+	if err := makeRequest(ctx, token, g.oauthConfig, DiscordUserInfoEndpoint, &user); err != nil {
 		return nil, err
 	}
 

--- a/backend/thirdparty/provider_facebook.go
+++ b/backend/thirdparty/provider_facebook.go
@@ -73,11 +73,11 @@ func (f facebookProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOptio
 	return f.oauthConfig.AuthCodeURL(state, opts...)
 }
 
-func (f facebookProvider) GetOAuthToken(code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return f.oauthConfig.Exchange(context.Background(), code, opts...)
+func (f facebookProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return f.oauthConfig.Exchange(ctx, code, opts...)
 }
 
-func (f facebookProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
+func (f facebookProvider) GetUserData(ctx context.Context, token *oauth2.Token) (*UserData, error) {
 	endpointURL, err := url.Parse(FacebookUserInfoEndpoint)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (f facebookProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 	endpointURL.RawQuery = endpointURLQuery.Encode()
 
 	var fbUser FacebookUser
-	if err = makeRequest(token, f.oauthConfig, endpointURL.String(), &fbUser); err != nil {
+	if err = makeRequest(ctx, token, f.oauthConfig, endpointURL.String(), &fbUser); err != nil {
 		return nil, err
 	}
 

--- a/backend/thirdparty/provider_github.go
+++ b/backend/thirdparty/provider_github.go
@@ -72,15 +72,15 @@ func (g githubProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption)
 	return g.oauthConfig.AuthCodeURL(state, opts...)
 }
 
-func (g githubProvider) GetOAuthToken(code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return g.oauthConfig.Exchange(context.Background(), code, opts...)
+func (g githubProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return g.oauthConfig.Exchange(ctx, code, opts...)
 }
 
-func (g githubProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
+func (g githubProvider) GetUserData(ctx context.Context, token *oauth2.Token) (*UserData, error) {
 	var user GithubUser
 
 	// https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user
-	if err := makeRequest(token, g.oauthConfig, GithubUserInfoEndpoint, &user); err != nil {
+	if err := makeRequest(ctx, token, g.oauthConfig, GithubUserInfoEndpoint, &user); err != nil {
 		return nil, err
 	}
 
@@ -98,7 +98,7 @@ func (g githubProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
 	// The user data 'email' value is the user's publicly visible email address. It is possible that the user
 	// chose to not make this email public, hence the dedicated call to the 'emails' endpoint.
 	// https://docs.github.com/en/rest/users/emails?apiVersion=2022-11-28#list-email-addresses-for-the-authenticated-user
-	if err := makeRequest(token, g.oauthConfig, GitHubEmailsEndpoint, &emails); err != nil {
+	if err := makeRequest(ctx, token, g.oauthConfig, GitHubEmailsEndpoint, &emails); err != nil {
 		return nil, err
 	}
 

--- a/backend/thirdparty/provider_google.go
+++ b/backend/thirdparty/provider_google.go
@@ -66,13 +66,13 @@ func (g googleProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption)
 	return g.oauthConfig.AuthCodeURL(state, opts...)
 }
 
-func (g googleProvider) GetOAuthToken(code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return g.oauthConfig.Exchange(context.Background(), code, opts...)
+func (g googleProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return g.oauthConfig.Exchange(ctx, code, opts...)
 }
 
-func (g googleProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
+func (g googleProvider) GetUserData(ctx context.Context, token *oauth2.Token) (*UserData, error) {
 	var user GoogleUser
-	if err := makeRequest(token, g.oauthConfig, GoogleUserInfoEndpoint, &user); err != nil {
+	if err := makeRequest(ctx, token, g.oauthConfig, GoogleUserInfoEndpoint, &user); err != nil {
 		return nil, err
 	}
 

--- a/backend/thirdparty/provider_linkedin.go
+++ b/backend/thirdparty/provider_linkedin.go
@@ -74,13 +74,13 @@ func (g linkedInProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOptio
 	return g.oauthConfig.AuthCodeURL(state, opts...)
 }
 
-func (g linkedInProvider) GetOAuthToken(code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return g.oauthConfig.Exchange(context.Background(), code, opts...)
+func (g linkedInProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return g.oauthConfig.Exchange(ctx, code, opts...)
 }
 
-func (g linkedInProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
+func (g linkedInProvider) GetUserData(ctx context.Context, token *oauth2.Token) (*UserData, error) {
 	var user LinkedinUser
-	if err := makeRequest(token, g.oauthConfig, g.oidcProvider.UserInfoEndpoint(), &user); err != nil {
+	if err := makeRequest(ctx, token, g.oauthConfig, g.oidcProvider.UserInfoEndpoint(), &user); err != nil {
 		return nil, err
 	}
 

--- a/backend/thirdparty/provider_microsoft.go
+++ b/backend/thirdparty/provider_microsoft.go
@@ -71,17 +71,17 @@ func (p microsoftProvider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOpti
 	return p.oauthConfig.AuthCodeURL(state, opts...)
 }
 
-func (p microsoftProvider) GetOAuthToken(code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return p.oauthConfig.Exchange(context.Background(), code, opts...)
+func (p microsoftProvider) GetOAuthToken(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return p.oauthConfig.Exchange(ctx, code, opts...)
 }
 
-func (p microsoftProvider) GetUserData(token *oauth2.Token) (*UserData, error) {
+func (p microsoftProvider) GetUserData(ctx context.Context, token *oauth2.Token) (*UserData, error) {
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
 		return nil, errors.New("id_token missing")
 	}
 
-	jwks, err := jwk.Fetch(context.Background(), MicrosoftKeysEndpoint)
+	jwks, err := jwk.Fetch(ctx, MicrosoftKeysEndpoint)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
While evaluating hanko's OAuth integration sub-system, we identified two critical areas where production reliability and resource management under load can be significantly improved.

**1. Context Propagation Omission:**
- The `OAuthProvider` interface and its 7 implementations (GitHub, Apple, Discord, Microsoft, Facebook, LinkedIn, Custom) currently omit `context.Context`.
- This forces implementations to use `context.Background()` for outbound token exchanges and JWKS key fetches.
- Under heavy load or slow network responses, login handlers cannot cancel these blocked outbound requests upon client disconnect, potentially leading to goroutine accumulation and resource exhaustion.

**2. Double Defer and Silenced IO Read Error:**
- Inside the shared `makeRequest` helper in `provider.go`, `defer res.Body.Close()` is registered twice on the same HTTP body, and `io.ReadAll` errors are silently discarded via blank identifiers.
- This causes confusing behavior for static analyzers and risks propagating corrupt body bytes to the JSON decoder under partial network read failures.

**The Fix:**
- Threaded `context.Context` throughout the `OAuthProvider` interface, all 7 provider implementations (plus Google for interface completeness), and the shared `makeRequest` helper.
- Cleaned up the redundant defer registration in `makeRequest` and added robust error-checking for the body read execution path.
- Connected the incoming Echo request context directly to the OAuth orchestrator to enable clean cancellation propagation.