### PR TITLE
fix: add validation to prevent linking unverified third-party provider emails

### DIFF
--- a/backend/handler/saml.go
+++ b/backend/handler/saml.go
@@ -361,7 +361,7 @@ func (handler *Handler) linkAccount(c echo.Context, redirectTo *url.URL, isFlow 
 		userData := saml.ExtractUserData(assertionInfo, providerConfig, samlProvider.AudienceURI)
 		identityProviderIssuer := assertionInfo.Assertions[0].Issuer
 		samlDomain := providerConfig.Domain
-		linkResult, errTx := thirdparty.LinkAccount(tx, &tenant.Config, handler.samlService.Persister(), userData, identityProviderIssuer.Value, true, &samlDomain, isFlow, nil, tenant.ID)
+		linkResult, errTx := thirdparty.LinkAccount(tx, &tenant.Config, handler.samlService.Persister(), userData, identityProviderIssuer.Value, true, &samlDomain, nil, tenant.ID)
 		if errTx != nil {
 			return errTx
 		}

--- a/backend/handler/thirdparty.go
+++ b/backend/handler/thirdparty.go
@@ -126,7 +126,7 @@ func (h *ThirdPartyHandler) Callback(c echo.Context) error {
 			return thirdparty.ErrorInvalidRequest("could not retrieve user data from provider").WithCause(terr)
 		}
 
-		linkingResult, terr := thirdparty.LinkAccount(tx, &tenant.Config, h.persister, userData, provider.ID(), false, nil, state.IsFlow, state.UserID, tenant.ID)
+		linkingResult, terr := thirdparty.LinkAccount(tx, &tenant.Config, h.persister, userData, provider.ID(), false, nil, state.UserID, tenant.ID)
 		if terr != nil {
 			return terr
 		}

--- a/backend/handler/thirdparty_callback_error_test.go
+++ b/backend/handler/thirdparty_callback_error_test.go
@@ -345,10 +345,14 @@ func (s *thirdPartySuite) TestThirdPartyHandler_Callback_Error_OAuthTokenExchang
 	}
 }
 
