### PR TITLE
fix(elements): preserve flow on session expiry

### DIFF
--- a/frontend/elements/jest.config.cjs
+++ b/frontend/elements/jest.config.cjs
@@ -1,0 +1,27 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  roots: ["<rootDir>/tests"],
+  moduleNameMapper: {
+    "\\.(css|sass|scss)$": "<rootDir>/tests/styleMock.cjs",
+    "^preact$": "<rootDir>/../node_modules/preact/dist/preact.umd.js",
+    "^preact/compat$":
+      "<rootDir>/../node_modules/preact/compat/dist/compat.umd.js",
+    "^preact/hooks$":
+      "<rootDir>/../node_modules/preact/hooks/dist/hooks.umd.js",
+    "^preact/jsx-runtime$":
+      "<rootDir>/../node_modules/preact/jsx-runtime/dist/jsxRuntime.umd.js",
+    "^preact/test-utils$":
+      "<rootDir>/../node_modules/preact/test-utils/dist/testUtils.umd.js",
+  },
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        tsconfig: "<rootDir>/tsconfig.test.json",
+      },
+    ],
+  },
+  coverageProvider: "v8",
+};

--- a/frontend/elements/package.json
+++ b/frontend/elements/package.json
@@ -103,7 +103,8 @@
     "lint": "eslint 'src/**/*.ts?(x)'",
     "format": "pretty-quick --staged",
     "build": "npx webpack --mode=production",
-    "build:dev": "npx webpack --mode=development --config webpack.config.dev.cjs"
+    "build:dev": "npx webpack --mode=development --config webpack.config.dev.cjs",
+    "test": "jest --coverage"
   },
   "description": "The <hanko-auth> element offers a complete user interface that will bring a modern login and registration experience to your users.",
   "repository": "github:teamhanko/hanko",
