### PR TITLE
fix: thirdparty allowed redirect bypass

### DIFF
--- a/backend/thirdparty/helper.go
+++ b/backend/thirdparty/helper.go
@@ -13,15 +13,346 @@ func IsAllowedRedirect(config config.ThirdParty, redirectTo string) bool {
 		return false
 	}
 
+	// Keep the existing behavior: configured redirect URLs must not have a
+	// trailing slash, and incoming redirect URLs are normalized by trimming one.
 	redirectTo = strings.TrimSuffix(redirectTo, "/")
 
-	for _, pattern := range config.AllowedRedirectURLMap {
-		if pattern.Match(redirectTo) {
+	// The user-controlled redirect target must be a real absolute URL. Unlike
+	// configured allowlist entries, this value is not a glob pattern. It is the
+	// actual destination the browser may be redirected to, so it must parse.
+	redirectURL, err := url.Parse(redirectTo)
+	if err != nil {
+		return false
+	}
+
+	// Reject relative URLs, protocol-relative URLs, malformed URLs, and URLs
+	// without a hostname. This prevents values such as:
+	//
+	//   /foo
+	//   //evil.com
+	//   https:///broken
+	//
+	// from being accepted as redirect destinations.
+	if !redirectURL.IsAbs() || redirectURL.Hostname() == "" {
+		return false
+	}
+
+	// Only allow normal browser-navigation schemes. This prevents redirects to
+	// dangerous or unexpected schemes such as:
+	//
+	//   javascript:alert(1)
+	//   data:text/html,...
+	//   file:///etc/passwd
+	if redirectURL.Scheme != "http" && redirectURL.Scheme != "https" {
+		return false
+	}
+
+	for allowedRedirectPattern, pattern := range config.AllowedRedirectURLMap {
+		// Keep legacy semantics: the configured allowlist entry is still used
+		// as a glob against the full redirect URL string. This preserves support
+		// for existing patterns such as:
+		//
+		//   http://localhost:8888**
+		//   https://*.example.com/**
+		//
+		// However, a raw string glob alone is not safe for host validation,
+		// because it can confuse "trusted host as prefix" with "trusted host as
+		// actual destination". Therefore, a glob match is necessary but no longer
+		// sufficient.
+		if !pattern.Match(redirectTo) {
+			continue
+		}
+
+		// After the legacy glob matched, perform an additional host-boundary
+		// check. This prevents host-collision bypasses such as:
+		//
+		//   allowed pattern: http://127.0.0.1**
+		//   attacker URL:    http://127.0.0.1.evil.com
+		//
+		// The glob may match as a string, but the parsed host is not actually
+		// 127.0.0.1, so it must be rejected.
+		if matchesAllowedRedirectHostBoundary(allowedRedirectPattern, redirectURL) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// matchesAllowedRedirectHostBoundary verifies that the parsed destination host
+// of redirectURL is compatible with the host part of the configured allowlist
+// pattern.
+//
+// This function deliberately does NOT parse allowedRedirectPattern as a URL.
+// Existing configurations may contain glob wildcards in places where net/url
+// would reject them, e.g.:
+//
+//	http://localhost:8888**
+//
+// Instead, we extract the scheme and authority/host part textually, then apply
+// conservative host matching rules:
+//
+//   - exact host patterns require an exact destination host;
+//   - patterns starting with "*." allow real subdomains only;
+//   - partial host wildcards like "127.0.0.1**" do not allow
+//     "127.0.0.1.evil.com".
+//
+// The original glob match is still responsible for path/query matching and
+// broader legacy pattern compatibility. This helper only adds a safe boundary
+// check around scheme, host, and port.
+func matchesAllowedRedirectHostBoundary(allowedRedirectPattern string, redirectURL *url.URL) bool {
+	allowedScheme, allowedAuthorityPattern, ok := extractSchemeAndAuthorityPattern(allowedRedirectPattern)
+	if !ok {
+		return false
+	}
+
+	// If the allowlist pattern contains a scheme, the destination URL must use
+	// the same scheme. This prevents an http-only pattern from allowing https,
+	// and vice versa. Keeping this strict avoids surprising behavior.
+	if allowedScheme != "" && !strings.EqualFold(allowedScheme, redirectURL.Scheme) {
+		return false
+	}
+
+	actualHost := normalizeHost(redirectURL.Hostname())
+	actualPort := redirectURL.Port()
+
+	allowedHostPattern, allowedPortPattern := splitAuthorityPattern(allowedAuthorityPattern)
+	allowedHostPattern = normalizeHost(allowedHostPattern)
+
+	if !matchesHostPatternSafely(allowedHostPattern, actualHost) {
+		return false
+	}
+
+	// If the allowlist pattern contains a static port, require the destination
+	// URL to use exactly that port.
+	//
+	// Example:
+	//
+	//   allowed: http://localhost:8888**
+	//
+	// allows:
+	//
+	//   http://localhost:8888/foo
+	//
+	// but rejects:
+	//
+	//   http://localhost:9999/foo
+	//
+	// If the configured port itself contains a wildcard, we only use the static
+	// prefix before the wildcard. This preserves compatibility while still
+	// preventing obvious host/port confusion.
+	if allowedPortPattern != "" && actualPort != allowedPortPattern {
+		return false
+	}
+
+	return true
+}
+
+// extractSchemeAndAuthorityPattern extracts the scheme and authority part from
+// a configured redirect glob pattern without parsing it as a URL.
+//
+// It accepts patterns like:
+//
+//	http://localhost:8888**
+//	https://*.example.com/**
+//
+// and returns:
+//
+//	scheme:    "http"
+//	authority: "localhost:8888**"
+//
+// or:
+//
+//	scheme:    "https"
+//	authority: "*.example.com"
+//
+// The authority is everything between "://" and the first "/", "?", or "#".
+func extractSchemeAndAuthorityPattern(pattern string) (scheme string, authorityPattern string, ok bool) {
+	schemeSeparatorIndex := strings.Index(pattern, "://")
+	if schemeSeparatorIndex < 0 {
+		return "", "", false
+	}
+
+	scheme = pattern[:schemeSeparatorIndex]
+	rest := pattern[schemeSeparatorIndex+len("://"):]
+
+	authorityEndIndex := strings.IndexAny(rest, "/?#")
+	if authorityEndIndex >= 0 {
+		authorityPattern = rest[:authorityEndIndex]
+	} else {
+		authorityPattern = rest
+	}
+
+	if scheme == "" || authorityPattern == "" {
+		return "", "", false
+	}
+
+	return scheme, authorityPattern, true
+}
+
+// splitAuthorityPattern separates the configured authority pattern into host
+// and port parts.
+//
+// Examples:
+//
+//	"localhost:8888**"      -> host "localhost",      port "8888"
+//	"127.0.0.1**"           -> host "127.0.0.1**",    port ""
+//	"*.example.com:443"     -> host "*.example.com",  port "443"
+//	"example.com"           -> host "example.com",    port ""
+//	"[::1]:8888**"          -> host "::1",            port "8888"
+//
+// The returned port is the static prefix before any glob wildcard, because an
+// existing configuration may have a pattern such as ":8888**".
+func splitAuthorityPattern(authorityPattern string) (hostPattern string, portPattern string) {
+	// IPv6 literals in URLs are written as [::1] or [2001:db8::1]. Handle those
+	// specially so the colons inside the address are not mistaken for a port
+	// separator.
+	if strings.HasPrefix(authorityPattern, "[") {
+		closingBracketIndex := strings.Index(authorityPattern, "]")
+		if closingBracketIndex < 0 {
+			return authorityPattern, ""
+		}
+
+		hostPattern = authorityPattern[1:closingBracketIndex]
+		rest := authorityPattern[closingBracketIndex+1:]
+
+		if strings.HasPrefix(rest, ":") {
+			portPattern = staticPrefixBeforeWildcard(rest[1:])
+		}
+
+		return hostPattern, portPattern
+	}
+
+	// For non-IPv6 authorities, the last colon separates host and port.
+	// This is intentionally simple because configured patterns are legacy glob
+	// strings, not necessarily valid URLs.
+	colonIndex := strings.LastIndex(authorityPattern, ":")
+	if colonIndex < 0 {
+		return authorityPattern, ""
+	}
+
+	hostPattern = authorityPattern[:colonIndex]
+	portPattern = staticPrefixBeforeWildcard(authorityPattern[colonIndex+1:])
+
+	return hostPattern, portPattern
+}
+
+// matchesHostPatternSafely decides whether the actual parsed destination host
+// is allowed by the configured host pattern.
+//
+// The key security rule is: partial host prefix matches are not enough.
+//
+// For example, if the configured host pattern is:
+//
+//	127.0.0.1**
+//
+// its static prefix is:
+//
+//	127.0.0.1
+//
+// The only accepted actual host is exactly:
+//
+//	127.0.0.1
+//
+// The following is rejected:
+//
+//	127.0.0.1.evil.com
+//
+// because that is a different DNS host.
+//
+// Subdomain matching is allowed only for explicit wildcard-subdomain patterns
+// of the form:
+//
+//	*.example.com
+//
+// That allows:
+//
+//	app.example.com
+//
+// but rejects:
+//
+//	example.com
+//	example.com.evil.com
+//	badexample.com
+func matchesHostPatternSafely(allowedHostPattern string, actualHost string) bool {
+	if allowedHostPattern == "" || actualHost == "" {
+		return false
+	}
+
+	// Explicit subdomain wildcard support. This preserves the intended meaning
+	// of patterns like:
+	//
+	//   https://*.example.com/**
+	//
+	// while still enforcing a domain boundary.
+	if strings.HasPrefix(allowedHostPattern, "*.") {
+		baseDomain := normalizeHost(strings.TrimPrefix(allowedHostPattern, "*."))
+		if baseDomain == "" {
+			return false
+		}
+
+		// Require a real subdomain. "*.example.com" should match
+		// "app.example.com", but not "example.com" itself.
+		return actualHost != baseDomain && strings.HasSuffix(actualHost, "."+baseDomain)
+	}
+
+	// For all other host patterns, take the static part before the first glob
+	// wildcard and require an exact parsed-host match. This is the critical
+	// protection against host-collision attacks.
+	//
+	// Example:
+	//
+	//   allowed pattern host: 127.0.0.1**
+	//   static prefix:       127.0.0.1
+	//
+	// Accepted:
+	//
+	//   actual host: 127.0.0.1
+	//
+	// Rejected:
+	//
+	//   actual host: 127.0.0.1.evil.com
+	allowedHostPrefix := normalizeHost(staticPrefixBeforeWildcard(allowedHostPattern))
+	if allowedHostPrefix == "" {
+		return false
+	}
+
+	return actualHost == allowedHostPrefix
+}
+
+// staticPrefixBeforeWildcard returns the part of a configured glob segment that
+// appears before the first wildcard character.
+//
+// This lets us derive the stable host or port prefix from legacy patterns such
+// as:
+//
+//	localhost**
+//	8888**
+//
+// without requiring the entire allowlist entry to be a valid URL.
+func staticPrefixBeforeWildcard(value string) string {
+	wildcardIndex := strings.IndexAny(value, "*?[")
+	if wildcardIndex < 0 {
+		return value
+	}
+
+	return value[:wildcardIndex]
+}
+
+// normalizeHost canonicalizes hostnames for comparison.
+//
+// It lowercases hostnames because DNS names are case-insensitive, and removes a
+// trailing dot so that:
+//
+//	example.com
+//
+// and:
+//
+//	example.com.
+//
+// compare the same.
+func normalizeHost(host string) string {
+	return strings.TrimSuffix(strings.ToLower(host), ".")
 }
 
 func GetErrorUrl(redirectTo string, err error) string {

--- a/backend/thirdparty/helper.go
+++ b/backend/thirdparty/helper.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/gobwas/glob"
 	"github.com/teamhanko/hanko/backend/v3/config"
 )
 
@@ -89,13 +90,14 @@ func IsAllowedRedirect(config config.ThirdParty, redirectTo string) bool {
 //
 //	http://localhost:8888**
 //
-// Instead, we extract the scheme and authority/host part textually, then apply
-// conservative host matching rules:
-//
-//   - exact host patterns require an exact destination host;
-//   - patterns starting with "*." allow real subdomains only;
-//   - partial host wildcards like "127.0.0.1**" do not allow
-//     "127.0.0.1.evil.com".
+// Instead, we extract the scheme and authority/host part textually, then
+// delegate to matchesHostPatternSafely, which applies conservative host
+// matching rules: exact literal hosts require an exact match; patterns whose
+// wildcards are all pinned down by literal text (e.g. "*.example.com",
+// "foo.*.bar.com", "192.168.*.*") are matched as a full glob; and patterns
+// with an unanchored trailing wildcard (e.g. "127.0.0.1**") fall back to an
+// exact match on the static text before the first wildcard, so that
+// "127.0.0.1**" does not allow "127.0.0.1.evil.com".
 //
 // The original glob match is still responsible for path/query matching and
 // broader legacy pattern compatibility. This helper only adds a safe boundary
@@ -240,84 +242,94 @@ func splitAuthorityPattern(authorityPattern string) (hostPattern string, portPat
 // matchesHostPatternSafely decides whether the actual parsed destination host
 // is allowed by the configured host pattern.
 //
-// The key security rule is: partial host prefix matches are not enough.
+// A host pattern is handled using one of three rules:
 //
-// For example, if the configured host pattern is:
+//  1. No wildcard characters at all: the actual host must match exactly.
 //
-//	127.0.0.1**
+//  2. The pattern's last "**" is not pinned down by literal text after it
+//     (nothing follows, or only further wildcard characters follow, e.g.
+//     "127.0.0.1**", "127.0.0.1**[a-z]", "127.0.0.1**.*"). Such a "**"
+//     conveys no fixed, unspoofable boundary, so falling back to a full glob
+//     match would let an attacker smuggle in their own apex domain:
 //
-// its static prefix is:
+//     allowed pattern: 127.0.0.1**
+//     attacker host:   127.0.0.1.evil.com
 //
-//	127.0.0.1
+//     Instead we require an exact match on the static text before the first
+//     wildcard character. (A bare trailing "**" with nothing after it, e.g.
+//     "*.example.com**", is first stripped and re-evaluated as the pattern
+//     that remains, so this fallback only actually triggers when a further
+//     wildcard character trails the "**" itself.)
 //
-// The only accepted actual host is exactly:
-//
-//	127.0.0.1
-//
-// The following is rejected:
-//
-//	127.0.0.1.evil.com
-//
-// because that is a different DNS host.
-//
-// Subdomain matching is allowed only for explicit wildcard-subdomain patterns
-// of the form:
-//
-//	*.example.com
-//
-// That allows:
-//
-//	app.example.com
-//
-// but rejects:
-//
-//	example.com
-//	example.com.evil.com
-//	badexample.com
+//  3. Otherwise every wildcard -- including any "**" -- is anchored by fixed
+//     literal text, so the pattern is compiled and matched as a full glob
+//     (with "." as the only separator). This handles subdomain wildcards
+//     ("*.example.com", "**.example.com"), bounded mid-host wildcards
+//     ("foo.*.bar.com", "foo-*.bar.com", "192.168.*.*"), and anchored
+//     mid-pattern super-globs ("foo.**.bar.com"), while still rejecting
+//     "example.com", "example.com.evil.com", and "badexample.com" against
+//     "*.example.com".
 func matchesHostPatternSafely(allowedHostPattern string, actualHost string) bool {
 	if allowedHostPattern == "" || actualHost == "" {
 		return false
 	}
 
-	// Explicit subdomain wildcard support. This preserves the intended meaning
-	// of patterns like:
-	//
-	//   https://*.example.com/**
-	//
-	// while still enforcing a domain boundary.
-	if strings.HasPrefix(allowedHostPattern, "*.") {
-		baseDomain := normalizeHost(strings.TrimPrefix(allowedHostPattern, "*."))
-		if baseDomain == "" {
-			return false
-		}
-
-		// Require a real subdomain. "*.example.com" should match
-		// "app.example.com", but not "example.com" itself.
-		return actualHost != baseDomain && strings.HasSuffix(actualHost, "."+baseDomain)
+	// Fast path: a pattern with no wildcard characters is a plain literal
+	// host and must match exactly. (This is subsumed by the glob.Compile
+	// branch below too, but is kept as a cheap allocation-free fast path for
+	// the common case of a plain configured host.)
+	if !strings.ContainsAny(allowedHostPattern, "*?[") {
+		return actualHost == allowedHostPattern
 	}
 
-	// For all other host patterns, take the static part before the first glob
-	// wildcard and require an exact parsed-host match. This is the critical
-	// protection against host-collision attacks.
-	//
-	// Example:
-	//
-	//   allowed pattern host: 127.0.0.1**
-	//   static prefix:       127.0.0.1
-	//
-	// Accepted:
-	//
-	//   actual host: 127.0.0.1
-	//
-	// Rejected:
-	//
-	//   actual host: 127.0.0.1.evil.com
-	allowedHostPrefix := normalizeHost(staticPrefixBeforeWildcard(allowedHostPattern))
-	if allowedHostPrefix == "" {
+	if lastSuperGlobIndex := strings.LastIndex(allowedHostPattern, "**"); lastSuperGlobIndex >= 0 {
+		tail := allowedHostPattern[lastSuperGlobIndex+len("**"):]
+
+		if tail == "" {
+			// A trailing "**" with nothing after it places no requirement on
+			// what may follow -- it is purely decorative legacy shorthand
+			// (e.g. "127.0.0.1**", but also "*.example.com**"). Strip it and
+			// re-evaluate the remaining pattern on its own terms, so a
+			// pattern like "*.example.com**" reduces to the well-understood
+			// "*.example.com" wildcard-subdomain pattern instead of being
+			// needlessly forced through the unbounded-super-glob fallback
+			// below (which would make it unmatchable, since its static
+			// prefix is empty).
+			return matchesHostPatternSafely(allowedHostPattern[:lastSuperGlobIndex], actualHost)
+		}
+
+		if strings.ContainsAny(tail, "*?[") {
+			// The "**" is followed by further wildcard characters, so its
+			// right-hand boundary still isn't pinned down by a fixed literal
+			// suffix (e.g. "127.0.0.1**[a-z]" only requires some trailing
+			// a-z character; "127.0.0.1**.*" only requires some final
+			// label). Fall back to the conservative rule that protects
+			// against host-collision bypasses: allowed "127.0.0.1**[a-z]"
+			// must not match "127.0.0.1.evil.com" just because it happens to
+			// end in a lowercase letter.
+			allowedHostPrefix := normalizeHost(staticPrefixBeforeWildcard(allowedHostPattern))
+			if allowedHostPrefix == "" {
+				return false
+			}
+
+			return actualHost == allowedHostPrefix
+		}
+	}
+
+	// Every wildcard in the pattern -- including any "**" -- is anchored by
+	// literal text that pins down where it must stop matching (e.g. the
+	// ".example.com" suffix in "*.example.com", or the "foo." prefix and
+	// ".bar.com" suffix in "foo.*.bar.com"). Compiling and matching the full
+	// host pattern (hosts never contain "/", so only "." is a separator)
+	// reproduces gobwas/glob's documented semantics and forces the actual
+	// host to align with the pattern's fixed structure, so it cannot be used
+	// to smuggle in an attacker-controlled apex domain.
+	hostGlob, err := glob.Compile(allowedHostPattern, '.')
+	if err != nil {
 		return false
 	}
 
-	return actualHost == allowedHostPrefix
+	return hostGlob.Match(actualHost)
 }
 
 // staticPrefixBeforeWildcard returns the part of a configured glob segment that

--- a/backend/thirdparty/helper_test.go
+++ b/backend/thirdparty/helper_test.go
@@ -45,6 +45,12 @@ func TestIsValidRedirectTo(t *testing.T) {
 			want:                true,
 		},
 		{
+			name:                "Starts with super glob",
+			requestedRedirect:   "https://foo.example.com",
+			allowedRedirectURLs: []string{"https://**.example.com"},
+			want:                true,
+		},
+		{
 			name:              "Error redirect url, trailing slash ignored",
 			requestedRedirect: "https://foo.example.com/error/",
 			errorRedirectURL:  "https://foo.example.com/error",
@@ -124,6 +130,128 @@ func TestIsValidRedirectTo(t *testing.T) {
 			name:                "localhost glob does not allow localhost.evil.com",
 			requestedRedirect:   "http://localhost.evil.com",
 			allowedRedirectURLs: []string{"http://localhost**"},
+			want:                false,
+		},
+		{
+			name:                "Super glob has path suffix",
+			requestedRedirect:   "https://example.com.evil.com/test",
+			allowedRedirectURLs: []string{"https://example.com**/test"},
+			want:                false,
+		},
+
+		// --- mid-host wildcard subdomain ---
+		{
+			name:                "Mid-host wildcard subdomain match",
+			requestedRedirect:   "https://foo.mid.bar.com",
+			allowedRedirectURLs: []string{"https://foo.*.bar.com"},
+			want:                true,
+		},
+		{
+			name:                "Mid-host wildcard subdomain rejects extra nested level",
+			requestedRedirect:   "https://foo.a.b.bar.com",
+			allowedRedirectURLs: []string{"https://foo.*.bar.com"},
+			want:                false,
+		},
+
+		// --- dash-suffixed label wildcard  ---
+		{
+			name:                "Dash-suffixed label wildcard match",
+			requestedRedirect:   "https://foo-prod.bar.com",
+			allowedRedirectURLs: []string{"https://foo-*.bar.com"},
+			want:                true,
+		},
+		{
+			name:                "Dash-suffixed label wildcard rejects wrong suffix domain",
+			requestedRedirect:   "https://foo-prod.evil.com",
+			allowedRedirectURLs: []string{"https://foo-*.bar.com"},
+			want:                false,
+		},
+
+		// --- IP subnet wildcard  ---
+		{
+			name:                "IP subnet wildcard matches address in range",
+			requestedRedirect:   "http://192.168.1.55/dashboard",
+			allowedRedirectURLs: []string{"http://192.168.*.*/**"},
+			want:                true,
+		},
+		{
+			name:                "IP subnet wildcard rejects address outside range",
+			requestedRedirect:   "http://10.0.0.1/dashboard",
+			allowedRedirectURLs: []string{"http://192.168.*.*/**"},
+			want:                false,
+		},
+		{
+			name:                "IP subnet wildcard rejects host-collision with extra label",
+			requestedRedirect:   "http://192.168.1.55.evil.com/dashboard",
+			allowedRedirectURLs: []string{"http://192.168.*.*/**"},
+			want:                false,
+		},
+
+		// --- anchored mid-pattern super-glob ---
+		{
+			name:                "Anchored mid-pattern super-glob allows nested subdomains",
+			requestedRedirect:   "https://foo.a.b.bar.com",
+			allowedRedirectURLs: []string{"https://foo.**.bar.com"},
+			want:                true,
+		},
+		{
+			name:                "Anchored mid-pattern super-glob still requires literal suffix domain",
+			requestedRedirect:   "https://foo.a.b.evil.com",
+			allowedRedirectURLs: []string{"https://foo.**.bar.com"},
+			want:                false,
+		},
+
+		// --- super-wildcard subdomain depth ---
+		{
+			name:                "Super-wildcard subdomain allows nested multi-level subdomains",
+			requestedRedirect:   "https://a.b.example.com",
+			allowedRedirectURLs: []string{"https://**.example.com"},
+			want:                true,
+		},
+		{
+			name:                "Super-wildcard subdomain does not match bare base domain",
+			requestedRedirect:   "https://example.com",
+			allowedRedirectURLs: []string{"https://**.example.com"},
+			want:                false,
+		},
+
+		// --- subdomain wildcard combined with a bare trailing ** ---
+		{
+			name:                "Subdomain wildcard with trailing super glob matches subdomain",
+			requestedRedirect:   "https://app.gett.co/callback",
+			allowedRedirectURLs: []string{"https://*.gett.co**"},
+			want:                true,
+		},
+		{
+			name:                "Subdomain wildcard with trailing super glob rejects base domain",
+			requestedRedirect:   "https://gett.co",
+			allowedRedirectURLs: []string{"https://*.gett.co**"},
+			want:                false,
+		},
+		{
+			name:                "Super-wildcard subdomain with trailing super glob matches nested subdomain",
+			requestedRedirect:   "https://a.b.kyr.link/callback",
+			allowedRedirectURLs: []string{"https://**.kyr.link**"},
+			want:                true,
+		},
+		{
+			name:                "Subdomain wildcard with trailing super glob rejects host-collision",
+			requestedRedirect:   "https://app.gett.co.evil.com",
+			allowedRedirectURLs: []string{"https://*.gett.co**"},
+			want:                false,
+		},
+
+		// --- regression guards: a trailing wildcard after ** is not a safe anchor ---
+		{
+			name:                "Trailing bracket class after ** does not create a safe anchor",
+			requestedRedirect:   "http://127.0.0.1.evil.com",
+			allowedRedirectURLs: []string{"http://127.0.0.1**[a-z]"},
+			want:                false,
+		},
+		{
+			name:                "Trailing dot-star after ** does not create a safe anchor",
+			requestedRedirect:   "http://127.0.0.1.evil.com",
+			allowedRedirectURLs: []string{"http://127.0.0.1**.*"},
 			want:                false,
 		},
 

--- a/backend/thirdparty/helper_test.go
+++ b/backend/thirdparty/helper_test.go
@@ -2,12 +2,13 @@ package thirdparty
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/teamhanko/hanko/backend/v3/config"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/teamhanko/hanko/backend/v3/config"
 )
 
 func TestIsValidRedirectTo(t *testing.T) {
@@ -16,31 +17,220 @@ func TestIsValidRedirectTo(t *testing.T) {
 		requestedRedirect   string
 		allowedRedirectURLs []string
 		errorRedirectURL    string
+		want                bool
 	}{
+		// --- existing positive cases ---
 		{
 			name:                "Exact match",
 			requestedRedirect:   "https://foo.example.com",
 			allowedRedirectURLs: []string{"https://foo.example.com"},
+			want:                true,
 		},
 		{
 			name:                "Subdomain match",
 			requestedRedirect:   "https://foo.example.com",
 			allowedRedirectURLs: []string{"https://*.example.com"},
+			want:                true,
 		},
 		{
 			name:                "Path match",
 			requestedRedirect:   "https://foo.example.com/page/anotherPage",
 			allowedRedirectURLs: []string{"https://foo.example.com/page/anotherPage"},
+			want:                true,
 		},
 		{
 			name:                "Trailing slash ignored",
 			requestedRedirect:   "https://foo.example.com/",
 			allowedRedirectURLs: []string{"https://*.example.com"},
+			want:                true,
 		},
 		{
 			name:              "Error redirect url, trailing slash ignored",
 			requestedRedirect: "https://foo.example.com/error/",
 			errorRedirectURL:  "https://foo.example.com/error",
+			want:              true,
+		},
+
+		// --- empty input ---
+		{
+			name:                "Empty redirectTo rejected",
+			requestedRedirect:   "",
+			allowedRedirectURLs: []string{"https://example.com"},
+			want:                false,
+		},
+
+		// --- relative and protocol-relative URLs ---
+		{
+			name:                "Relative URL rejected",
+			requestedRedirect:   "/foo",
+			allowedRedirectURLs: []string{"https://example.com"},
+			want:                false,
+		},
+		{
+			name:                "Protocol-relative URL rejected",
+			requestedRedirect:   "//evil.com",
+			allowedRedirectURLs: []string{"https://evil.com"},
+			want:                false,
+		},
+
+		// --- missing hostname ---
+		{
+			name:                "URL with empty hostname rejected",
+			requestedRedirect:   "https:///broken",
+			allowedRedirectURLs: []string{"https:///broken"},
+			want:                false,
+		},
+
+		// --- forbidden schemes ---
+		{
+			name:                "javascript: scheme rejected",
+			requestedRedirect:   "javascript:alert(1)",
+			allowedRedirectURLs: []string{"javascript:alert(1)"},
+			want:                false,
+		},
+		{
+			name:                "data: scheme rejected",
+			requestedRedirect:   "data:text/html,hi",
+			allowedRedirectURLs: []string{"data:text/html,**"},
+			want:                false,
+		},
+		{
+			name:                "file: scheme rejected",
+			requestedRedirect:   "file:///etc/passwd",
+			allowedRedirectURLs: []string{"file:///etc/passwd"},
+			want:                false,
+		},
+
+		// --- host-collision prevention ---
+		{
+			name:                "IP glob does not match attacker host",
+			requestedRedirect:   "http://127.0.0.1.evil.com",
+			allowedRedirectURLs: []string{"http://127.0.0.1**"},
+			want:                false,
+		},
+		{
+			name:                "IP glob allows exact IP",
+			requestedRedirect:   "http://127.0.0.1",
+			allowedRedirectURLs: []string{"http://127.0.0.1**"},
+			want:                true,
+		},
+		{
+			name:                "IP glob allows path on exact IP",
+			requestedRedirect:   "http://127.0.0.1/dashboard",
+			allowedRedirectURLs: []string{"http://127.0.0.1**"},
+			want:                true,
+		},
+		{
+			name:                "localhost glob does not allow localhost.evil.com",
+			requestedRedirect:   "http://localhost.evil.com",
+			allowedRedirectURLs: []string{"http://localhost**"},
+			want:                false,
+		},
+
+		// --- subdomain wildcard boundary ---
+		{
+			name:                "Wildcard matches real subdomain",
+			requestedRedirect:   "https://app.example.com",
+			allowedRedirectURLs: []string{"https://*.example.com"},
+			want:                true,
+		},
+		{
+			name:                "Wildcard does not match base domain",
+			requestedRedirect:   "https://example.com",
+			allowedRedirectURLs: []string{"https://*.example.com"},
+			want:                false,
+		},
+		{
+			name:                "Wildcard does not match sibling with base as suffix",
+			requestedRedirect:   "https://badexample.com",
+			allowedRedirectURLs: []string{"https://*.example.com"},
+			want:                false,
+		},
+		{
+			name:                "Wildcard does not match evil suffix on base domain",
+			requestedRedirect:   "https://example.com.evil.com",
+			allowedRedirectURLs: []string{"https://*.example.com"},
+			want:                false,
+		},
+		{
+			name:                "Wildcard does not match nested subdomain (glob separator blocks it)",
+			requestedRedirect:   "https://a.b.example.com",
+			allowedRedirectURLs: []string{"https://*.example.com"},
+			want:                false,
+		},
+
+		// --- port matching ---
+		{
+			name:                "Correct port allowed",
+			requestedRedirect:   "http://localhost:8888/foo",
+			allowedRedirectURLs: []string{"http://localhost:8888**"},
+			want:                true,
+		},
+		{
+			name:                "Wrong port rejected",
+			requestedRedirect:   "http://localhost:9999/foo",
+			allowedRedirectURLs: []string{"http://localhost:8888**"},
+			want:                false,
+		},
+		{
+			name:                "Port omitted in pattern — any port accepted",
+			requestedRedirect:   "http://localhost/foo",
+			allowedRedirectURLs: []string{"http://localhost**"},
+			want:                true,
+		},
+		{
+			name:                "Port in pattern required — URL without port rejected",
+			requestedRedirect:   "http://localhost/foo",
+			allowedRedirectURLs: []string{"http://localhost:8888**"},
+			want:                false,
+		},
+
+		// --- scheme mismatch ---
+		{
+			name:                "http pattern does not allow https redirect",
+			requestedRedirect:   "https://example.com",
+			allowedRedirectURLs: []string{"http://example.com"},
+			want:                false,
+		},
+		{
+			name:                "https pattern does not allow http redirect",
+			requestedRedirect:   "http://example.com",
+			allowedRedirectURLs: []string{"https://example.com"},
+			want:                false,
+		},
+
+		// --- path glob ---
+		{
+			name:                "Double-star glob matches any path",
+			requestedRedirect:   "https://example.com/deep/path/page",
+			allowedRedirectURLs: []string{"https://example.com/**"},
+			want:                true,
+		},
+		{
+			name:                "Single-star glob matches one path segment",
+			requestedRedirect:   "https://example.com/page",
+			allowedRedirectURLs: []string{"https://example.com/*"},
+			want:                true,
+		},
+		{
+			name:                "Single-star glob does not match multi-segment path",
+			requestedRedirect:   "https://example.com/page/sub",
+			allowedRedirectURLs: []string{"https://example.com/*"},
+			want:                false,
+		},
+
+		// --- no matching entry ---
+		{
+			name:                "No allowlist entry matches",
+			requestedRedirect:   "https://other.com",
+			allowedRedirectURLs: []string{"https://example.com"},
+			want:                false,
+		},
+		{
+			name:                "Empty allowlist",
+			requestedRedirect:   "https://example.com",
+			allowedRedirectURLs: []string{},
+			want:                false,
 		},
 	}
 
@@ -58,7 +248,7 @@ func TestIsValidRedirectTo(t *testing.T) {
 			require.NoError(t, err)
 
 			got := IsAllowedRedirect(cfg, testData.requestedRedirect)
-			assert.True(t, got)
+			assert.Equal(t, testData.want, got)
 		})
 	}
 }


### PR DESCRIPTION
# Description

Third party allowed redirect URLs may use glob patterns and server-side validation matching on those patterns allows bypassing crafted hosts, e.g., `127.0.0.1.evil.com` bypasses `127.0.0.1**` whitelist glob because it performs simple pattern matching but does not perform strict checks on hosts.

# Implementation

- Adds host boundary check to prevent bypass due to globbing. 
- Keeps legacy globbing and semantics for backward-compatibility.

# Tests

## Unit 

- Updates/extends tests for `IsAllowedRedirect` utility

## Manual

1. Start frontend example (default port is 8888)
2. Get `ngrok`, then :```ngrok http 8888```
3. Configure redirect url(s) in backend with ngrokked URL (`<ngrok_url>**`)
4. Configure third party provider for testing
5. Start backend
6. Install proxy, e.g. Burp Suite
7. Open Burp Suite, go to Proxy -> Intercept. Turn on intercept. Open Burp Suite browser.
8. Navigate to ngrokked URL, keep forwarding requests until the login page has loaded
9. Click to login with third party provider
10. In Burp Suite forward until you hit a POST request to "/login?action=thirdparty_oauth%40<flow_id>" 
11. Modify request body's `input_data.redirect_to`, e.g. `<ngrok_url>` -> `<ngrok_url>.evil`, then forward the modified request
12. Elements should show form data error
