### PR TITLE
fix: rate limit bypass

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,6 +25,7 @@ easily integrated into any web app with as little as two lines of code.
   - [User import](#user-import)
   - [Webhooks](#webhooks)
   - [Session JWT templates](#session-jwt-templates)
+  - [Client IP address resolution](#client-ip-address-resolution)
 - [API specification](#api-specification)
 - [Configuration reference](#configuration-reference)
 - [License](#license)
@@ -774,6 +775,89 @@ Notes:
 - Boolean strings ("true" or "false") from templates are automatically converted to actual booleans.
 
 For more details on template syntax, see: https://pkg.go.dev/text/template
+
+### Client IP address resolution
+
+Hanko uses the resolved client IP address in several places, including rate limiting, audit logs, request logs, and
+session-related metadata.
+
+By default, Hanko uses the direct network peer address of the incoming request and ignores client-supplied
+forwarding headers such as `X-Forwarded-For` and `X-Real-IP`.
+
+This default is secure for direct deployments and prevents clients from spoofing their IP address to bypass
+rate limits.
+
+```yaml
+server:
+  ip:
+    extractor: direct
+```
+
+#### Deployments behind reverse proxies
+
+If Hanko is deployed behind a reverse proxy, load balancer, ingress controller, or CDN, the direct peer address seen
+by Hanko may be the proxy address instead of the original client address.
+
+In this case, you can configure Hanko to use a forwarding header, but only from explicitly trusted proxy IP ranges.
+
+Example using `X-Forwarded-For`:
+
+```yaml
+server:
+  ip:
+    extractor: x_forwarded_for
+    trusted_proxies:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+```
+
+Example using `X-Real-IP`:
+
+```yaml
+server:
+  ip:
+    extractor: x_real_ip
+    trusted_proxies:
+      - 10.12.34.56/32
+```
+
+#### Rate limiting behind reverse proxies
+
+When Hanko is deployed behind a reverse proxy and `server.ip.extractor` is set to `direct`, Hanko sees the proxy IP
+address as the client IP. In that setup, multiple users may share the same resolved IP address and therefore the same
+IP-based rate-limit buckets.
+
+For deployments with meaningful traffic behind a reverse proxy, configure a header-based extractor such as
+`x_forwarded_for` together with narrow `trusted_proxies` ranges. This allows Hanko to resolve the original client
+IP while still ignoring forwarding headers from untrusted peers.
+
+#### Available options
+
+| Option | Description |
+|---|---|
+| `server.ip.extractor` | Determines how Hanko resolves the client IP address. |
+| `server.ip.trusted_proxies` | List of trusted reverse proxy CIDR ranges. Required when using a header-based extractor. |
+
+Supported values for `server.ip.extractor`:
+
+| Value | Description |
+|---|---|
+| `direct` | Uses the direct network peer address. Ignores `X-Forwarded-For` and `X-Real-IP`. This is the default. |
+| `x_forwarded_for` | Uses the `X-Forwarded-For` header, but only when the direct peer is in `trusted_proxies`. |
+| `x_real_ip` | Uses the `X-Real-IP` header, but only when the direct peer is in `trusted_proxies`. |
+
+#### Security considerations
+
+Only enable `x_forwarded_for` or `x_real_ip` if Hanko is reachable exclusively through trusted reverse proxies.
+
+When using a header-based extractor:
+
+- configure only your own reverse proxies, load balancers, ingress controllers, or CDN proxy ranges in `trusted_proxies`;
+- keep `trusted_proxies` as narrow as possible;
+- do not include client networks, public internet ranges, or other untrusted networks in `trusted_proxies`;
+- ensure the Hanko service is not directly reachable from the public internet;
+- ensure your proxy strips or overwrites incoming `X-Forwarded-For` and `X-Real-IP` headers from clients.
 
 ## API specification
 

--- a/backend/config/config_default.go
+++ b/backend/config/config_default.go
@@ -21,6 +21,9 @@ func DefaultApplicationConfig() ApplicationConfig {
 			Management: ServerSettings{
 				Address: ":8002",
 			},
+			IP: IPConfig{
+				Extractor: IPExtractorDirect,
+			},
 		},
 		Database: Database{
 			Database:        "hanko",

--- a/backend/config/config_server.go
+++ b/backend/config/config_server.go
@@ -3,7 +3,10 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strings"
+
+	"github.com/invopop/jsonschema"
 )
 
 type Server struct {
@@ -13,6 +16,9 @@ type Server struct {
 	Admin ServerSettings `yaml:"admin" json:"admin,omitempty" koanf:"admin" jsonschema:"title=admin"`
 	// `management` contains the server configuration for the management API.
 	Management ServerSettings `yaml:"management" json:"management,omitempty" koanf:"management" jsonschema:"title=management"`
+	// `ip` configures how client IP addresses are resolved. This configuration is global and applies to public, admin,
+	// and management APIs.
+	IP IPConfig `yaml:"ip" json:"ip,omitempty" koanf:"ip"`
 }
 
 func (s *Server) Validate() error {
@@ -27,6 +33,9 @@ func (s *Server) Validate() error {
 	err = s.Management.Validate()
 	if err != nil {
 		return fmt.Errorf("error validating management server settings: %w", err)
+	}
+	if err := s.IP.Validate(); err != nil {
+		return fmt.Errorf("error validating ip settings: %w", err)
 	}
 	return nil
 }
@@ -71,4 +80,89 @@ func (s *ServerSettings) Validate() error {
 		return errors.New("field Address must not be empty")
 	}
 	return nil
+}
+
+type IPExtractorType string
+
+const (
+	IPExtractorDirect        IPExtractorType = "direct"
+	IPExtractorXForwardedFor IPExtractorType = "x_forwarded_for"
+	IPExtractorXRealIP       IPExtractorType = "x_real_ip"
+)
+
+type IPConfig struct {
+	// `extractor` determines how the client IP address is resolved.
+	//
+	// The default `direct` uses the direct network peer address and ignores forwarding headers.
+	// Use `x_forwarded_for` or `x_real_ip` only when Hanko is deployed behind trusted reverse proxies.
+	//
+	// When using x_forwarded_for or x_real_ip, ensure the application is not directly reachable from the internet and
+	// that your reverse proxy strips or overwrites incoming forwarding headers.
+	Extractor IPExtractorType `yaml:"extractor" json:"extractor,omitempty" koanf:"extractor" jsonschema:"default=direct,enum=direct,enum=x_forwarded_for,enum=x_real_ip"`
+
+	// `trusted_proxies` contains CIDR ranges of reverse proxies that are trusted to provide client IP headers.
+	//
+	// Required when `extractor` is `x_forwarded_for` or `x_real_ip`.
+	// Do not configure public client IP ranges here. Only configure your own reverse proxies,
+	// load balancers, or ingress controllers.
+	TrustedProxies []string `yaml:"trusted_proxies" json:"trusted_proxies,omitempty" koanf:"trusted_proxies"`
+}
+
+func (IPConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
+	extractor, _ := schema.Properties.Get("extractor")
+	extractor.Extras = map[string]any{"meta:enum": map[string]string{
+		"direct": "Uses the direct network peer address. This is the default and ignores X-Forwarded-For / X-Real-IP.",
+		"x_forwarded_for": `Uses the X-Forwarded-For header, but only from trusted proxies. Requires trusted_proxies.
+							When using this option ensure the application is not directly reachable from the internet
+							and that your reverse proxy strips or overwrites incoming forwarding headers.`,
+		"x_real_ip": `Uses the X-Real-IP header, but only from trusted proxies. Requires trusted_proxies.
+							When using this option ensure the application is not directly reachable from the internet
+							and that your reverse proxy strips or overwrites incoming forwarding headers.`,
+	}}
+
+	if schema.Extras == nil {
+		schema.Extras = map[string]any{}
+	}
+
+	// Add if/then manually.
+	schema.Extras["if"] = map[string]any{
+		"required": []string{"extractor"},
+		"properties": map[string]any{
+			"extractor": map[string]any{
+				"enum": []string{"x_forwarded_for", "x_real_ip"},
+			},
+		},
+	}
+
+	schema.Extras["then"] = map[string]any{
+		"required": []string{"trusted_proxies"},
+		"properties": map[string]any{
+			"trusted_proxies": map[string]any{
+				"minItems": 1,
+			},
+		},
+	}
+}
+
+func (c IPConfig) Validate() error {
+	switch c.Extractor {
+	case "", IPExtractorDirect:
+		return nil
+
+	case IPExtractorXForwardedFor, IPExtractorXRealIP:
+		if len(c.TrustedProxies) == 0 {
+			return fmt.Errorf("trusted_proxies must be configured when ip.extractor is %q", c.Extractor)
+		}
+
+		for _, trustedProxy := range c.TrustedProxies {
+			if _, _, err := net.ParseCIDR(trustedProxy); err != nil {
+				return fmt.Errorf("invalid trusted proxy CIDR %q: %w", trustedProxy, err)
+			}
+		}
+
+		return nil
+
+	default:
+		return errors.New("ip.extractor must be one of: direct, x_forwarded_for, x_real_ip")
+	}
 }

--- a/backend/handler/admin_router.go
+++ b/backend/handler/admin_router.go
@@ -10,11 +10,17 @@ import (
 	hankoMiddleware "github.com/teamhanko/hanko/backend/v3/middleware"
 	"github.com/teamhanko/hanko/backend/v3/persistence"
 	"github.com/teamhanko/hanko/backend/v3/template"
+	"github.com/teamhanko/hanko/backend/v3/utils"
 )
 
 func NewAdminRouter(cfg *config.Config, persister persistence.Persister, prometheus echo.MiddlewareFunc) *echo.Echo {
 	e := echo.New()
 	e.Renderer = template.NewTemplateRenderer()
+
+	if err := utils.ConfigureIPExtractor(e, cfg.Server.IP); err != nil {
+		panic(err)
+	}
+
 	e.HideBanner = true
 	g := e.Group("")
 

--- a/backend/handler/management_router.go
+++ b/backend/handler/management_router.go
@@ -8,12 +8,17 @@ import (
 	"github.com/teamhanko/hanko/backend/v3/dto"
 	hankoMiddleware "github.com/teamhanko/hanko/backend/v3/middleware"
 	"github.com/teamhanko/hanko/backend/v3/persistence"
+	"github.com/teamhanko/hanko/backend/v3/utils"
 )
 
 func NewManagementRouter(cfg *config.Config, persister persistence.Persister) *echo.Echo {
 
 	e := echo.New()
 	e.HideBanner = true
+
+	if err := utils.ConfigureIPExtractor(e, cfg.Server.IP); err != nil {
+		panic(err)
+	}
 
 	e.HTTPErrorHandler = dto.NewHTTPErrorHandler(dto.HTTPErrorHandlerConfig{Debug: false, Logger: e.Logger})
 	e.Use(middleware.RequestID())

--- a/backend/handler/public_router.go
+++ b/backend/handler/public_router.go
@@ -15,12 +15,18 @@ import (
 	"github.com/teamhanko/hanko/backend/v3/persistence"
 	"github.com/teamhanko/hanko/backend/v3/saml"
 	"github.com/teamhanko/hanko/backend/v3/template"
+	"github.com/teamhanko/hanko/backend/v3/utils"
 )
 
 func NewPublicRouter(cfg *config.Config, persister persistence.Persister, prometheus echo.MiddlewareFunc, authenticatorMetadata mapper.AuthenticatorMetadata) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 	e.Renderer = template.NewTemplateRenderer()
+
+	if err := utils.ConfigureIPExtractor(e, cfg.Server.IP); err != nil {
+		panic(err)
+	}
+
 	e.Validator = dto.NewCustomValidator()
 	e.HTTPErrorHandler = dto.NewHTTPErrorHandler(dto.HTTPErrorHandlerConfig{Debug: cfg.Debug, Logger: e.Logger})
 

--- a/backend/json_schema/hanko.config.json
+++ b/backend/json_schema/hanko.config.json
@@ -747,6 +747,57 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "IPConfig": {
+      "properties": {
+        "extractor": {
+          "type": "string",
+          "enum": [
+            "direct",
+            "x_forwarded_for",
+            "x_real_ip"
+          ],
+          "description": "`extractor` determines how the client IP address is resolved.\n\nThe default `direct` uses the direct network peer address and ignores forwarding headers.\nUse `x_forwarded_for` or `x_real_ip` only when Hanko is deployed behind trusted reverse proxies.\n\nWhen using x_forwarded_for or x_real_ip, ensure the application is not directly reachable from the internet and\nthat your reverse proxy strips or overwrites incoming forwarding headers.",
+          "default": "direct",
+          "meta:enum": {
+            "direct": "Uses the direct network peer address. This is the default and ignores X-Forwarded-For / X-Real-IP.",
+            "x_forwarded_for": "Uses the X-Forwarded-For header, but only from trusted proxies. Requires trusted_proxies.\n\t\t\t\t\t\t\tWhen using this option ensure the application is not directly reachable from the internet\n\t\t\t\t\t\t\tand that your reverse proxy strips or overwrites incoming forwarding headers.",
+            "x_real_ip": "Uses the X-Real-IP header, but only from trusted proxies. Requires trusted_proxies.\n\t\t\t\t\t\t\tWhen using this option ensure the application is not directly reachable from the internet\n\t\t\t\t\t\t\tand that your reverse proxy strips or overwrites incoming forwarding headers."
+          }
+        },
+        "trusted_proxies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "`trusted_proxies` contains CIDR ranges of reverse proxies that are trusted to provide client IP headers.\n\nRequired when `extractor` is `x_forwarded_for` or `x_real_ip`.\nDo not configure public client IP ranges here. Only configure your own reverse proxies,\nload balancers, or ingress controllers."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "if": {
+        "properties": {
+          "extractor": {
+            "enum": [
+              "x_forwarded_for",
+              "x_real_ip"
+            ]
+          }
+        },
+        "required": [
+          "extractor"
+        ]
+      },
+      "then": {
+        "properties": {
+          "trusted_proxies": {
+            "minItems": 1
+          }
+        },
+        "required": [
+          "trusted_proxies"
+        ]
+      }
+    },
     "IdentityProvider": {
       "properties": {
         "enabled": {
@@ -1520,6 +1571,10 @@
           "$ref": "#/$defs/ServerSettings",
           "title": "management",
           "description": "`management` contains the server configuration for the management API."
+        },
+        "ip": {
+          "$ref": "#/$defs/IPConfig",
+          "description": "`ip` configures how client IP addresses are resolved. This configuration is global and applies to public, admin,\nand management APIs."
         }
       },
       "additionalProperties": false,

--- a/backend/rate_limiter/rate_limiter_test.go
+++ b/backend/rate_limiter/rate_limiter_test.go
@@ -2,11 +2,17 @@ package rate_limiter
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
+	"github.com/sethvargo/go-limiter"
 	"github.com/teamhanko/hanko/backend/v3/config"
+	"github.com/teamhanko/hanko/backend/v3/utils"
 )
 
 func TestNewRateLimiter(t *testing.T) {
@@ -36,5 +42,174 @@ func TestNewRateLimiter(t *testing.T) {
 	log.Printf("Tokens: %v, Remaining: %v, Reset: %v, ok: %v, error: %v\n", tokens, remaining, time.Unix(0, int64(reset)).String(), ok, e)
 	if ok {
 		t.Error("Taking a token should fail at this point")
+	}
+}
+
+func TestLimit_IPExtractorRateLimitBehavior(t *testing.T) {
+	tests := []struct {
+		name                   string
+		ipConfig               config.IPConfig
+		firstRemoteAddr        string
+		firstHeaders           map[string]string
+		secondRemoteAddr       string
+		secondHeaders          map[string]string
+		expectSecondRateLimit  bool
+		expectedSecondErrorMsg string
+	}{
+		{
+			name: "direct extractor cannot be bypassed with spoofed X-Forwarded-For",
+			ipConfig: config.IPConfig{
+				Extractor: config.IPExtractorDirect,
+			},
+			firstRemoteAddr: "198.51.100.10:11111",
+			firstHeaders: map[string]string{
+				echo.HeaderXForwardedFor: "203.0.113.1",
+			},
+			secondRemoteAddr: "198.51.100.10:11111",
+			secondHeaders: map[string]string{
+				echo.HeaderXForwardedFor: "203.0.113.2",
+			},
+			expectSecondRateLimit: true,
+		},
+		{
+			name: "X-Forwarded-For extractor uses header from trusted proxy",
+			ipConfig: config.IPConfig{
+				Extractor:      config.IPExtractorXForwardedFor,
+				TrustedProxies: []string{"10.0.0.0/8"},
+			},
+			firstRemoteAddr: "10.0.1.25:11111",
+			firstHeaders: map[string]string{
+				echo.HeaderXForwardedFor: "203.0.113.1",
+			},
+			secondRemoteAddr: "10.0.1.25:22222",
+			secondHeaders: map[string]string{
+				echo.HeaderXForwardedFor: "203.0.113.2",
+			},
+			expectSecondRateLimit: false,
+		},
+		{
+			name: "X-Forwarded-For extractor ignores header from untrusted peer",
+			ipConfig: config.IPConfig{
+				Extractor:      config.IPExtractorXForwardedFor,
+				TrustedProxies: []string{"10.0.0.0/8"},
+			},
+			firstRemoteAddr: "198.51.100.10:11111",
+			firstHeaders: map[string]string{
+				echo.HeaderXForwardedFor: "203.0.113.1",
+			},
+			secondRemoteAddr: "198.51.100.10:22222",
+			secondHeaders: map[string]string{
+				echo.HeaderXForwardedFor: "203.0.113.2",
+			},
+			expectSecondRateLimit: true,
+		},
+		{
+			name: "X-Real-IP extractor uses header from trusted proxy",
+			ipConfig: config.IPConfig{
+				Extractor:      config.IPExtractorXRealIP,
+				TrustedProxies: []string{"10.0.0.0/8"},
+			},
+			firstRemoteAddr: "10.0.1.25:11111",
+			firstHeaders: map[string]string{
+				echo.HeaderXRealIP: "203.0.113.1",
+			},
+			secondRemoteAddr: "10.0.1.25:22222",
+			secondHeaders: map[string]string{
+				echo.HeaderXRealIP: "203.0.113.2",
+			},
+			expectSecondRateLimit: false,
+		},
+		{
+			name: "X-Real-IP extractor ignores header from untrusted peer",
+			ipConfig: config.IPConfig{
+				Extractor:      config.IPExtractorXRealIP,
+				TrustedProxies: []string{"10.0.0.0/8"},
+			},
+			firstRemoteAddr: "198.51.100.10:11111",
+			firstHeaders: map[string]string{
+				echo.HeaderXRealIP: "203.0.113.1",
+			},
+			secondRemoteAddr: "198.51.100.10:22222",
+			secondHeaders: map[string]string{
+				echo.HeaderXRealIP: "203.0.113.2",
+			},
+			expectSecondRateLimit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			err := utils.ConfigureIPExtractor(e, tt.ipConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			store := newTestRateLimiter(1)
+			userID := uuid.Must(uuid.NewV4())
+
+			firstContext := newRateLimitTestContext(e, http.MethodPost, "/login", tt.firstRemoteAddr, tt.firstHeaders)
+			if err := Limit(store, userID, firstContext); err != nil {
+				t.Fatalf("first request should not be rate limited: %v", err)
+			}
+
+			secondContext := newRateLimitTestContext(e, http.MethodPost, "/login", tt.secondRemoteAddr, tt.secondHeaders)
+			secondErr := Limit(store, userID, secondContext)
+
+			if tt.expectSecondRateLimit {
+				assertTooManyRequests(t, secondErr)
+				return
+			}
+
+			if secondErr != nil {
+				t.Fatalf("second request should not be rate limited: %v", secondErr)
+			}
+		})
+	}
+}
+
+func newTestRateLimiter(tokens uint64) limiter.Store {
+	return NewRateLimiter(
+		config.RateLimiter{
+			Enabled: true,
+			Store:   config.RATE_LIMITER_STORE_IN_MEMORY,
+			Redis:   nil,
+		},
+		config.RateLimits{
+			Tokens:   tokens,
+			Interval: time.Minute,
+		},
+	)
+}
+
+func newRateLimitTestContext(e *echo.Echo, method, target, remoteAddr string, headers map[string]string) echo.Context {
+	req := httptest.NewRequest(method, target, nil)
+	req.RemoteAddr = remoteAddr
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath(target)
+
+	return c
+}
+
+func assertTooManyRequests(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+
+	httpError, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+
+	if httpError.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected status %d, got %d", http.StatusTooManyRequests, httpError.Code)
 	}
 }

--- a/backend/utils/ip.go
+++ b/backend/utils/ip.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/labstack/echo/v4"
+	"github.com/teamhanko/hanko/backend/v3/config"
+)
+
+func ConfigureIPExtractor(e *echo.Echo, cfg config.IPConfig) error {
+	switch cfg.Extractor {
+	case "", config.IPExtractorDirect:
+		e.IPExtractor = echo.ExtractIPDirect()
+		return nil
+
+	case config.IPExtractorXForwardedFor:
+		trustOptions, err := buildTrustOptions(cfg.TrustedProxies)
+		if err != nil {
+			return err
+		}
+
+		e.IPExtractor = echo.ExtractIPFromXFFHeader(trustOptions...)
+		return nil
+
+	case config.IPExtractorXRealIP:
+		trustOptions, err := buildTrustOptions(cfg.TrustedProxies)
+		if err != nil {
+			return err
+		}
+
+		e.IPExtractor = echo.ExtractIPFromRealIPHeader(trustOptions...)
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported IP extractor %q", cfg.Extractor)
+	}
+}
+
+func buildTrustOptions(trustedProxies []string) ([]echo.TrustOption, error) {
+	if len(trustedProxies) == 0 {
+		return nil, fmt.Errorf("trusted_proxies must be configured when using a header-based IP extractor")
+	}
+
+	trustOptions := make([]echo.TrustOption, 0, len(trustedProxies))
+
+	for _, cidr := range trustedProxies {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid trusted proxy CIDR %q: %w", cidr, err)
+		}
+
+		trustOptions = append(trustOptions, echo.TrustIPRange(ipNet))
+	}
+
+	return trustOptions, nil
+}

--- a/backend/utils/ip_test.go
+++ b/backend/utils/ip_test.go
@@ -1,0 +1,117 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"github.com/teamhanko/hanko/backend/v3/config"
+)
+
+func TestConfigureIPExtractor_RealIPResolution(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            config.IPConfig
+		remoteAddr     string
+		headers        map[string]string
+		expectedRealIP string
+	}{
+		{
+			name: "direct ignores X-Forwarded-For and X-Real-IP",
+			cfg: config.IPConfig{
+				Extractor: config.IPExtractorDirect,
+			},
+			remoteAddr: "198.51.100.10:12345",
+			headers: map[string]string{
+				"X-Forwarded-For": "203.0.113.99",
+				"X-Real-IP":       "203.0.113.88",
+			},
+			expectedRealIP: "198.51.100.10",
+		},
+		{
+			name: "x_forwarded_for trusts header from trusted proxy",
+			cfg: config.IPConfig{
+				Extractor: config.IPExtractorXForwardedFor,
+				TrustedProxies: []string{
+					"10.0.0.0/8",
+				},
+			},
+			remoteAddr: "10.0.1.25:12345",
+			headers: map[string]string{
+				"X-Forwarded-For": "203.0.113.44",
+			},
+			expectedRealIP: "203.0.113.44",
+		},
+		{
+			name: "x_forwarded_for ignores header from untrusted peer",
+			cfg: config.IPConfig{
+				Extractor: config.IPExtractorXForwardedFor,
+				TrustedProxies: []string{
+					"10.0.0.0/8",
+				},
+			},
+			remoteAddr: "198.51.100.10:12345",
+			headers: map[string]string{
+				"X-Forwarded-For": "203.0.113.44",
+			},
+			expectedRealIP: "198.51.100.10",
+		},
+		{
+			name: "x_real_ip trusts header from trusted proxy",
+			cfg: config.IPConfig{
+				Extractor: config.IPExtractorXRealIP,
+				TrustedProxies: []string{
+					"10.0.0.0/8",
+				},
+			},
+			remoteAddr: "10.0.1.25:12345",
+			headers: map[string]string{
+				"X-Real-IP": "203.0.113.55",
+			},
+			expectedRealIP: "203.0.113.55",
+		},
+		{
+			name: "x_real_ip ignores header from untrusted peer",
+			cfg: config.IPConfig{
+				Extractor: config.IPExtractorXRealIP,
+				TrustedProxies: []string{
+					"10.0.0.0/8",
+				},
+			},
+			remoteAddr: "198.51.100.10:12345",
+			headers: map[string]string{
+				"X-Real-IP": "203.0.113.55",
+			},
+			expectedRealIP: "198.51.100.10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+
+			err := ConfigureIPExtractor(e, tt.cfg)
+			require.NoError(t, err)
+
+			e.GET("/ip", func(c echo.Context) error {
+				return c.String(http.StatusOK, c.RealIP())
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/ip", nil)
+			req.RemoteAddr = tt.remoteAddr
+
+			for key, value := range tt.headers {
+				req.Header.Set(key, value)
+			}
+
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.Equal(t, tt.expectedRealIP, rec.Body.String())
+		})
+	}
+}


### PR DESCRIPTION
# Description

Rate limiting uses Echo's `c.RealIP()`. If the Echo IPExtractor is not explicitly configured, it trusts user-controlled headers such as `X-Forwarded-For` and `X-Real-IP`.

Said headers can be spoofed by a client, attackers can arbitrarily change their apparent IP address for each request, which resets the rate limit bucket.

This allows attackers to bypass authentication rate limits and perform unlimited brute-force attempts.

# Implementation

- Customizes echo IP Extractor: 
    - Can be configured using different IP extraction modes: `direct` (default) , `x_forwarded_for`, `x_real_ip` 
    - Trusted Proxy address ranges _must_ be configured if `x_forwarded_for` or `x_real_ip` modes are configured

# Tests

- Adds tests for the new IP Extractor customization (utility) itself
- Adds tests in `rate_limiter` package to test integration 