-func (s *thirdPartySuite) TestThirdPartyHandler_Callback_Error_VerificationRequiredUnverifiedProviderEmail() {
+func (s *thirdPartySuite) TestThirdPartyHandler_Callback_Error_LinkingRejectsUnverifiedProviderEmail() {
+	defer gock.Off()
 	if testing.Short() {
 		s.T().Skip("skipping test in short mode.")
 	}
+
+	err := s.LoadFixtures("../test/fixtures/thirdparty")
+	s.NoError(err)
 
 	gock.New(thirdparty.GoogleOauthTokenEndpoint).
 		Post("/").
@@ -359,15 +363,17 @@ func (s *thirdPartySuite) TestThirdPartyHandler_Callback_Error_VerificationRequi
 		Get("/").
 		Reply(200).
 		JSON(&thirdparty.GoogleUser{
-			ID:            "google_abcde",
-			Email:         "test-google-signup@example.com",
+			ID:            "google_1234",
+			Email:         "test-no-identity@example.com",
 			EmailVerified: false,
 		})
 
 	cfg := s.setUpConfig([]string{"google"}, []string{"https://example.com"})
 	cfg.Email.RequireVerification = true
 
-	state, err := thirdparty.GenerateState(cfg, "google", "https://example.com")
+	// Production third-party logins always go through the Flow API, which generates state with IsFlow=true
+	// (see flow_api/flow/shared/action_thirdparty_oauth.go).
+	state, err := thirdparty.GenerateState(cfg, "google", "https://example.com", thirdparty.GenerateStateForFlowAPI(true))
 	s.NoError(err)
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/thirdparty/callback?code=abcde&state=%s", state), nil)
@@ -379,6 +385,9 @@ func (s *thirdPartySuite) TestThirdPartyHandler_Callback_Error_VerificationRequi
 	c, rec := s.setUpContext(req, cfg.TenantConfig)
 	handler := s.setUpHandler(cfg)
 
+	// test-no-identity@example.com already exists and is verified on an existing account with no third party
+	// identity linked yet. Even though that email is already verified, this particular login never proved
+	// ownership of it, so linking must be rejected outright rather than silently granting access to that account.
 	if s.NoError(handler.Callback(c)) {
 		s.Equal(http.StatusTemporaryRedirect, rec.Code)
 		location, err := rec.Result().Location()
@@ -387,57 +396,13 @@ func (s *thirdPartySuite) TestThirdPartyHandler_Callback_Error_VerificationRequi
 		s.Equal(thirdparty.ErrorCodeUnverifiedProviderEmail, location.Query().Get("error"))
 		s.Equal("third party provider email must be verified", location.Query().Get("error_description"))
 
-		logs, lerr := s.Storage.GetAuditLogPersister().List(0, 0, nil, nil, []string{"thirdparty_signin_signup_failed"}, "", "", "", "", uuid.FromStringOrNil(config.DefaultTenantID))
-		s.NoError(lerr)
-		s.Len(logs, 1)
-	}
-}
-
-func (s *thirdPartySuite) TestThirdPartyHandler_Callback_Error_MicrosoftUnverifiedEmail() {
-	if testing.Short() {
-		s.T().Skip("skipping test in short mode.")
-	}
-
-	err := s.LoadFixtures("../test/fixtures/thirdparty")
-	s.NoError(err)
-
-	fakeIdToken := s.setUpMicrosoftIdToken("microsoft_abcde", "fakeClientID", "test-with-microsoft-identity@example.com", false)
-	gock.New(thirdparty.MicrosoftOAuthTokenEndpoint).
-		Post("/").
-		Reply(200).
-		JSON(map[string]string{"access_token": "fakeAccessToken", "id_token": fakeIdToken})
-
-	fakeJwkSet := s.setUpFakeJwkSet()
-	gock.New(thirdparty.MicrosoftKeysEndpoint).
-		Get("/").
-		Reply(200).
-		JSON(fakeJwkSet)
-
-	cfg := s.setUpConfig([]string{"microsoft"}, []string{"https://example.com"})
-	cfg.Email.RequireVerification = true
-
-	state, err := thirdparty.GenerateState(cfg, "microsoft", "https://example.com")
-	s.NoError(err)
-
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/thirdparty/callback?code=abcde&state=%s", state), nil)
-	req.AddCookie(&http.Cookie{
-		Name:  utils.HankoThirdpartyStateCookie,
-		Value: string(state),
-	})
-
-	c, rec := s.setUpContext(req, cfg.TenantConfig)
-	handler := s.setUpHandler(cfg)
-
-	if s.NoError(handler.Callback(c)) {
-		s.Equal(http.StatusTemporaryRedirect, rec.Code)
-		location, err := rec.Result().Location()
+		email, err := s.Storage.GetEmailPersister().FindByAddress("test-no-identity@example.com", uuid.FromStringOrNil(config.DefaultTenantID))
 		s.NoError(err)
+		s.NotNil(email)
+		s.Nil(email.Identities.GetIdentity("google", "google_1234"))
 
-		s.Equal(thirdparty.ErrorCodeUnverifiedProviderEmail, location.Query().Get("error"))
-		s.Equal("third party provider email must be verified", location.Query().Get("error_description"))
-
-		logs, lerr := s.Storage.GetAuditLogPersister().List(0, 0, nil, nil, []string{"thirdparty_signin_signup_failed"}, "", "", "", "", uuid.FromStringOrNil(config.DefaultTenantID))
+		logs, lerr := s.Storage.GetAuditLogPersister().List(0, 0, nil, nil, []string{"thirdparty_linking_succeeded"}, "", "", "", "", uuid.FromStringOrNil(config.DefaultTenantID))
 		s.NoError(lerr)
-		s.Len(logs, 1)
+		s.Len(logs, 0)
 	}
 }

--- a/backend/handler/thirdparty_callback_test.go
+++ b/backend/handler/thirdparty_callback_test.go
@@ -1103,6 +1103,130 @@ func (s *thirdPartySuite) TestThirdPartyHandler_Callback_Link_ExistingAccountNoI
 	}
 }
 
