### PR TITLE
fix(frontend-sdk): don't report cancelled passkey creation as already-existing

### DIFF
--- a/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
@@ -18,9 +18,19 @@ async function handleCredentialCreation(
     return await state.actions.webauthn_verify_attestation_response.run({
       public_key: attestationResponse,
     });
-  } catch {
+  } catch (error) {
     const nextState = await state.actions.back.run();
-    nextState.error = { code: errorCode, message: errorMessage };
+    // Only an InvalidStateError signals that the credential is already
+    // registered on the authenticator. Other failures - e.g. NotAllowedError
+    // when the user cancels the prompt, or AbortError when a new request
+    // supersedes this one - must not be reported as "credential already exists"
+    // (see #2265). Preserve any error the server already set instead, mirroring
+    // the login_passkey step.
+    if (error instanceof DOMException && error.name === "InvalidStateError") {
+      nextState.error = { code: errorCode, message: errorMessage };
+    } else if (state.error) {
+      nextState.error = state.error;
+    }
     return nextState;
   }
 }

--- a/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
@@ -23,8 +23,8 @@ async function handleCredentialCreation(
     // Only an InvalidStateError signals that the credential is already
     // registered on the authenticator. Other failures - e.g. NotAllowedError
     // when the user cancels the prompt, or AbortError when a new request
-    // supersedes this one - must not be reported as "credential already exists"
-    // (see #2265). Preserve any error the server already set instead, mirroring
+    // supersedes this one - must not be reported as "credential already exists".
+    // Preserve any error the server already set instead, mirroring
     // the login_passkey step.
     if (error instanceof DOMException && error.name === "InvalidStateError") {
       nextState.error = { code: errorCode, message: errorMessage };

--- a/frontend/frontend-sdk/tests/lib/flow-api/Webauthn.spec.ts
+++ b/frontend/frontend-sdk/tests/lib/flow-api/Webauthn.spec.ts
@@ -4,7 +4,7 @@ import WebauthnManager from "../../../src/lib/flow-api/WebauthnManager";
 // Regression tests for the passkey credential-creation auto-steps. Canceling the
 // passkey prompt rejects with a NotAllowedError (and superseded requests reject
 // with an AbortError); neither means the credential already exists, so they must
-// not be surfaced as "webauthn_credential_already_exists" (see issue #2265).
+// not be surfaced as "webauthn_credential_already_exists".
 describe("autoSteps webauthn credential creation error handling", () => {
   const alreadyExistsCode = "webauthn_credential_already_exists";
 

--- a/frontend/frontend-sdk/tests/lib/flow-api/webauthn-credential-creation.spec.ts
+++ b/frontend/frontend-sdk/tests/lib/flow-api/webauthn-credential-creation.spec.ts
@@ -1,0 +1,80 @@
+import { autoSteps } from "../../../src/lib/flow-api/auto-steps";
+import WebauthnManager from "../../../src/lib/flow-api/WebauthnManager";
+
+// Regression tests for the passkey credential-creation auto-steps. Canceling the
+// passkey prompt rejects with a NotAllowedError (and superseded requests reject
+// with an AbortError); neither means the credential already exists, so they must
+// not be surfaced as "webauthn_credential_already_exists" (see issue #2265).
+describe("autoSteps webauthn credential creation error handling", () => {
+  const alreadyExistsCode = "webauthn_credential_already_exists";
+
+  const buildState = (overrides: Record<string, unknown> = {}) => ({
+    payload: { creation_options: {} },
+    error: undefined,
+    actions: {
+      back: { run: jest.fn().mockResolvedValue({ name: "back_state" }) },
+      webauthn_verify_attestation_response: { run: jest.fn() },
+    },
+    ...overrides,
+  });
+
+  const mockCreate = (impl: () => Promise<unknown>) => {
+    jest.spyOn(WebauthnManager, "getInstance").mockReturnValue({
+      createWebauthnCredential: jest.fn(impl),
+    } as never);
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not report 'already exists' when the user cancels the prompt", async () => {
+    mockCreate(() =>
+      Promise.reject(new DOMException("The operation was cancelled.", "NotAllowedError")),
+    );
+    const state = buildState();
+
+    const result = await autoSteps.webauthn_credential_verification(state as never);
+
+    expect(state.actions.back.run).toHaveBeenCalled();
+    expect(result.error).toBeUndefined();
+  });
+
+  it("does not report 'already exists' when the request is aborted", async () => {
+    mockCreate(() =>
+      Promise.reject(new DOMException("The operation was aborted.", "AbortError")),
+    );
+    const state = buildState();
+
+    const result = await autoSteps.webauthn_credential_verification(state as never);
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it("still reports 'already exists' for an InvalidStateError", async () => {
+    mockCreate(() =>
+      Promise.reject(new DOMException("Credential already registered.", "InvalidStateError")),
+    );
+    const state = buildState();
+
+    const result = await autoSteps.webauthn_credential_verification(state as never);
+
+    expect(result.error).toEqual({
+      code: alreadyExistsCode,
+      message: "Webauthn credential already exists",
+    });
+  });
+
+  it("verifies the attestation response on success", async () => {
+    const attestation = { id: "cred" };
+    mockCreate(() => Promise.resolve(attestation));
+    const state = buildState();
+
+    await autoSteps.webauthn_credential_verification(state as never);
+
+    expect(
+      state.actions.webauthn_verify_attestation_response.run,
+    ).toHaveBeenCalledWith({ public_key: attestation });
+    expect(state.actions.back.run).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Description

Canceling a passkey registration via the Flow API surfaced the misleading error
`webauthn_credential_already_exists` (Fixes #2265).

# Implementation

`handleCredentialCreation` (frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts) reported
**every** credential-creation failure as `webauthn_credential_already_exists`:

```ts
} catch {
  const nextState = await state.actions.back.run();
  nextState.error = { code: errorCode, message: errorMessage };
  return nextState;
}
```

Only a WebAuthn `InvalidStateError` actually means the credential is already registered on
the authenticator (an `excludeCredentials` match). Canceling the browser prompt rejects
with `NotAllowedError`, and a request that is superseded by a newer one rejects with
`AbortError` (the manager aborts the previous request via its `AbortController`).

The catch now emits `webauthn_credential_already_exists` only for `InvalidStateError`, and
otherwise preserves any server-provided error — mirroring the existing `login_passkey`
step. `@github/webauthn-json`'s `create()` awaits `navigator.credentials.create()`
directly and rethrows the raw `DOMException`, so `error instanceof DOMException &&
error.name === "InvalidStateError"` is a reliable discriminator. No new error code /
translation key is introduced.

# Tests

Added `frontend/frontend-sdk/tests/lib/flow-api/webauthn-credential-creation.spec.ts`
(run via `npm test` → `turbo run test` → `jest`).

## Test verification (RED → GREEN)

RED — on `main` (fix reverted): the cancel and abort cases still report the wrong code:

```
  ● ... › does not report 'already exists' when the user cancels the prompt
    expect(received).toBeUndefined()
    Received: {"code": "webauthn_credential_already_exists", "message": "Webauthn credential already exists"}
  ● ... › does not report 'already exists' when the request is aborted
    Received: {"code": "webauthn_credential_already_exists", ...}
Tests:       2 failed, 2 passed, 4 total
```

GREEN — with the fix:

```
  autoSteps webauthn credential creation error handling
    ✓ does not report 'already exists' when the user cancels the prompt
    ✓ does not report 'already exists' when the request is aborted
    ✓ still reports 'already exists' for an InvalidStateError
    ✓ verifies the attestation response on success
Tests:       4 passed, 4 total
```

Full `frontend-sdk` suite after the change: **10 suites / 100 tests passing**, `npm run build` succeeds.

# Todos

None.

# Additional context

`InvalidStateError` is preserved as the genuine "already registered" case, so the existing
UX for re-registering a known device is unchanged.
