### PR TITLE
fix: make concurrent test deterministic with an attempt barrier

### DIFF
--- a/backend/flow_api/flow_locker/redis_test.go
+++ b/backend/flow_api/flow_locker/redis_test.go
@@ -186,9 +186,11 @@ func (suite *RedisLockerTestSuite) TestConcurrentLockAttempts() {
 	failCount := 0
 	var mu sync.Mutex
 	var wg sync.WaitGroup
+	var attempted sync.WaitGroup
 	ready := make(chan struct{})
 
 	wg.Add(numGoroutines)
+	attempted.Add(numGoroutines)
 
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
@@ -197,18 +199,23 @@ func (suite *RedisLockerTestSuite) TestConcurrentLockAttempts() {
 			<-ready
 
 			unlock, err := locker.Lock(ctx, flowID)
+			attempted.Done()
 
 			mu.Lock()
 			if err == nil {
 				successCount++
-				unlockErr := unlock(ctx)
-				if unlockErr != nil {
-					suite.T().Errorf("unlock failed: %v", unlockErr)
-				}
 			} else {
 				failCount++
 			}
 			mu.Unlock()
+
+			if err == nil {
+				attempted.Wait() // hold the lock until every goroutine has attempted
+				unlockErr := unlock(ctx)
+				if unlockErr != nil {
+					suite.T().Errorf("unlock failed: %v", unlockErr)
+				}
+			}
 		}()
 	}
 


### PR DESCRIPTION
# Description

The prior start-barrier fix (#2747) still flaked in CI, sometimes with successCount as high as 3. Removing the hold-time sleep let the winner release the lock almost instantly, so in constrained runtime environments multiple goroutines could sequentially acquire-and-release the same key in quick succession before all 10 had even been scheduled.

# Implementation

Add a second WaitGroup that every goroutine signals right after its `Lock()` call resolves; the winner waits on it before unlocking. This makes the lock's hold time depend on actual attempt completion rather than wall-clock timing, removing the race entirely instead of just narrowing its window.
