### PR TITLE
Canceling passkey registration shows wrong error webauthn_credential_already_exists — NotAllowedError not distinguished

### DIFF
--- a/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
@@ -18,9 +18,11 @@ async function handleCredentialCreation(
     return await state.actions.webauthn_verify_attestation_response.run({
       public_key: attestationResponse,
     });
-  } catch {
+  } catch (e) {
     const nextState = await state.actions.back.run();
-    nextState.error = { code: errorCode, message: errorMessage };
+    if (e?.name !== "NotAllowedError" && e?.name !== "AbortError") {
+      nextState.error = { code: errorCode, message: errorMessage };
+    }
     return nextState;
   }
 }


### PR DESCRIPTION
Skip setting error on passkey registration cancel (NotAllowedError/AbortError) to avoid showing wrong webauthn_credential_already_exists error

Found via automated repo scanning, fix written and reviewed before opening.