@@ -120,6 +121,7 @@
   ],
   "homepage": "https://hanko.io",
   "devDependencies": {
+    "@types/jest": "30.0.0",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.62.0",
     "css-loader": "^7.1.4",
@@ -130,6 +132,8 @@
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-promise": "^6.1.1",
     "sass": "^1.102.0",
+    "jest": "30.3.0",
+    "jest-environment-jsdom": "29.7.0",
     "sass-loader": "^16.0.7",
     "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.2",

--- a/frontend/elements/src/contexts/AppProvider.tsx
+++ b/frontend/elements/src/contexts/AppProvider.tsx
@@ -17,6 +17,7 @@ import {
   HankoError,
   TechnicalError,
   State,
+  StateName,
   FlowName,
   FlowError,
   LastLogin,
@@ -55,6 +56,20 @@ export type ComponentName =
   | "registration"
   | "profile"
   | "events";
+
+const AUTHENTICATION_COMPONENTS: ComponentName[] = [
+  "auth",
+  "login",
+  "registration",
+];
+
+const INACTIVE_AUTHENTICATION_STATES: StateName[] = [
+  "account_deleted",
+  "error",
+  "login_init",
+  "registration_init",
+  "success",
+];
 
 export type HankoAuthMode = "registration" | "login";
 
@@ -149,6 +164,7 @@ const AppProvider = ({
 
   // TODO: check if necessary, see also TODO below
   const hasInitializedRef = useRef(false);
+  const authenticationFlowInProgressRef = useRef(false);
   const [isReadyToInit, setIsReadyToInit] = useState(false);
 
   const componentFlowNameMap = useMemo<Record<ComponentName, FlowName>>(
@@ -219,6 +235,11 @@ const AppProvider = ({
         if (!isOwnFlow(state)) {
           return;
         }
+
+        authenticationFlowInProgressRef.current =
+          AUTHENTICATION_COMPONENTS.includes(componentName) &&
+          !INACTIVE_AUTHENTICATION_STATES.includes(state.name);
+
         if (
           ![
             "onboarding_verify_passkey_attestation",
@@ -309,6 +330,7 @@ const AppProvider = ({
   );
 
   const flowInit = useCallback(async (flowName: FlowName) => {
+    authenticationFlowInProgressRef.current = false;
     setUIState((prev) => ({ ...prev, isDisabled: true }));
     const lastLoginEncoded = localStorage.getItem(storageKeyLastLogin);
     if (lastLoginEncoded) {
@@ -408,9 +430,13 @@ const AppProvider = ({
     const cb = () => {
       init(componentName);
     };
-    if (["auth", "login", "registration"].includes(componentName)) {
+    if (AUTHENTICATION_COMPONENTS.includes(componentName)) {
       const cleanUserLoggedOut = hanko.onUserLoggedOut(cb);
-      const cleanSessionExpired = hanko.onSessionExpired(cb);
+      const cleanSessionExpired = hanko.onSessionExpired(() => {
+        if (!authenticationFlowInProgressRef.current) {
+          cb();
+        }
+      });
       const cleanUserDeleted = hanko.onUserDeleted(cb);
       return () => {
         cleanUserLoggedOut();

--- a/frontend/elements/tests/contexts/AppProvider.spec.tsx
+++ b/frontend/elements/tests/contexts/AppProvider.spec.tsx
@@ -1,0 +1,183 @@
+import { h, render } from "preact";
+import { act } from "preact/test-utils";
+import type { Hanko, State } from "@teamhanko/hanko-frontend-sdk";
+
+import AppProvider from "../../src/contexts/AppProvider";
+
+jest.mock("@denysvuika/preact-translate", () => ({
+  TranslateProvider: ({ children }: { children: unknown }) => children,
+}));
+
+jest.mock("@teamhanko/hanko-frontend-sdk", () => ({
+  HankoError: class extends Error {},
+  TechnicalError: class extends Error {},
+}));
+
+jest.mock(
+  "../../src/components/wrapper/Container",
+  (): { __esModule: true; default: unknown } => {
+    const { h: createElement } = jest.requireActual("preact");
+    const { forwardRef } = jest.requireActual("preact/compat");
+
+    return {
+      __esModule: true,
+      default: forwardRef(
+        ({ children }: { children: unknown }, ref: { current: HTMLElement }) =>
+          createElement("section", { ref }, children),
+      ),
+    };
+  },
+);
+
+jest.mock("../../src/pages/InitPage", () => ({
+  __esModule: true,
+  default: (): null => null,
+}));
+
+jest.mock("../../src/pages/PasscodePage", () => ({
+  __esModule: true,
+  default: (): null => null,
+}));
+
+type EventCallback = () => void;
+type RestartEvent = "onSessionExpired" | "onUserDeleted" | "onUserLoggedOut";
+type StateChangeCallback = (detail: { state: State }) => void;
+
+const AUTH_COMPONENT = "auth";
+const LOGIN_FLOW = "login";
+const ACTIVE_FLOW_STATE = "passcode_confirmation";
+const COMPLETED_FLOW_STATE = "success";
+const INITIALIZATION_DELAY_MS = 50;
+const INITIAL_CREATE_STATE_CALLS = 1;
+const REINITIALIZED_CREATE_STATE_CALLS = 2;
+
+describe("AppProvider session events", () => {
+  let container: HTMLDivElement;
+  let eventCallbacks: Record<RestartEvent, EventCallback[]>;
+  let stateChangeCallbacks: StateChangeCallback[];
+  let createState: jest.Mock;
+  let hanko: Hanko;
+
+  const renderProvider = () => {
+    act(() => {
+      render(
+        <AppProvider
+          componentName={AUTH_COMPONENT}
+          globalOptions={{
+            hanko,
+            injectStyles: false,
+            fallbackLanguage: "en",
+            storageKey: "hanko",
+          }}
+          createWebauthnAbortSignal={() => new AbortController().signal}
+        />,
+        container,
+      );
+    });
+  };
+
+  const waitForInitialization = async () => {
+    await act(async () => {
+      await new Promise((resolve) =>
+        setTimeout(resolve, INITIALIZATION_DELAY_MS),
+      );
+    });
+  };
+
+  const dispatchStateChange = (
+    name: typeof ACTIVE_FLOW_STATE | typeof COMPLETED_FLOW_STATE,
+  ) => {
+    const state = {
+      name,
+      flowName: LOGIN_FLOW,
+      payload: null,
+      autoStep: jest.fn().mockResolvedValue(undefined),
+    } as unknown as State;
+
+    act(() => {
+      stateChangeCallbacks.forEach((callback) => callback({ state }));
+    });
+  };
+
+  beforeEach(() => {
+    eventCallbacks = {
+      onSessionExpired: [],
+      onUserDeleted: [],
+      onUserLoggedOut: [],
+    };
+    stateChangeCallbacks = [];
+    container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const subscribe = () => jest.fn();
+    const subscribeToRestartEvent = (eventName: RestartEvent) =>
+      jest.fn((callback: EventCallback) => {
+        eventCallbacks[eventName].push(callback);
+        return jest.fn();
+      });
+    createState = jest.fn().mockResolvedValue({
+      flowName: LOGIN_FLOW,
+      dispatchAfterStateChangeEvent: jest.fn(),
+    });
+    hanko = {
+      setLang: jest.fn(),
+      createState,
+      onBeforeStateChange: jest.fn(subscribe),
+      onAfterStateChange: jest.fn((callback: StateChangeCallback) => {
+        stateChangeCallbacks.push(callback);
+        return jest.fn();
+      }),
+      onSessionCreated: jest.fn(subscribe),
+      onUserLoggedOut: subscribeToRestartEvent("onUserLoggedOut"),
+      onUserDeleted: subscribeToRestartEvent("onUserDeleted"),
+      onSessionExpired: subscribeToRestartEvent("onSessionExpired"),
+    } as unknown as Hanko;
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it("keeps an active authentication flow when a stale session expires", async () => {
+    renderProvider();
+    await waitForInitialization();
+    dispatchStateChange(ACTIVE_FLOW_STATE);
+
+    expect(createState).toHaveBeenCalledTimes(INITIAL_CREATE_STATE_CALLS);
+
+    await act(async () => {
+      eventCallbacks.onSessionExpired.forEach((callback) => callback());
+      await Promise.resolve();
+    });
+
+    expect(createState).toHaveBeenCalledTimes(INITIAL_CREATE_STATE_CALLS);
+  });
+
+  it("restarts an inactive authentication flow after session expiry", async () => {
+    renderProvider();
+    await waitForInitialization();
+    dispatchStateChange(COMPLETED_FLOW_STATE);
+
+    eventCallbacks.onSessionExpired.forEach((callback) => callback());
+
+    expect(createState).toHaveBeenCalledTimes(REINITIALIZED_CREATE_STATE_CALLS);
+  });
+
+  it.each([
+    ["user logout", "onUserLoggedOut"],
+    ["user deletion", "onUserDeleted"],
+  ] as const)(
+    "restarts the authentication flow after %s",
+    async (_, eventName) => {
+      renderProvider();
+      await waitForInitialization();
+
+      eventCallbacks[eventName].forEach((callback) => callback());
+
+      expect(createState).toHaveBeenCalledTimes(
+        REINITIALIZED_CREATE_STATE_CALLS,
+      );
+    },
+  );
+});

--- a/frontend/elements/tests/styleMock.cjs
+++ b/frontend/elements/tests/styleMock.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/frontend/elements/tsconfig.test.json
+++ b/frontend/elements/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "preact": "^10.28.4"
       },
       "devDependencies": {
+        "@types/jest": "30.0.0",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.62.0",
         "css-loader": "^7.1.4",
@@ -39,6 +40,8 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-promise": "^6.1.1",
+        "jest": "30.3.0",
+        "jest-environment-jsdom": "29.7.0",
         "sass": "^1.102.0",
         "sass-loader": "^16.0.7",
         "source-map-loader": "^4.0.1",
@@ -97,6 +100,34 @@
           "optional": true
         },
         "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "elements/node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
           "optional": true
         }
       }


### PR DESCRIPTION
# Description

Prevents a stale session-expired event from restarting an active login or registration flow. The SDK event is still forwarded to integrators, while the authentication element now distinguishes active states from initial and terminal states before deciding whether to reinitialize.

Fixes #2868

# Implementation

- Track whether an authentication component is in a user-progressed flow state.
- Ignore session expiry for active states such as passcode confirmation.
- Preserve session-expiry reinitialization for initial and terminal states.
- Preserve unconditional resets after explicit logout and user deletion.
- Add an Elements Jest setup and lifecycle regression coverage for all branches.

# Test verification (RED → GREEN)

- Upstream RED reproduced the regression:
  ```text
  Expected number of calls: 1
  Received number of calls: 2
  Test Suites: 1 failed, 1 total
  ```
- Patched GREEN passed the same regression test:
  ```text
  Test Suites: 1 passed, 1 total
  Tests:       1 passed, 1 total
  ```
- Full local suite on Node 24.11.1 with repository-pinned npm 11.6.2: `npm ci`, `npm run build`, and `npm test` (8/8 tasks successful).
- Elements regression suite: 4/4 tests passing.
- Production-only revert: 1 expected regression failure, restored patch: 4/4 passing.
- Headless Chromium using the real built Elements/SDK bundle: upstream restarted passcode state (2 transitions); patched build preserved passcode state (1 transition) and still restarted inactive login state (2 transitions).
- Changed executable lines in `AppProvider.tsx`: 28/28 covered (100%).

# Todos

None.