+func (s *thirdPartySuite) TestThirdPartyHandler_Callback_SignUp_WithUnverifiedProviderEmail() {
+	defer gock.Off()
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
+	}
+
+	gock.New(thirdparty.GoogleOauthTokenEndpoint).
+		Post("/").
+		Reply(200).
+		JSON(map[string]string{"access_token": "fakeAccessToken"})
+
+	gock.New(thirdparty.GoogleUserInfoEndpoint).
+		Get("/").
+		Reply(200).
+		JSON(&thirdparty.GoogleUser{
+			ID:            "google_abcde",
+			Email:         "test-google-signup@example.com",
+			EmailVerified: false,
+		})
+
+	cfg := s.setUpConfig([]string{"google"}, []string{"https://example.com"})
+	s.True(cfg.Email.RequireVerification)
+
+	state, err := thirdparty.GenerateState(cfg, "google", "https://example.com")
+	s.NoError(err)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/thirdparty/callback?code=abcde&state=%s", state), nil)
+	req.AddCookie(&http.Cookie{
+		Name:  utils.HankoThirdpartyStateCookie,
+		Value: string(state),
+	})
+
+	c, rec := s.setUpContext(req, cfg.TenantConfig)
+	handler := s.setUpHandler(cfg)
+
+	// Signing up doesn't grant access to anyone else's account, so an unverified provider email is allowed
+	// through here; ExchangeToken's downstream check (on the freshly-created, unverified Email row) is what
+	// forces the user through email passcode confirmation before the flow can reach StateSuccess.
+	if s.NoError(handler.Callback(c)) {
+		s.Equal(http.StatusTemporaryRedirect, rec.Code)
+
+		s.assertLocationHeaderHasToken(rec)
+		s.assertStateCookieRemoved(rec)
+
+		email, err := s.Storage.GetEmailPersister().FindByAddress("test-google-signup@example.com", uuid.FromStringOrNil(config.DefaultTenantID))
+		s.NoError(err)
+		s.NotNil(email)
+		s.False(email.Verified)
+
+		user, err := s.Storage.GetUserPersister().Get(*email.UserID, uuid.FromStringOrNil(config.DefaultTenantID))
+		s.NoError(err)
+		s.NotNil(user)
+
+		identity := email.Identities.GetIdentity("google", "google_abcde")
+		s.NotNil(identity)
+
+		logs, lerr := s.Storage.GetAuditLogPersister().List(0, 0, nil, nil, []string{"thirdparty_signup_succeeded"}, user.ID.String(), email.Address, "", "", uuid.FromStringOrNil(config.DefaultTenantID))
+		s.NoError(lerr)
+		s.Len(logs, 1)
+	}
+}
+
+func (s *thirdPartySuite) TestThirdPartyHandler_Callback_SignIn_WithUnverifiedProviderEmail() {
+	defer gock.Off()
+	if testing.Short() {
+		s.T().Skip("skipping test in short mode.")
+	}
+
+	err := s.LoadFixtures("../test/fixtures/thirdparty")
+	s.NoError(err)
+
+	fakeIdToken := s.setUpMicrosoftIdToken("microsoft_abcde", "fakeClientID", "test-with-microsoft-identity@example.com", false)
+	gock.New(thirdparty.MicrosoftOAuthTokenEndpoint).
+		Post("/").
+		Reply(200).
+		JSON(map[string]string{"access_token": "fakeAccessToken", "id_token": fakeIdToken})
+
+	fakeJwkSet := s.setUpFakeJwkSet()
+	gock.New(thirdparty.MicrosoftKeysEndpoint).
+		Get("/").
+		Reply(200).
+		JSON(fakeJwkSet)
+
+	cfg := s.setUpConfig([]string{"microsoft"}, []string{"https://example.com"})
+	s.True(cfg.Email.RequireVerification)
+
+	state, err := thirdparty.GenerateState(cfg, "microsoft", "https://example.com")
+	s.NoError(err)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/thirdparty/callback?code=abcde&state=%s", state), nil)
+	req.AddCookie(&http.Cookie{
+		Name:  utils.HankoThirdpartyStateCookie,
+		Value: string(state),
+	})
+
+	c, rec := s.setUpContext(req, cfg.TenantConfig)
+	handler := s.setUpHandler(cfg)
+
+	// This identity already exists and is signing back in with the same (still-unverified) email, not attaching
+	// itself to a different account, so it isn't the account-takeover-by-linking scenario and is allowed through.
+	if s.NoError(handler.Callback(c)) {
+		s.Equal(http.StatusTemporaryRedirect, rec.Code)
+
+		s.assertLocationHeaderHasToken(rec)
+		s.assertStateCookieRemoved(rec)
+
+		email, err := s.Storage.GetEmailPersister().FindByAddress("test-with-microsoft-identity@example.com", uuid.FromStringOrNil(config.DefaultTenantID))
+		s.NoError(err)
+		s.NotNil(email)
+		s.False(email.Verified)
+
+		user, err := s.Storage.GetUserPersister().Get(*email.UserID, uuid.FromStringOrNil(config.DefaultTenantID))
+		s.NoError(err)
+		s.NotNil(user)
+
+		identity := email.Identities.GetIdentity("microsoft", "microsoft_abcde")
+		s.NotNil(identity)
+
+		logs, lerr := s.Storage.GetAuditLogPersister().List(0, 0, nil, nil, []string{"thirdparty_signin_succeeded"}, user.ID.String(), "", "", "", uuid.FromStringOrNil(config.DefaultTenantID))
+		s.NoError(lerr)
+		s.Len(logs, 1)
+	}
+}
+
 func (s *thirdPartySuite) TestThirdPartyHandler_Callback_Link_GoogleToAccountWithGithubIdentity() {
 	defer gock.Off()
 	if testing.Short() {

--- a/backend/thirdparty/linking.go
+++ b/backend/thirdparty/linking.go
@@ -20,13 +20,7 @@ type AccountLinkingResult struct {
 	UserCreated  bool
 }
 
-func LinkAccount(tx *pop.Connection, cfg *config.TenantConfig, p persistence.Persister, userData *UserData, providerID string, isSaml bool, samlDomain *string, isFlow bool, userID *uuid.UUID, tenantID uuid.UUID) (*AccountLinkingResult, error) {
-	if !isFlow {
-		if cfg.Email.RequireVerification && !userData.Metadata.EmailVerified {
-			return nil, ErrorUnverifiedProviderEmail("third party provider email must be verified")
-		}
-	}
-
+func LinkAccount(tx *pop.Connection, cfg *config.TenantConfig, p persistence.Persister, userData *UserData, providerID string, isSaml bool, samlDomain *string, userID *uuid.UUID, tenantID uuid.UUID) (*AccountLinkingResult, error) {
 	// Validate userData
 	if userData == nil {
 		return nil, ErrorInvalidRequest("user data must be set")
@@ -53,9 +47,24 @@ func LinkAccount(tx *pop.Connection, cfg *config.TenantConfig, p persistence.Per
 
 		if user == nil {
 			return signUp(tx, cfg, p, userData, providerID, isSaml, samlDomain, tenantID)
-		} else {
-			return link(tx, cfg, p, userData, providerID, user, isSaml, samlDomain, userID != nil, tenantID)
 		}
+
+		// Linking attaches a new identity to an account matched purely by email address. Unlike signUp/signIn,
+		// where an unverified email is caught downstream by ExchangeToken's re-check on the freshly-created
+		// Email row, link() reuses the target account's pre-existing, already-verified Email row, so that
+		// downstream check would otherwise never see that this particular login never proved ownership of it.
+		//
+		// SECURITY: This check prevents account takeover attacks. Without it, an attacker could:
+		// 1. Create an OAuth account at a provider (e.g., Google) with an unverified email matching a victim's email
+		// 2. Initiate OAuth login, which would match the victim's existing account by email address
+		// 3. Link their malicious OAuth identity to the victim's account without proving ownership of the email
+		// 4. Gain full access to the victim's account
+		// By requiring email verification at the provider, we ensure the user proves ownership before linking.
+		if !isSaml && cfg.Email.RequireVerification && !userData.Metadata.EmailVerified {
+			return nil, ErrorUnverifiedProviderEmail("third party provider email must be verified")
+		}
+
+		return link(tx, cfg, p, userData, providerID, user, isSaml, samlDomain, userID != nil, tenantID)
 	} else {
 		return signIn(tx, cfg, p, userData, identity, tenantID)
 	}


### PR DESCRIPTION
# Description

Added checks during account linking to ensure third-party provider emails must be verified. Updated relevant tests to reflect the new behavior and prevent potential account takeover scenarios.

# Implementation

Already existing check that was not used in the Flow API, is now used.

# Tests

Updated relevant tests to reflect the new behavior.


