### PR TITLE
fix(backend): allow long user agents

### DIFF
--- a/backend/persistence/migrations/20260905030100_change_user_agent_columns.down.fizz
+++ b/backend/persistence/migrations/20260905030100_change_user_agent_columns.down.fizz
@@ -1,0 +1,4 @@
+sql("UPDATE sessions SET user_agent = LEFT(user_agent, 255) WHERE LENGTH(user_agent) > 255")
+sql("UPDATE audit_logs SET meta_user_agent = LEFT(meta_user_agent, 255) WHERE LENGTH(meta_user_agent) > 255")
+change_column("sessions", "user_agent", "string", {"null": true})
+change_column("audit_logs", "meta_user_agent", "string", {})

--- a/backend/persistence/migrations/20260905030100_change_user_agent_columns.up.fizz
+++ b/backend/persistence/migrations/20260905030100_change_user_agent_columns.up.fizz
@@ -1,0 +1,2 @@
+change_column("sessions", "user_agent", "text", {"null": true})
+change_column("audit_logs", "meta_user_agent", "text", {})

--- a/backend/persistence/user_agent_test.go
+++ b/backend/persistence/user_agent_test.go
@@ -1,0 +1,87 @@
+package persistence_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/nulls"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/suite"
+	"github.com/teamhanko/hanko/backend/v3/config"
+	"github.com/teamhanko/hanko/backend/v3/persistence/models"
+	"github.com/teamhanko/hanko/backend/v3/test"
+)
+
+const (
+	longUserAgentCharacter = "a"
+	longUserAgentLength    = 278
+	testSourceIP           = "127.0.0.1"
+)
+
+func TestUserAgentSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(userAgentSuite))
+}
+
+type userAgentSuite struct {
+	test.Suite
+}
+
+func (s *userAgentSuite) TestSessionPersister_CreateStoresLongUserAgent() {
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
+	}
+
+	tenantID := uuid.FromStringOrNil(config.DefaultTenantID)
+	user := models.NewUser(tenantID)
+	err := s.Storage.GetUserPersister().Create(user)
+	s.Require().NoError(err)
+
+	userAgent := strings.Repeat(longUserAgentCharacter, longUserAgentLength)
+	now := time.Now().UTC()
+	session := models.Session{
+		ID:        uuid.Must(uuid.NewV4()),
+		UserID:    user.ID,
+		TenantID:  tenantID,
+		UserAgent: nulls.NewString(userAgent),
+		CreatedAt: now,
+		UpdatedAt: now,
+		LastUsed:  now,
+	}
+
+	err = s.Storage.GetSessionPersister().Create(session)
+	s.Require().NoError(err)
+
+	stored, err := s.Storage.GetSessionPersister().Get(session.ID, tenantID)
+	s.Require().NoError(err)
+	s.Require().NotNil(stored)
+	s.Equal(userAgent, stored.UserAgent.String)
+}
+
+func (s *userAgentSuite) TestAuditLogPersister_CreateStoresLongUserAgent() {
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
+	}
+
+	userAgent := strings.Repeat(longUserAgentCharacter, longUserAgentLength)
+	now := time.Now().UTC()
+	auditLog := models.AuditLog{
+		ID:                uuid.Must(uuid.NewV4()),
+		Type:              models.AuditLogLoginSuccess,
+		MetaHttpRequestId: uuid.Must(uuid.NewV4()).String(),
+		MetaSourceIp:      testSourceIP,
+		MetaUserAgent:     userAgent,
+		TenantID:          uuid.FromStringOrNil(config.DefaultTenantID),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+
+	err := s.Storage.GetAuditLogPersister().Create(auditLog)
+	s.Require().NoError(err)
+
+	stored, err := s.Storage.GetAuditLogPersister().Get(auditLog.ID, auditLog.TenantID)
+	s.Require().NoError(err)
+	s.Require().NotNil(stored)
+	s.Equal(userAgent, stored.MetaUserAgent)
+}


### PR DESCRIPTION
# Description
Fix #2877.

Login and registration can persist the request User-Agent in sessions and audit logs. Those columns were backed by Fizz `string` columns, which map to a 255-character limit and reject longer in-app browser headers.

# Implementation
- Change `sessions.user_agent` and `audit_logs.meta_user_agent` to `text` columns.
- Keep the existing nullable setting for `sessions.user_agent`.
- Make the down migration rollback-safe by truncating values longer than the old string column limit before restoring the previous column type.

## Test verification (RED -> GREEN)

RED on upstream `main` with only the regression test added:

```text
failed to store auditlog: named insert: ERROR: value too long for type character varying(255) (SQLSTATE 22001)
failed to store session: named insert: ERROR: value too long for type character varying(255) (SQLSTATE 22001)
FAIL github.com/teamhanko/hanko/backend/v3/persistence
```

GREEN after the migration change:

```text
--- PASS: TestUserAgentSuite (4.47s)
    --- PASS: TestUserAgentSuite/TestAuditLogPersister_CreateStoresLongUserAgent (0.79s)
    --- PASS: TestUserAgentSuite/TestSessionPersister_CreateStoresLongUserAgent (0.77s)
PASS
ok github.com/teamhanko/hanko/backend/v3/persistence 4.493s
```

Regression check with the migration removed again:

```text
failed to store auditlog: named insert: ERROR: value too long for type character varying(255) (SQLSTATE 22001)
failed to store session: named insert: ERROR: value too long for type character varying(255) (SQLSTATE 22001)
FAIL github.com/teamhanko/hanko/backend/v3/persistence
```

Full local suite proof:

```text
cd backend && go generate ./... && go build -v ./... && go test -v ./...
PASS
ok github.com/teamhanko/hanko/backend/v3/persistence 6.587s
```

# Todos
None.

# Additional context
Validation ran in Docker with Go 1.26 and the repo's dockertest-backed PostgreSQL setup.