### PR TITLE
fix(backend): embed version in container images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,3 +85,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            HANKO_VERSION=${{ steps.meta.outputs.version }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,7 @@
 FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 
 ARG TARGETARCH
+ARG HANKO_VERSION=dev
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -35,7 +36,7 @@ COPY flow_api flow_api/
 COPY flowpilot flowpilot/
 
 # Build
-RUN go generate ./...
+RUN HANKO_VERSION="$HANKO_VERSION" go generate ./... && go test ./build_info
 RUN CGO_ENABLED=0 GOOS=linux GOARCH="$TARGETARCH" go build -a -o hanko main.go
 
 # Use distroless as minimal base image to package hanko binary

--- a/backend/build_info/build_info.go
+++ b/backend/build_info/build_info.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-//go:generate sh -c "git describe --tags --always --match backend/* | sed -e s#^backend/## > version.txt"
+//go:generate sh -c "git describe --tags --always --match backend/* 2>/dev/null | sed -e s#^backend/## > version.txt; test -s version.txt || { test -n \"$HANKO_VERSION\" && printf '%s\n' \"$HANKO_VERSION\" > version.txt; }"
 //go:embed version.txt
 var version string
 var realVersion *string

--- a/backend/build_info/build_info_test.go
+++ b/backend/build_info/build_info_test.go
@@ -1,0 +1,11 @@
+package build_info
+
+import "testing"
+
+const emptyVersionError = "GetVersion() returned an empty version"
+
+func TestGetVersionIsNotEmpty(t *testing.T) {
+	if GetVersion() == "" {
+		t.Fatal(emptyVersionError)
+	}
+}


### PR DESCRIPTION
# Description

Fixes #1222.

Container builds now pass Docker metadata into the backend version generator, so `hanko version` no longer prints an empty line.

# Implementation

- fall back to `HANKO_VERSION` when Git metadata is unavailable
- pass the generated image version from `docker/metadata-action`
- keep no-argument local builds working with the `dev` default
- fail the image build if version generation regresses

# Tests

## Test verification (RED → GREEN)

Unmodified `main`, running the new test in the Docker build context without `.git`:

```text
=== RUN   TestGetVersionIsNotEmpty
    build_info_test.go:9: GetVersion() returned an empty version
--- FAIL: TestGetVersionIsNotEmpty (0.00s)
FAIL
```

Patched branch with an injected version:

```text
=== RUN   TestGetVersionIsNotEmpty
--- PASS: TestGetVersionIsNotEmpty (0.00s)
PASS
```

Full backend CI replay:

```text
go generate ./... && go build -v ./... && go test -v ./...
BASELINE_CI_EXIT=0
FINAL_CI_EXIT=0
```

Exact image verification:

```text
EXPECTED=v3.0.4-test
ACTUAL=v3.0.4-test
IMAGE_RUN_EXIT=0

EXPECTED=dev
ACTUAL=dev
NO_ARG_RUN_EXIT=0
```

# Todos

None.

# Additional context

None.
