### PR TITLE
fix: add support for bcrypt "$2b$" format in import password validation

### DIFF
--- a/backend/cmd/user/format.go
+++ b/backend/cmd/user/format.go
@@ -161,7 +161,7 @@ func (entry *ImportOrExportEntry) validate(v *validator.Validate) error {
 	}
 
 	if entry.Password != nil && entry.Password.Password != "" {
-		if !strings.HasPrefix(entry.Password.Password, "$2a$") && !strings.HasPrefix(entry.Password.Password, "$fbscrypt$") {
+		if !strings.HasPrefix(entry.Password.Password, "$2a$") && !strings.HasPrefix(entry.Password.Password, "$2b$") && !strings.HasPrefix(entry.Password.Password, "$fbscrypt$") {
 			return errors.New("password must be in bcrypt or firebase scrypt format")
 		}
 	}


### PR DESCRIPTION
# Description

The 2a and 2b format are basically the same and as you can see in the [source code](https://cs.opensource.google/go/x/crypto/+/refs/tags/v0.54.0:bcrypt/bcrypt.go;l=265-279) the `CompareHashAndPassword` function only checks if the major version (`2`) matches and not the minor version (`a` or `b`)

# Tests

Import a password with a different version (`2b`) and check that login succeeds.


