### PR TITLE
fix: deflake TestConcurrentLockAttempts with a start barrier

### DIFF
--- a/backend/flow_api/flow_locker/redis_test.go
+++ b/backend/flow_api/flow_locker/redis_test.go
@@ -186,6 +186,7 @@ func (suite *RedisLockerTestSuite) TestConcurrentLockAttempts() {
 	failCount := 0
 	var mu sync.Mutex
 	var wg sync.WaitGroup
+	ready := make(chan struct{})
 
 	wg.Add(numGoroutines)
 
@@ -193,12 +194,13 @@ func (suite *RedisLockerTestSuite) TestConcurrentLockAttempts() {
 		go func() {
 			defer wg.Done()
 
+			<-ready
+
 			unlock, err := locker.Lock(ctx, flowID)
 
 			mu.Lock()
 			if err == nil {
 				successCount++
-				time.Sleep(10 * time.Millisecond)
 				unlockErr := unlock(ctx)
 				if unlockErr != nil {
 					suite.T().Errorf("unlock failed: %v", unlockErr)
@@ -210,6 +212,7 @@ func (suite *RedisLockerTestSuite) TestConcurrentLockAttempts() {
 		}()
 	}
 
+	close(ready)
 	wg.Wait()
 
 	assert.Equal(suite.T(), 1, successCount, "exactly one lock should succeed")


### PR DESCRIPTION
# Description

Goroutines in the test raced to call `Lock()` as soon as they were spawned, with no guarantee all 10 had started before the winner's hold period elapsed. Under CPU-constrained CI runners a late goroutine could acquire the lock after the winner released it, causing successCount to occasionally exceed 1, i.e.: goroutine A wins the lock, sleeps 10ms, and unlocks — but the rest of the goroutines  haven't even reached their locker.Lock() call yet (they were still waiting for a scheduler slot / GC / container CPU throttling). Once the first goroutine releases the key, one of the late goroutines now successfully acquires the lock too, giving `successCount == 2` and failing `assert.Equal(1, successCount)`.

# Implementation

Adds a "start barrier" - channel which makes goroutines block until all goroutines are spawned and released together, and a corresponding "start" signal (channel close).

