### PR TITLE
fix(frontend-sdk): avoid navigating to /undefined in thirdparty step

### DIFF
--- a/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
@@ -122,10 +122,14 @@ export const autoSteps: AutoSteps = {
       return nextState;
     }
 
-    if (!state.isCached) {
+    if (!state.isCached && state.payload?.redirect_url) {
       state.saveToLocalStorage();
       window.location.assign(state.payload.redirect_url);
     } else {
+      // The payload may re-enter the thirdparty state without a redirect_url
+      // (e.g. after a failed token exchange, once hanko_token was already
+      // stripped from the URL). Assigning it directly would navigate to
+      // "/undefined", so fall back to the back action instead.
       return await state.actions.back.run();
     }
 

--- a/frontend/frontend-sdk/tests/lib/flow-api/auto-steps.spec.ts
+++ b/frontend/frontend-sdk/tests/lib/flow-api/auto-steps.spec.ts
@@ -1,0 +1,74 @@
+import { autoSteps } from "../../../src/lib/flow-api/auto-steps";
+
+// Regression tests for the "thirdparty" auto-step. When the flow re-enters the
+// thirdparty state without a redirect_url in its payload (e.g. after a failed
+// token exchange, once hanko_token was already stripped from the URL), the SDK
+// must not call window.location.assign(undefined), which navigates to
+// "/undefined" (see issue #2805).
+describe("autoSteps.thirdparty", () => {
+  let assignMock: jest.Mock;
+  const originalLocation = window.location;
+
+  const buildState = (overrides: Record<string, unknown> = {}) => ({
+    isCached: false,
+    payload: {},
+    saveToLocalStorage: jest.fn(),
+    actions: {
+      back: { run: jest.fn().mockResolvedValue({ name: "back_state" }) },
+      exchange_token: { run: jest.fn() },
+    },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    assignMock = jest.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { search: "", pathname: "/login", assign: assignMock },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("does not navigate when the payload has no redirect_url", async () => {
+    const state = buildState({ isCached: false, payload: {} });
+
+    await autoSteps.thirdparty(state as never);
+
+    expect(assignMock).not.toHaveBeenCalled();
+    expect(state.actions.back.run).toHaveBeenCalled();
+  });
+
+  it("navigates to the redirect_url when present and the state is not cached", async () => {
+    const redirectUrl = "https://example.com/authorize";
+    const state = buildState({
+      isCached: false,
+      payload: { redirect_url: redirectUrl },
+    });
+
+    await autoSteps.thirdparty(state as never);
+
+    expect(state.saveToLocalStorage).toHaveBeenCalled();
+    expect(assignMock).toHaveBeenCalledWith(redirectUrl);
+    expect(state.actions.back.run).not.toHaveBeenCalled();
+  });
+
+  it("runs the back action when the state is cached", async () => {
+    const state = buildState({
+      isCached: true,
+      payload: { redirect_url: "https://example.com/authorize" },
+    });
+
+    await autoSteps.thirdparty(state as never);
+
+    expect(assignMock).not.toHaveBeenCalled();
+    expect(state.actions.back.run).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Description

A user reported being redirected to `/undefined` after a GitHub social sign-in (Fixes #2805).

The root cause is in the `thirdparty` auto-step of the frontend SDK. When the flow
re-enters the thirdparty state **without** a `redirect_url` in its payload — e.g. after a
failed token exchange, once `hanko_token` has already been stripped from the URL via
`history.replaceState` — the step unconditionally called:

```ts
window.location.assign(state.payload.redirect_url); // redirect_url === undefined
```

`window.location.assign(undefined)` navigates the browser to `/undefined`.

# Implementation

`frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts` — the non-cached branch now only
navigates when `state.payload?.redirect_url` is truthy; otherwise it falls back to the
`back` action, which is exactly what the cached-state branch already does to safely
re-enter the flow:

```diff
-    if (!state.isCached) {
+    if (!state.isCached && state.payload?.redirect_url) {
       state.saveToLocalStorage();
       window.location.assign(state.payload.redirect_url);
     } else {
       return await state.actions.back.run();
     }
```

# Tests

Added `frontend/frontend-sdk/tests/lib/flow-api/auto-steps.spec.ts` covering the
`thirdparty` step. `npm test` runs it via `turbo run test` → `jest`.

## Test verification (RED → GREEN)

RED — on `main` (fix reverted, test only): the guard test fails because
`window.location.assign` is called with `undefined`:

```
  ● autoSteps.thirdparty › does not navigate when the payload has no redirect_url
    expect(jest.fn()).not.toHaveBeenCalled()
    Expected number of calls: 0
    Received number of calls: 1
    1: undefined
Tests:       1 failed, 2 passed, 3 total
```

GREEN — with the fix:

```
PASS tests/lib/flow-api/auto-steps.spec.ts
  autoSteps.thirdparty
    ✓ does not navigate when the payload has no redirect_url
    ✓ navigates to the redirect_url when present and the state is not cached
    ✓ runs the back action when the state is cached
Tests:       3 passed, 3 total
```

Full `frontend-sdk` suite after the change: **10 suites / 99 tests passing**, `npm run build` succeeds.

# Todos

None.

# Additional context

The reporter could not reproduce reliably (it depends on a failed token exchange, which
can happen e.g. with multiple tabs open), so the fix is a defensive guard against the
re-entry path together with a unit test that reproduces the exact `assign(undefined)`
condition.
