### PR TITLE
fix: don't redirect with undefined url when thirdparty state has an error

### DIFF
--- a/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
+++ b/frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts
@@ -122,6 +122,20 @@ export const autoSteps: AutoSteps = {
       return nextState;
     }
 
+    if (state.error) {
+      const nextState = await state.actions.back.run(null, {
+        dispatchAfterStateChangeEvent: false,
+      });
+
+      nextState.error = {
+        code: state.error.code,
+        message: state.error.message,
+      };
+      nextState.dispatchAfterStateChangeEvent();
+
+      return nextState;
+    }
+
     if (!state.isCached) {
       state.saveToLocalStorage();
       window.location.assign(state.payload.redirect_url);

--- a/frontend/frontend-sdk/tests/lib/flow-api/auto-steps.spec.ts
+++ b/frontend/frontend-sdk/tests/lib/flow-api/auto-steps.spec.ts
@@ -1,0 +1,152 @@
+import { autoSteps } from "../../../src/lib/flow-api/auto-steps";
+import * as Pkce from "../../../src/lib/Pkce";
+
+jest.mock("../../../src/lib/Pkce", () => ({
+  getStoredCodeVerifier: jest.fn(),
+  clearStoredCodeVerifier: jest.fn(),
+}));
+
+// eslint-disable-next-line require-jsdoc
+function createState(overrides: any = {}) {
+  return {
+    error: undefined,
+    isCached: false,
+    payload: { redirect_url: "https://example.com/redirect" },
+    actions: {
+      exchange_token: { run: jest.fn().mockResolvedValue({ name: "success" }) },
+      back: {
+        run: jest.fn().mockResolvedValue({
+          name: "login_init",
+          dispatchAfterStateChangeEvent: jest.fn(),
+        }),
+      },
+    },
+    saveToLocalStorage: jest.fn(),
+    dispatchAfterStateChangeEvent: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("autoSteps.thirdparty", () => {
+  const realLocation = window.location;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // @ts-ignore
+    delete window.location;
+    // @ts-ignore
+    window.location = {
+      search: "",
+      pathname: "/callback",
+      assign: jest.fn(),
+    };
+
+    jest.spyOn(history, "replaceState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    window.location = realLocation;
+  });
+
+  it("exchanges the token when hanko_token is present", async () => {
+    window.location.search = "?hanko_token=abc123";
+    (Pkce.getStoredCodeVerifier as jest.Mock).mockReturnValue("verifier-value");
+    const state = createState();
+
+    const result = await autoSteps.thirdparty(state as any);
+
+    expect(state.actions.exchange_token.run).toHaveBeenCalledWith({
+      token: "abc123",
+      code_verifier: "verifier-value",
+    });
+    expect(Pkce.clearStoredCodeVerifier).toHaveBeenCalled();
+    expect(history.replaceState).toHaveBeenCalledWith(null, null, "/callback");
+    expect(result).toEqual({ name: "success" });
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  it("falls back to undefined code_verifier when none is stored", async () => {
+    window.location.search = "?hanko_token=abc123";
+    (Pkce.getStoredCodeVerifier as jest.Mock).mockReturnValue(null);
+    const state = createState();
+
+    await autoSteps.thirdparty(state as any);
+
+    expect(state.actions.exchange_token.run).toHaveBeenCalledWith({
+      token: "abc123",
+      code_verifier: undefined,
+    });
+  });
+
+  it("maps an access_denied error query param to third_party_access_denied", async () => {
+    window.location.search =
+      "?error=access_denied&error_description=user%20cancelled";
+    const state = createState();
+
+    const result = await autoSteps.thirdparty(state as any);
+
+    expect(state.actions.back.run).toHaveBeenCalledWith(null, {
+      dispatchAfterStateChangeEvent: false,
+    });
+    expect(result.error).toEqual({
+      code: "third_party_access_denied",
+      message: "user cancelled",
+    });
+    expect(result.dispatchAfterStateChangeEvent).toHaveBeenCalled();
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  it("maps any other error query param to technical_error", async () => {
+    window.location.search = "?error=server_error&error_description=boom";
+    const state = createState();
+
+    const result = await autoSteps.thirdparty(state as any);
+
+    expect(result.error).toEqual({
+      code: "technical_error",
+      message: "boom",
+    });
+  });
+
+  it("propagates state.error back instead of redirecting with an undefined url", async () => {
+    const state = createState({
+      error: { code: "some_backend_error", message: "something went wrong" },
+      payload: { redirect_url: undefined },
+    });
+
+    const result = await autoSteps.thirdparty(state as any);
+
+    expect(state.actions.back.run).toHaveBeenCalledWith(null, {
+      dispatchAfterStateChangeEvent: false,
+    });
+    expect(result.error).toEqual({
+      code: "some_backend_error",
+      message: "something went wrong",
+    });
+    expect(result.dispatchAfterStateChangeEvent).toHaveBeenCalled();
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the payload's redirect_url when there is no error and state is not cached", async () => {
+    const state = createState({ isCached: false });
+
+    const result = await autoSteps.thirdparty(state as any);
+
+    expect(state.saveToLocalStorage).toHaveBeenCalled();
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "https://example.com/redirect",
+    );
+    expect(result).toBe(state);
+  });
+
+  it("goes back instead of redirecting when the state is cached", async () => {
+    const state = createState({ isCached: true });
+
+    await autoSteps.thirdparty(state as any);
+
+    expect(state.actions.back.run).toHaveBeenCalledWith();
+    expect(state.saveToLocalStorage).not.toHaveBeenCalled();
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Description

The `thirdparty` auto-step in the frontend SDK only handled errors surfaced via the `error` query param on the OAuth provider redirect. If the backend flow state itself carried an `error` (`redirect_url` is only populated on a successful, non-error `thirdparty` state), that case fell through to the final branch and called `window.location.assign(state.payload.redirect_url)` with an `undefined` url. 

Fixes https://github.com/teamhanko/hanko/issues/2805

# Implementation

Added a `state.error` check in `frontend/frontend-sdk/src/lib/flow-api/auto-steps.ts` that runs before the redirect branch. It mirrors the existing "error query param" handling: it calls `back.run()`, propagates the error's code/message onto the resulting state, and dispatches the state-change event, instead of falling through to `window.location.assign`.

# Tests

Added `frontend/frontend-sdk/tests/lib/flow-api/auto-steps.spec.ts`, covering all branches of the `thirdparty` auto-step:
- token exchange (with and without a stored PKCE verifier)
- `error` query param mapping (`access_denied` → `third_party_access_denied`, others → `technical_error`)
- `state.error` set with no query params — the regression case, asserting `window.location.assign` is never called
- redirect to `payload.redirect_url` when there's no error and the state isn't cached
- going back instead of redirecting when the state is cached

Run with:
```
cd frontend/frontend-sdk && npx jest tests/lib/flow-api/auto-steps.spec.ts
```

I verified the added regression test actually fails against the pre-fix code (by temporarily reverting the `auto-steps.ts` change) and passes with the fix applied.

# Todos

None.

# Additional context

None.